### PR TITLE
feat: 관리자 페이지 api 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/apis/admin.ts
+++ b/src/apis/admin.ts
@@ -1,26 +1,16 @@
-import { useTokenStore } from '../stores/useTokenStore';
 import apiClient from './apiClient';
 
 export const getDashboard = async () => {
-  const token = useTokenStore.getState().token;
-  const headers = token ? { Authorization: `Bearer ${token}` } : {};
-
-  const res = await apiClient.get('/admin/dashboard', { headers });
+  const res = await apiClient.get('/admin/dashboard');
   return res.data;
 };
 
 export const getRanking = async () => {
-  const token = useTokenStore.getState().token;
-  const headers = token ? { Authorization: `Bearer ${token}` } : {};
-
-  const res = await apiClient.get('/admin/ranking', { headers });
+  const res = await apiClient.get('/admin/ranking');
   return res.data;
 };
 
 export const getRate = async () => {
-  const token = useTokenStore.getState().token;
-  const headers = token ? { Authorization: `Bearer ${token}` } : {};
-
-  const res = await apiClient.get('/admin/participation-rate', { headers });
+  const res = await apiClient.get('/admin/participation-rate');
   return res.data;
 };

--- a/src/apis/admin.ts
+++ b/src/apis/admin.ts
@@ -1,0 +1,26 @@
+import { useTokenStore } from '../stores/useTokenStore';
+import apiClient from './apiClient';
+
+export const getDashboard = async () => {
+  const token = useTokenStore.getState().token;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const res = await apiClient.get('/admin/dashboard', { headers });
+  return res.data;
+};
+
+export const getRanking = async () => {
+  const token = useTokenStore.getState().token;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const res = await apiClient.get('/admin/ranking', { headers });
+  return res.data;
+};
+
+export const getRate = async () => {
+  const token = useTokenStore.getState().token;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const res = await apiClient.get('/admin/participation-rate', { headers });
+  return res.data;
+};

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { useTokenStore } from 'stores/useTokenStore';
+import Cookies from 'js-cookie';
 
 const base = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -14,7 +15,10 @@ const apiClient = axios.create({
 
 apiClient.interceptors.request.use(
   (config) => {
-    const token = useTokenStore.getState().token;
+    // 토큰 쿠키에서 직접 가져옴
+    // const token = useTokenStore.getState().token;
+    const token = Cookies.get('access_token');
+    console.log(token);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,10 +7,11 @@ import App from './App';
 import { worker } from '@mocks/browsers';
 import { QueryClientProvider } from '@tanstack/react-query';
 import queryClient from 'stores/queryClient';
+import { useTokenStore } from './stores/useTokenStore';
 
-if (process.env.NODE_ENV === 'development') {
-  await worker.start();
-}
+// if (process.env.NODE_ENV === 'development') {
+//   await worker.start();
+// }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/mocks/data/dashboard.ts
+++ b/src/mocks/data/dashboard.ts
@@ -1,0 +1,8 @@
+export const mockDashboardDetail = Array.from({ length: 20 }, (_, i) => ({
+    teamId: i + 1,
+    teamName: `Pnu ops ${i + 1}`,
+    projectName: `Pnu ops 프로젝트 ${i + 1}`,
+    isSubmitted: i % 5 !== 2, // 3개 정도 미제출
+  }));
+  
+  

--- a/src/mocks/data/teamslike.ts
+++ b/src/mocks/data/teamslike.ts
@@ -1,0 +1,6 @@
+export const mockLikeDetail = Array.from({ length: 20 }, (_, i) => ({
+    rank: 20 - i,
+    teamName: `Pnu ops ${i + 1}`,
+    projectName: `Pnu ops 프로젝트 ${i + 1}`,
+    likeCount: 2000 + 50 * i,
+  }));

--- a/src/mocks/data/voterate.ts
+++ b/src/mocks/data/voterate.ts
@@ -1,0 +1,4 @@
+export const mockVoteRate = {
+  voteRate: 50,
+  totalVoteCount: 1500,
+};

--- a/src/mocks/handlers/admin.ts
+++ b/src/mocks/handlers/admin.ts
@@ -1,0 +1,16 @@
+import { mockDashboardDetail } from '@mocks/data/dashboard';
+import { mockLikeDetail } from '@mocks/data/teamslike';
+import { mockVoteRate } from '@mocks/data/voterate';
+import { http, HttpResponse } from 'msw';
+
+export const adminHandlers = [
+  http.get('/api/admin/dashboard', async () => {
+    return HttpResponse.json(mockDashboardDetail);
+  }),
+  http.get('/api/admin/ranking', async () => {
+    return HttpResponse.json(mockLikeDetail);
+  }),
+  http.get('/api/admin/participation-rate', async () => {
+    return HttpResponse.json(mockVoteRate);
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,6 @@
 import { signInHandlers } from './sign-in';
 import { signUpHandlers } from './sign-up';
 import { teamsHandlers } from './teams';
+import { adminHandlers } from './admin';
 
-export const handlers = [...teamsHandlers, ...signInHandlers, ...signUpHandlers];
+export const handlers = [...teamsHandlers, ...signInHandlers, ...signUpHandlers, ...adminHandlers];

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -3,6 +3,7 @@ import VoteRate from '@pages/admin/VoteRate';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getDashboard, getRanking } from 'apis/admin';
+
 interface DashboardSubmission {
   teamId: number;
   teamName: string;
@@ -53,4 +54,3 @@ const AdminPage = () => {
 };
 
 export default AdminPage;
-

--- a/src/pages/admin/ProjectSubmissionTable.tsx
+++ b/src/pages/admin/ProjectSubmissionTable.tsx
@@ -1,9 +1,11 @@
+
 interface Submission {
-  id: number;
+  teamId?: number;
+  rank?: number;
   teamName: string;
   projectName: string;
-  isSubmitted: boolean;
-  likes: number;
+  isSubmitted?: boolean;
+  likeCount?: number;
 }
 
 interface Props {
@@ -30,15 +32,16 @@ const TableBody = ({ submissions, type }: Props) => {
   return (
     <tbody>
       {submissions.map((item: Submission, idx: number) => (
-        <tr key={item.id} className="">
+        <tr key={item.teamId} className="">
           <td className="w-[10%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{idx + 1}</td>
           <td className="w-[20%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.teamName}</td>
           <td className="w-[50%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.projectName}</td>
           {type === 'vote' ? (
             <td className="w-[20%] border-b border-gray-300 p-2 py-3 pl-4 text-sm">
-              <div className="flex h-[30px] w-[100px] items-center">
-                <span>좋아요&nbsp;&nbsp;</span>
-                <span className="font-bold">{item.likes.toLocaleString()}</span>개
+              <div className="inline-flex items-center gap-1">
+                <span className="min-w-[50px]">좋아요</span>
+                <span className="font-bold">{item.likeCount?.toLocaleString()}</span>
+                <span>개</span>
               </div>
             </td>
           ) : (
@@ -71,3 +74,4 @@ const ProjectSubmissionTable = ({ submissions, type }: Props) => {
 };
 
 export default ProjectSubmissionTable;
+

--- a/src/pages/admin/VoteRate.tsx
+++ b/src/pages/admin/VoteRate.tsx
@@ -1,62 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
 import { PieChart, Pie, Cell } from 'recharts';
+import { getRate } from 'apis/admin';
 
-interface PieItem {
-  name: string;
-  value: number;
-}
+const VoteRate = () => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['voteRate'],
+    queryFn: getRate,
+  });
 
-interface Props {
-  pieData: PieItem[];
-  totalVotes: number;
-  participationRate: number;
-  pieColors: string[];
-}
+  const pieColors = ['#22c55e', '#e5e7eb'];
+  const voteRate = data?.voteRate ?? 0;
+  const totalVoteCount = data?.totalVoteCount ?? 0;
 
-const VoteRate = ({ pieData, totalVotes, participationRate, pieColors }: Props) => {
   return (
-    <section className="">
-      <h2 className="mb-4 text-2xl font-bold">투표 참여율</h2>
-      <div
-        className="mx-auto w-[100%] rounded bg-white p-6 text-center shadow-md"
-        style={{ boxShadow: '0 0 10px rgba(0, 0, 0, 0.12)' }}
-      >
-        <div className="flex justify-center">
-          <PieChart width={150} height={150}>
-            <Pie
-              data={[{ name: '배경', value: 100 }]}
-              cx="50%"
-              cy="50%"
-              innerRadius={50}
-              outerRadius={70}
-              startAngle={0}
-              endAngle={360}
-              dataKey="value"
-              cornerRadius={0}
-            >
-              <Cell fill={pieColors[1]} stroke="none" />
-            </Pie>
-            <Pie
-              data={[{ name: '참여', value: participationRate }]}
-              cx="50%"
-              cy="50%"
-              innerRadius={50}
-              outerRadius={70}
-              startAngle={90}
-              endAngle={90 - (360 * participationRate) / 100}
-              dataKey="value"
-              cornerRadius={10}
-            >
-              <Cell fill={pieColors[0]} />
-            </Pie>
-          </PieChart>
+    <section>
+      {isError ? (
+        <div className="mx-auto w-full rounded bg-white p-6 text-center shadow-md">
+          <p className="text-red-500">투표 참여율을 불러오는 데 실패했습니다.</p>
         </div>
-        <p className="-mt-20 text-xl font-bold text-green-600">{participationRate}%</p>
-        <p className="mt-20 text-gray-400">총 투표수 </p>
-        <p className="text-lg font-bold">
-          <span className="text-black">{totalVotes}개</span>
-        </p>
-      </div>
+      ) : isLoading ? (
+        <p className="text-center text-gray-400">로딩 중...</p>
+      ) : (
+        <>
+          <h2 className="mb-4 text-2xl font-bold">투표 참여율</h2>
+          <div
+            className="mx-auto w-full rounded bg-white p-6 text-center shadow-md"
+            style={{ boxShadow: '0 0 10px rgba(0, 0, 0, 0.12)' }}
+          >
+            <div className="flex justify-center">
+              <PieChart width={150} height={150}>
+                <Pie
+                  data={[{ name: '배경', value: 100 }]}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={70}
+                  startAngle={0}
+                  endAngle={360}
+                  dataKey="value"
+                >
+                  <Cell fill={pieColors[1]} stroke="none" />
+                </Pie>
+                <Pie
+                  data={[{ name: '참여', value: voteRate }]}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={70}
+                  startAngle={90}
+                  endAngle={90 - (360 * voteRate) / 100}
+                  dataKey="value"
+                  cornerRadius={10}
+                >
+                  <Cell fill={pieColors[0]} />
+                </Pie>
+              </PieChart>
+            </div>
+            <p className="-mt-20 text-xl font-bold text-green-600">{voteRate}%</p>
+            <p className="mt-20 text-gray-400">총 투표수</p>
+            <p className="text-lg font-bold">
+              <span className="text-black">{totalVoteCount}개</span>
+            </p>
+          </div>
+        </>
+      )}
     </section>
   );
 };
+
 export default VoteRate;
+


### PR DESCRIPTION
### 개요
관리자 페이지 api 연결
### 목적
관리자 페이지 api 연결
### 변경사항
1. apis/admin.ts -> apiClient 사용해 관리자 api 생성
2. mocks/data/dashboard, teamslike, voterate.ts -> response 타입 이름 변경
3. handlers/admin.ts 추가
4. pages/admin/Adminpage.tsx -> useQuery로 api 연결
pages/admin/VoteRate.tsx -> useQuery로 api 연결
pages/admin/ProjectSubmissionTable -> respponse 타입 이름 변경