### PR TITLE
feat: 메인페이지 api 연동 로직 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^5.77.2",
         "axios": "^1.9.0",
         "eslint-plugin-react": "^7.37.5",
+        "jose": "^6.0.11",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.511.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
@@ -4937,6 +4938,15 @@
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-cookie": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.77.2",
     "axios": "^1.9.0",
     "eslint-plugin-react": "^7.37.5",
+    "jose": "^6.0.11",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.511.0",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/src/apis/main.ts
+++ b/src/apis/main.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+import { useTokenStore } from "../stores/useTokenStore";
+
+export const fetchAllTeams = async () => {
+    const token = useTokenStore.getState().token;
+    const headers = token ? {Authorization: `Bearer ${token}`} : {};
+
+    const res = await axios.get("/teams", {headers});
+    return res.data;
+}

--- a/src/apis/main.ts
+++ b/src/apis/main.ts
@@ -1,10 +1,16 @@
 import axios from "axios";
 import { useTokenStore } from "../stores/useTokenStore";
+import apiClient from "./apiClient";
 
 export const fetchAllTeams = async () => {
     const token = useTokenStore.getState().token;
     const headers = token ? {Authorization: `Bearer ${token}`} : {};
 
     const res = await axios.get("/teams", {headers});
+    return res.data;
+}
+
+export const fetchSubmissionStatus = async () => {
+    const res = await apiClient.get("/teams/submission-status");
     return res.data;
 }

--- a/src/mocks/data/sign-in.ts
+++ b/src/mocks/data/sign-in.ts
@@ -7,3 +7,10 @@ export const mockSignInResponse: SignInResponseDto = {
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVtYmVySWQiOjEyMywibmFtZSI6Iu2XiOuPme2YgSIsIm1lbWJlclR5cGUiOlsiUk9MRV_tmozsm5AiLCJST0xFX-2MgOyepSJdLCJpYXQiOjE1MTYyMzkwMjJ9.I0vUQfo_hznLHUbZHvl8RuuaBvZ7N2_qX14cRzrvG3E',
   memberType: ['ROLE_회원', 'ROLE_팀장'],
 };
+
+export const mockTeamLeaderMessage = {
+  teamId: 1,
+  teamName: "team1",
+  projectName: "team1 Project",
+  isSubmitted: false,
+}

--- a/src/mocks/data/teams.ts
+++ b/src/mocks/data/teams.ts
@@ -9,3 +9,24 @@ export const mockTeamDetail = {
   isLiked: true,
   viewCount: 1523,
 };
+
+export const mockTeamsMain = [
+  {
+    teamId: 1,
+    teamName: "team1",
+    projectName: "team1 Project",
+    isLiked: false,
+  },
+  {
+    teamId: 2,
+    teamName: "team2",
+    projectName: "team2 Project",
+    isLiked: true,
+  },
+  {
+    teamId: 3,
+    teamName: "PNU OPS",
+    projectName: "OPs Bakery",
+    isLiked: true,
+  },
+]

--- a/src/mocks/data/teams.ts
+++ b/src/mocks/data/teams.ts
@@ -16,17 +16,20 @@ export const mockTeamsMain = [
     teamName: "team1",
     projectName: "team1 Project",
     isLiked: false,
+    thumbnail: undefined,
   },
   {
     teamId: 2,
     teamName: "team2",
     projectName: "team2 Project",
     isLiked: true,
+    thumbnail: undefined,
   },
   {
     teamId: 3,
     teamName: "PNU OPS",
     projectName: "OPs Bakery",
     isLiked: true,
+    thumbnail: 'https://images.unsplash.com/photo-1511367461989-f85a21fda167?w=1200&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8cHJvZmlsZXxlbnwwfHwwfHx8MA%3D%3D',
   },
 ]

