### PR TITLE
feat: axios interceptor Authorization 헤더 설정

### DIFF
--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useTokenStore } from 'stores/useTokenStore';
 
 const base = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -10,5 +11,16 @@ const apiClient = axios.create({
   },
   withCredentials: true,
 });
+
+apiClient.interceptors.request.use(
+  (config) => {
+    const token = useTokenStore.getState().token;
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
 
 export default apiClient;


### PR DESCRIPTION
### 개요
axios interceptor Authorization 헤더 설정

### 목적
Api 요청 시 Authorization 헤더에 JWT 토큰을 전달하기 위한 axios request interceptor 설정

### 변경사항
- /apis/apiClient.ts
  - request interceptor를 설정하여 token이 존재하는 경우 Authorization헤더에 주입
  - token은 zustand 저장소인 useTokenStore에서 획득