### PR TITLE
chore: react-icons 의존성 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "prettier-plugin-tailwindcss": "^0.6.11",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.0",
         "vite-tsconfig-paths": "^5.1.4"
       },
@@ -5869,6 +5870,14 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.0",
     "vite-tsconfig-paths": "^5.1.4"
   },


### PR DESCRIPTION
### 개요
react-icons 의존성 추가

### 목적
아이콘 사용을 위한 react-icons 라이브러리 추가

### 변경사항
react-icons 의존성 추가
프로젝트에서는 Material Design Icon 사용을 권장

### 참고 문서
- [React Icons](https://react-icons.github.io/react-icons/icons/md/)
- [개발자 가이드](https://www.notion.so/05-17-1f5dea889b87808b91cfdd99b18c08a7?pvs=4#1fedea889b87804eaa13f2af64722b2f)