--- a/src/pages/main/LeaderMessage.tsx
+++ b/src/pages/main/LeaderMessage.tsx
@@ -6,6 +6,7 @@ interface LeaderProps {
 }
 
 const LeaderMessage = ({ leaderName } : LeaderProps) => {
+    console.log("👀 LeaderMessage 렌더링됨");
     return(
         <div className="relative ml-2 rounded-lg px-4 py-2 text-base text-mainGreen shadow-sm border border-green-200">
             <span className="flex items-center gap-1">

--- a/src/pages/main/LeaderMessage.tsx
+++ b/src/pages/main/LeaderMessage.tsx
@@ -1,8 +1,9 @@
 import { BiError } from "react-icons/bi";
+// TODO: lucide-react 써서 말풍선 모양 구현하기
 
-type LeaderProps = {
+interface LeaderProps {
     leaderName : string;
-};
+}
 
 const LeaderMessage = ({ leaderName } : LeaderProps) => {
     return(

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -1,6 +1,7 @@
 
 import { FaHeart } from "react-icons/fa";
 import {useState} from "react";
+import { useNavigate} from "react-router-dom";
 
 /*
 * 썸네일과 좋아요는 null or defined 예외 처리

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -15,14 +15,20 @@ interface OneCardProps {
 }
 
 const TeamCard = ({thumbnail, title, teamName, isLiked = false}: OneCardProps) => {
+    const navigate = useNavigate();
+
+    const handleClick = () => {
+        navigate(`/view`); // Todo: /teams/${teamId}로 변경 필요
+    };
+
     const [imageError, setImageError] = useState(false);
 
     const showImage = thumbnail && !imageError;
 
     return (
-      <section
+      <section onClick={handleClick}
         aria-labelledby="teamCard"
-        className="w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm"
+        className="cursor-pointer transition-transform duration-200 hover:shadow-lg hover:scale-[1.02] w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm"
       >
         {showImage ? (
           <div className="w-full aspect-[5/3]">

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -1,8 +1,10 @@
 
 import { FaHeart } from "react-icons/fa";
+import {useState} from "react";
 
 /*
-* 썸네일과 좋아요는 null 예외 처리
+* 썸네일과 좋아요는 null or defined 예외 처리
+* Todo : 초기값이 null 인지 undefined 인지에 따라서 interface 수정하기
 * */
 interface OneCardProps {
     thumbnail? : string;
@@ -12,29 +14,36 @@ interface OneCardProps {
 }
 
 const TeamCard = ({thumbnail, title, teamName, isLiked = false}: OneCardProps) => {
-return (
-  <section
-    aria-labelledby="teamCard"
-    className="w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm"
-  >
-    {thumbnail ? (
-      <div className="w-full aspect-[5/3]">
-        <img src={thumbnail} alt="썸네일" className="w-full h-full object-cover" />
-      </div>
-    ) : (
-      <div className="w-full aspect-[5/3] flex items-center justify-center bg-lightGray text-midGray text-sm">썸네일</div>
-    )}
+    const [imageError, setImageError] = useState(false);
 
-    <div className="relative p-4 flex-grow flex flex-col justify-between">
-      <div className="text-sm font-semibold text-black">{title}</div>
-      <div className="text-base text-midGray">{teamName}</div>
+    const showImage = thumbnail && !imageError;
 
-      <div className="absolute right-4 bottom-4 text-gray-300">
-        {isLiked ? <FaHeart color="red" size={24}/> : <FaHeart color="lightGray" size={24}/>}
-      </div>
-    </div>
-  </section>
-);
+    return (
+      <section
+        aria-labelledby="teamCard"
+        className="w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm"
+      >
+        {showImage ? (
+          <div className="w-full aspect-[5/3]">
+            <img src={thumbnail}
+                 alt="썸네일"
+                 className="w-full h-full object-cover"
+                 onError={() => setImageError(true)}/>
+          </div>
+        ) : (
+          <div className="w-full aspect-[5/3] flex items-center justify-center bg-lightGray text-midGray text-sm">썸네일</div>
+        )}
+
+        <div className="relative p-4 flex-grow flex flex-col justify-between">
+          <div className="text-sm font-semibold text-black">{title}</div>
+          <div className="text-base text-midGray">{teamName}</div>
+
+          <div className="absolute right-4 bottom-4 text-gray-300">
+            {isLiked ? <FaHeart color="red" size={24}/> : <FaHeart color="lightGray" size={24}/>}
+          </div>
+        </div>
+      </section>
+    );
 };
 
 export default TeamCard;

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -9,7 +9,7 @@ interface OneCardProps {
     title : string;
     teamName : string;
     isLiked?: boolean;
-};
+}
 
 const TeamCard = ({thumbnail, title, teamName, isLiked = false}: OneCardProps) => {
 return (
@@ -22,12 +22,12 @@ return (
         <img src={thumbnail} alt="썸네일" className="w-full h-full object-cover" />
       </div>
     ) : (
-      <div className="w-full aspect-[5/3] flex items-center justify-center bg-lightGray text-middleGray text-sm">썸네일</div>
+      <div className="w-full aspect-[5/3] flex items-center justify-center bg-lightGray text-midGray text-sm">썸네일</div>
     )}
 
     <div className="relative p-4 flex-grow flex flex-col justify-between">
       <div className="text-sm font-semibold text-black">{title}</div>
-      <div className="text-base text-gray-500">{teamName}</div>
+      <div className="text-base text-midGray">{teamName}</div>
 
       <div className="absolute right-4 bottom-4 text-gray-300">
         {isLiked ? <FaHeart color="red" size={24}/> : <FaHeart color="lightGray" size={24}/>}

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -1,39 +1,73 @@
 import {mockTeamsMain} from "@mocks/data/teams";
 import TeamCard from "@pages/main/TeamCard";
 import LeaderMessage from "@pages/main/LeaderMessage";
-import {mockSignInResponse} from "@mocks/data/sign-in";
+import {mockSignInResponse, mockTeamLeaderMessage} from "@mocks/data/sign-in";
 import {useEffect, useState} from "react";
-import {fetchAllTeams} from "../../apis/main";
-import {team_thumbnail} from "@mocks/data/viewer";
+import {fetchAllTeams, fetchSubmissionStatus} from "../../apis/main";
+import {useTokenStore} from "../../stores/useTokenStore";
+import { decodeJwt } from "jose";
+
 
 const TotalCards = () => {
+    console.log("🎯 TotalCards 함수 시작됨");
     const [teams, setTeams] = useState([]);
+    const [isLeaderAndNotSubmitted, setCondition] = useState(false);
+    const token = useTokenStore((state)=> state.token);
 
     useEffect(() => {
-        const token = localStorage.getItem("ACCESS_TOKEN");
-        fetchAllTeams().then(setTeams).catch(console.error);
+        /*
+        Todo : payload role == 팀장 확인 로직
+        // if (!token) {
+        //     console.log("토큰 없음");
+        //     return;
+        // }
+        // const payload = decodeJwt(token);
+        // const isLeader = payload?.role?.includes("ROLE_팀장");
+
+        */
+
+        const mockIsLeader = mockSignInResponse.memberType.includes("ROLE_팀장");
+        const mockIsSubmitted = mockTeamLeaderMessage.isSubmitted;
+
+        if (mockIsLeader && !mockIsSubmitted) {
+        /*
+        Todo : 실제 api 연동 시
+        if (mockIsLeader) {
+            fetchSubmissionStatus()
+                .then(() => {
+                    if (!mockTeamLeaderMessage.isSubmitted) {
+                        setCondition(true);
+                    }
+                })
+                .catch(console.error);
+              */
+           setCondition(true);
+
+        }
+
+        // fetchAllTeams().then(setTeams).catch(console.error);
     }, []);
 
     return (
         <div id="projects" className="flex flex-col gap-4">
             <h3 id="projects" className="text-sm font-bold">현재 투표진행중인 작품</h3>
-            <LeaderMessage leaderName={mockSignInResponse.name} />
+            {isLeaderAndNotSubmitted && (
+                <LeaderMessage leaderName={mockSignInResponse.name} />
+            )}
+
             <section aria-labelledby="allCards"
                      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-w-screen-xl px-4 mx-0">
-                {mockTeamsMain.map((team) => {
-                    return(
-                        <TeamCard
-                            key={team.teamId}
-                            title={team.projectName}
-                            teamName={team.teamName}
-                            isLiked={team.isLiked}
-                            //thumbnail={`${import.meta.env.VITE_API_URL}/teams/${team.teamId}/thumbnail`}
-                            // Todo: 실제 api 연동할 때는 위 코드로
-                            thumbnail={team.thumbnail}
-                        />
-                    )
-
-                })}
+                {mockTeamsMain.map((team) => (
+                    <TeamCard
+                        key={team.teamId}
+                        title={team.projectName}
+                        teamName={team.teamName}
+                        isLiked={team.isLiked}
+                        //thumbnail={`${import.meta.env.VITE_API_URL}/teams/${team.teamId}/thumbnail`}
+                        // Todo: 실제 api 연동할 때는 위 코드로
+                        thumbnail={team.thumbnail}
+                    />
+                ))}
 
             </section>
 

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -4,6 +4,7 @@ import LeaderMessage from "@pages/main/LeaderMessage";
 import {mockSignInResponse} from "@mocks/data/sign-in";
 import {useEffect, useState} from "react";
 import {fetchAllTeams} from "../../apis/main";
+import {team_thumbnail} from "@mocks/data/viewer";
 
 const TotalCards = () => {
     const [teams, setTeams] = useState([]);
@@ -26,6 +27,9 @@ const TotalCards = () => {
                             title={team.projectName}
                             teamName={team.teamName}
                             isLiked={team.isLiked}
+                            //thumbnail={`${import.meta.env.VITE_API_URL}/teams/${team.teamId}/thumbnail`}
+                            // Todo: 실제 api 연동할 때는 위 코드로
+                            thumbnail={team.thumbnail}
                         />
                     )
 

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -1,44 +1,35 @@
-import {mockTeamDetail} from "@mocks/data/teams";
+import {mockTeamsMain} from "@mocks/data/teams";
 import TeamCard from "@pages/main/TeamCard";
 import LeaderMessage from "@pages/main/LeaderMessage";
-import {project_view} from "@mocks/data/viewer";
+import {mockSignInResponse} from "@mocks/data/sign-in";
+import {useEffect, useState} from "react";
+import {fetchAllTeams} from "../../apis/main";
 
 const TotalCards = () => {
+    const [teams, setTeams] = useState([]);
+
+    useEffect(() => {
+        const token = localStorage.getItem("ACCESS_TOKEN");
+        fetchAllTeams().then(setTeams).catch(console.error);
+    }, []);
+
     return (
         <div id="projects" className="flex flex-col gap-4">
             <h3 id="projects" className="text-sm font-bold">현재 투표진행중인 작품</h3>
-            <LeaderMessage leaderName={"수아"} />
+            <LeaderMessage leaderName={mockSignInResponse.name} />
             <section aria-labelledby="allCards"
                      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-w-screen-xl px-4 mx-0">
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
-                <TeamCard
-                    title = "안녕"
-                    teamName= "방가요"
-                    isLiked={true}/>
-                <TeamCard
-                    title = {project_view.projectName}
-                    teamName= {project_view.teamName}
-                    isLiked={project_view.isLiked}/>
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
-                <TeamCard
-                    title = "하이요"
-                    teamName= "방가방가"/>
+                {mockTeamsMain.map((team) => {
+                    return(
+                        <TeamCard
+                            key={team.teamId}
+                            title={team.projectName}
+                            teamName={team.teamName}
+                            isLiked={team.isLiked}
+                        />
+                    )
+
+                })}
 
             </section>
 

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -9,7 +9,6 @@ import { decodeJwt } from "jose";
 
 
 const TotalCards = () => {
-    console.log("🎯 TotalCards 함수 시작됨");
     const [teams, setTeams] = useState([]);
     const [isLeaderAndNotSubmitted, setCondition] = useState(false);
     const token = useTokenStore((state)=> state.token);


### PR DESCRIPTION
### 개요
메인페이지 내의 api 연동 mock 테스트

### 내용 
- 팀 전체보기 : /teams api 로직 구현
- 카드의 썸네일 들고오기 : teamId로 썸네일 조회 api 적용 (지금은 mock로) / 썸네일 값 없을 때는 기본 카드뷰
- 팀장 수정 메시지 출력 : /teams/submission-state api 적용 테스트 및 판단 로직 구현 
- 카드 클릭 시 뷰어 페이지 이동 : navigation 사용 & UI 효과 추가 (teams/${teamId}로 해야하지만 지금은 /views로 이동)

### 변경사항
- 메인페이지에서 뷰어 페이지로 이동할 때 hover & 마우스 포인터 효과 추가
- (궁금한점) apis/ 의 ts 파일의 기준이 궁금합니다. 팀 전체보기와 팀장 메시지 출력 api가 메인 페이지에서 사용되어서 두 개를 `main.ts`라는 하나의 파일 안에 선언해 놨습니다. 'apis의 파일 단위 == page 단위' 여도 되는지 여쭙습니다

### (옵션) 화면 이미지 등
이건 전체 화면 버전 
<img width="925" alt="3" src="https://github.com/user-attachments/assets/ecee4ad8-a292-4ab7-9331-f1e3f0f306a5" />
이건 1/2 화면 버전 
<img width="454" alt="5" src="https://github.com/user-attachments/assets/fc5ef151-3dc2-483e-9a53-63ce01336659" />
