### PR TITLE
feat: 대시보드 목 데이터 추가 및 좋아요 UI 개선

### DIFF
--- a/src/mocks/data/dashboard.ts
+++ b/src/mocks/data/dashboard.ts
@@ -1,0 +1,8 @@
+export const mockDashboardDetail = {
+  mockDashboard: Array.from({ length: 20 }, (_, i) => ({
+    id: i + 1,
+    teamName: `Pnu ops ${i + 1}`,
+    projectName: `Pnu ops 프로젝트 ${i + 1}`,
+    isSubmitted: i % 5 !== 2, // 3개 정도 미제출로
+  })),
+};

--- a/src/mocks/data/teamslike.ts
+++ b/src/mocks/data/teamslike.ts
@@ -1,0 +1,8 @@
+export const mockLikeDetail = {
+  mockLike: Array.from({ length: 20 }, (_, i) => ({
+    rank: 20 - i,
+    teamName: `Pnu ops ${i + 1}`,
+    projectName: `Pnu ops 프로젝트 ${i + 1}`,
+    likeCount: 2000 + 50 * i,
+  })),
+};

--- a/src/mocks/data/voterate.ts
+++ b/src/mocks/data/voterate.ts
@@ -1,0 +1,4 @@
+export const mockVoteRateDetail = {
+  mockVoteRate: 50,
+  totalVoteCount: 1500,
+};

--- a/src/mocks/handlers/dashboard.ts
+++ b/src/mocks/handlers/dashboard.ts
@@ -1,0 +1,16 @@
+import { mockDashboardDetail } from '@mocks/data/dashboard';
+import { mockLikeDetail } from '@mocks/data/teamslike';
+import { mockVoteRateDetail } from '@mocks/data/voterate';
+import { http, HttpResponse } from 'msw';
+
+export const DashboardHandlers = [
+  http.get('/api/admin/dashboard', () => {
+    return HttpResponse.json(mockDashboardDetail);
+  }),
+  http.get('api/admin/ranking', () => {
+    return HttpResponse.json(mockLikeDetail);
+  }),
+  http.get('api/admin/participation-rate', () => {
+    return HttpResponse.json(mockVoteRateDetail);
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { teamsHandlers } from './teams';
+import { DashboardHandlers } from './dashboard';
 
-export const handlers = [...teamsHandlers];
+export const handlers = [...teamsHandlers, ...DashboardHandlers];

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,37 +1,21 @@
 import ProjectSubmissionTable from '@pages/admin/ProjectSubmissionTable';
 import VoteRate from '@pages/admin/VoteRate';
-
-const mockSubmissions = Array.from({ length: 20 }, (_, i) => ({
-  id: i + 1,
-  teamName: `Pnu ops ${i + 1}`,
-  projectName: `Pnu ops`,
-  isSubmitted: i % 5 !== 2, // 3개 정도 미제출로
-  likes: 1000 + i,
-}));
-const sortedByLikes = [...mockSubmissions].sort((a, b) => b.likes - a.likes);
-
-const pieData = [
-  { name: '참여', value: 10 },
-  { name: '미참여', value: 90 },
-];
-const pieColors = ['#22c55e', '#e5e7eb'];
+import { mockDashboardDetail } from '@mocks/data/dashboard';
+import { mockLikeDetail } from '@mocks/data/teamslike';
+import { mockVoteRateDetail } from '@mocks/data/voterate';
 
 const AdminPage = () => {
+  const { mockDashboard } = mockDashboardDetail;
+  const { mockLike } = mockLikeDetail;
+  const { mockVoteRate, totalVoteCount } = mockVoteRateDetail;
+  mockLike.sort((a, b) => a.rank - b.rank);
   return (
     <div className="max-w-container flex flex-col gap-12 p-8">
-      {/* 프로젝트 등록현황 */}
-      <ProjectSubmissionTable submissions={mockSubmissions} type="project" />
+      <ProjectSubmissionTable submissions={mockDashboard} type="project" />
 
-      {/* 좋아요 랭킹 */}
-      <ProjectSubmissionTable submissions={sortedByLikes} type="vote" />
+      <ProjectSubmissionTable submissions={mockLike} type="vote" />
 
-      {/* 투표 참여율 */}
-      <VoteRate
-        pieData={pieData}
-        pieColors={pieColors}
-        totalVotes={1000} // 총 투표수
-        participationRate={pieData[0].value} // 참여율
-      />
+      <VoteRate totalVotes={totalVoteCount} participationRate={mockVoteRate} />
     </div>
   );
 };

--- a/src/pages/admin/ProjectSubmissionTable.tsx
+++ b/src/pages/admin/ProjectSubmissionTable.tsx
@@ -1,9 +1,10 @@
 interface Submission {
-  id: number;
+  id?: number;
+  rank?: number;
   teamName: string;
   projectName: string;
-  isSubmitted: boolean;
-  likes: number;
+  isSubmitted?: boolean;
+  likeCount?: number;
 }
 
 interface Props {
@@ -36,9 +37,10 @@ const TableBody = ({ submissions, type }: Props) => {
           <td className="w-[50%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.projectName}</td>
           {type === 'vote' ? (
             <td className="w-[20%] border-b border-gray-300 p-2 py-3 pl-4 text-sm">
-              <div className="flex h-[30px] w-[100px] items-center">
-                <span>좋아요&nbsp;&nbsp;</span>
-                <span className="font-bold">{item.likes.toLocaleString()}</span>개
+              <div className="inline-flex items-center gap-1">
+                <span className="min-w-[50px]">좋아요</span>
+                <span className="font-bold">{item.likeCount?.toLocaleString()}</span>
+                <span>개</span>
               </div>
             </td>
           ) : (

--- a/src/pages/admin/VoteRate.tsx
+++ b/src/pages/admin/VoteRate.tsx
@@ -1,18 +1,12 @@
 import { PieChart, Pie, Cell } from 'recharts';
 
-interface PieItem {
-  name: string;
-  value: number;
-}
-
 interface Props {
-  pieData: PieItem[];
   totalVotes: number;
   participationRate: number;
-  pieColors: string[];
 }
 
-const VoteRate = ({ pieData, totalVotes, participationRate, pieColors }: Props) => {
+const VoteRate = ({ totalVotes, participationRate }: Props) => {
+  const pieColors = ['#22c55e', '#e5e7eb'];
   return (
     <section className="">
       <h2 className="mb-4 text-2xl font-bold">투표 참여율</h2>


### PR DESCRIPTION
### 개요
api 명세 바탕으로 mock 데이터 추가, 관리자 페이지 좋아요 UI 수정
### 목적
api 명세 바탕으로 mock 데이터 추가, 관리자페이지 좋아요 UI 수정
### 변경사항
mock 데이터, handler 추가, 관리자 페이지 좋아요 UI 깨짐 수정
### (옵션) 화면 이미지 등
<img width="500" alt="스크린샷 2025-05-28 오후 1 23 00" src="https://github.com/user-attachments/assets/1fd3f094-8510-407d-b176-06906f7fa3d2" />
