### PR TITLE
refactor: 메인페이지 코드리뷰 기반 리팩토링 및 스타일 수정 

### DIFF
--- a/src/apis/teams.ts
+++ b/src/apis/teams.ts
@@ -1,13 +1,13 @@
-import { TeamListItemDto } from "../types/DTO/teamListDto";
-import { SubmissionStatusDto} from "../types/DTO/submissionStatusDto";
+import { TeamListItemResponseDto } from "../types/DTO/teams/teamListDto";
+import { SubmissionStatusResponseDto} from "../types/DTO/teams/submissionStatusDto";
 import apiClient from "./apiClient";
 
-export const getAllTeams = async (): Promise<TeamListItemDto[]> => {
+export const getAllTeams = async (): Promise<TeamListItemResponseDto[]> => {
     const res = await apiClient.get("/teams");
     return res.data;
 }
 
-export const getSubmissionStatus = async (): Promise<SubmissionStatusDto> => {
+export const getSubmissionStatus = async (): Promise<SubmissionStatusResponseDto> => {
     const res = await apiClient.get("/teams/submission-status");
     return res.data;
 }

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -1,0 +1,41 @@
+
+import LeaderMessage from "@pages/main/LeaderMessage";
+import useAuth from "../../hooks/useAuth";
+import {getSubmissionStatus} from "../../apis/teams";
+import {useQuery} from "@tanstack/react-query";
+import {SubmissionStatusResponseDto} from "../../types/DTO/teams/submissionStatusDto";
+import {Link} from "react-router-dom";
+import {TbPencil} from "react-icons/tb";
+
+const LeaderSection = () => {
+    const { isLeader, user } = useAuth();
+    const {
+        data: submissionData,
+    } = useQuery<SubmissionStatusResponseDto>({
+        queryKey: ['submissionStatus'],
+        queryFn: getSubmissionStatus,
+        enabled: isLeader,
+    });
+
+    const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
+
+    if (!isLeader) return null;
+
+    return (
+        <>
+            {submissionData?.teamId && (
+            <Link
+                to={`/teams/edit/${submissionData.teamId}`}
+                className="flex items-center gap-2 bg-mainGreen text-white font-bold text-lg leading-[100%] rounded-full px-5 py-3">
+                <TbPencil size={16} strokeWidth={2} />
+                프로젝트 에디터
+            </Link>
+            )}
+            {showLeaderMessage && (<LeaderMessage leaderName={user?.name ?? '팀장'} />)}
+        </>
+
+    )
+}
+
+
+export default LeaderSection;

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -26,7 +26,7 @@ const LeaderSection = () => {
             {submissionData?.teamId && (
             <Link
                 to={`/teams/edit/${submissionData.teamId}`}
-                className="flex items-center gap-2 bg-mainGreen text-white font-bold text-lg leading-[100%] rounded-full px-5 py-3">
+                className="border border-2px px-10 py-5 flex items-center gap-2 bg-mainGreen text-white font-bold text-lg leading-[100%] rounded-full shadow-md hover:brightness-110 transition">
                 <TbPencil size={16} strokeWidth={2} />
                 프로젝트 에디터
             </Link>

--- a/src/pages/main/LoadingSpinner.tsx
+++ b/src/pages/main/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+const LoadingSpinner = () => (
+    <div className="flex justify-center items-center py-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-4 border-mainGray border-t-mainGreen" />
+    </div>
+);
+
+export default LoadingSpinner;

--- a/src/pages/main/LoadingSpinner.tsx
+++ b/src/pages/main/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 const LoadingSpinner = () => (
     <div className="flex justify-center items-center py-8">
-        <div className="animate-spin rounded-full h-8 w-8 border-4 border-mainGray border-t-mainGreen" />
+        <div className="animate-spin rounded-full h-16 w-16 border-4 border-mainGray border-t-mainGreen" />
     </div>
 );
 

--- a/src/pages/main/Notice.tsx
+++ b/src/pages/main/Notice.tsx
@@ -3,8 +3,7 @@ import banner from "@assets/banner.svg"
 const Notice = () => {
   return (
     <section aria-labelledby="notice" className="flex flex-col gap-4">
-      <h3 className="text-sm font-bold" id="notice">공지사항</h3>
-
+      <h3 className="text-sm md:text-base lg:text-xl font-bold" id="notice">공지사항</h3>
       <img src={banner} alt="대회 로고" />
     </section>
   );

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -1,18 +1,17 @@
 
 import { FaHeart } from "react-icons/fa";
-import {useEffect, useState} from "react";
+import { useState} from "react";
 import {Link} from "react-router-dom";
-import apiClient from "../../apis/apiClient";
 
 interface TeamCardProps {
     teamId : number;
     teamName : string;
     projectName : string;
-    liked : boolean;
+    isLiked : boolean;
 }
 
 
-const TeamCard = ({teamId, teamName, projectName, liked} : TeamCardProps) => {
+const TeamCard = ({teamId, teamName, projectName, isLiked} : TeamCardProps) => {
     const [imageError, setImageError] = useState(false);
 
     const thumbnailUrl = `${import.meta.env.VITE_API_BASE_URL}/api/teams/${teamId}/image/thumbnail`;
@@ -38,7 +37,7 @@ const TeamCard = ({teamId, teamName, projectName, liked} : TeamCardProps) => {
           <div className="text-base text-midGray">{teamName}</div>
 
           <div className="absolute right-4 bottom-4 text-gray-300">
-            {liked ? <FaHeart color="red" size={24}/> : <FaHeart color="lightGray" size={24}/>}
+            {isLiked ? <FaHeart color="red" size={24}/> : <FaHeart color="lightGray" size={24}/>}
           </div>
         </div>
       </Link>

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -19,8 +19,7 @@ const TeamCard = ({teamId, teamName, projectName, isLiked} : TeamCardProps) => {
 
     return (
       <Link to={`/teams/view/${teamId}`}
-        className="cursor-pointer transition-transform duration-200 hover:shadow-lg hover:scale-[1.02] w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm"
-      >
+        className="cursor-pointer transition-transform duration-200 hover:shadow-lg hover:scale-[1.02] w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm">
         {!imageError ? (
           <div className="w-full aspect-[5/3]">
             <img src={thumbnailUrl}

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -18,25 +18,36 @@ const TeamCard = ({teamId, teamName, projectName, isLiked} : TeamCardProps) => {
 
 
     return (
-      <Link to={`/teams/view/${teamId}`}
-        className="cursor-pointer transition-transform duration-200 hover:shadow-lg hover:scale-[1.02] w-full max-w-[250px] max-h-[250px] aspect-[5/6] min-w-0 overflow-hidden rounded-xl border border-gray-200 shadow-sm">
+      <Link
+        to={`/teams/view/${teamId}`}
+        className="border-lightGray flex aspect-[5/6] w-full cursor-pointer flex-col overflow-hidden rounded-xl border shadow-sm transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg"
+      >
         {!imageError ? (
-          <div className="w-full aspect-[5/3]">
-            <img src={thumbnailUrl}
-                 alt="썸네일"
-                 className="w-full h-full object-cover"
-                 onError={() => setImageError(true)}/>
+          <div className="w-full aspect-[3/2] overflow-hidden">
+            <img
+              src={thumbnailUrl}
+              alt="썸네일"
+              className="h-full w-full object-cover object-center"
+              onError={() => setImageError(true)}
+            />
           </div>
         ) : (
-          <div className="w-full aspect-[5/3] flex items-center justify-center bg-lightGray text-midGray text-sm">썸네일</div>
+          <div className="bg-lightGray flex aspect-[3/2] w-full items-center justify-center">
+            <div className="flex h-full items-center justify-center text-sm text-midGray">썸네일</div>
+          </div>
         )}
 
-        <div className="relative p-4 flex-grow flex flex-col justify-between">
-          <div className="text-sm font-semibold text-black">{projectName}</div>
-          <div className="text-base text-midGray">{teamName}</div>
+        <div className="relative p-4">
+          <div className="text-[clamp(1rem,1.2vw,1.2rem)] font-semibold text-black">{projectName}</div>
 
-          <div className="absolute right-4 bottom-4 text-gray-300">
-            {isLiked ? <FaHeart color="red" size={24}/> : <FaHeart color="lightGray" size={24}/>}
+          <div className="text-[clamp(1rem,1.2vw,1.2rem)] text-midGray text-base">{teamName}</div>
+
+          <div className="flex justify-end">
+            {isLiked ? (
+              <FaHeart color="red" size="clamp(0.6rem, 2vw, 1.8rem)" />
+            ) : (
+              <FaHeart color="lightGray" size="clamp(0.6rem, 2vw, 1.8rem)" />
+            )}
           </div>
         </div>
       </Link>

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -21,12 +21,12 @@ const TotalCards = () => {
     return (
       <div id="projects" className="flex flex-col gap-4">
           <div className="flex justify-between items-center px-4">
-            <h3 id="projects" className="text-sm font-bold">현재 투표진행중인 작품</h3>
+            <h3 id="projects" className="text-sm md:text-md lg:text-xl font-bold">현재 투표진행중인 작품</h3>
             <LeaderSection />
       </div>
 
         <section
-          className="mx-0 grid max-w-screen-xl grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          className="mx-0 grid max-w-screen-xl grid-cols-1 gap-8 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {isLoading && <LoadingSpinner />}
             {isError && <p>데이터를 불러오지 못했습니다.</p>}
           {teams?.map((team) => (

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -1,18 +1,21 @@
 import TeamCard from "@pages/main/TeamCard";
-import LeaderMessage from "@pages/main/LeaderMessage";
-import useAuth from "../../hooks/useAuth";
 import {useQuery} from "@tanstack/react-query"
 import {getAllTeams, getSubmissionStatus} from "../../apis/teams";
 import {TeamListItemResponseDto} from "../../types/DTO/teams/teamListDto";
 import LeaderSection from "@pages/main/LeaderSection";
+import LoadingSpinner from "@pages/main/LoadingSpinner";
 
 
 const TotalCards = () => {
     const {
         data: teams,
+        isLoading,
+        isError,
     } = useQuery<TeamListItemResponseDto[]>({
         queryKey: ['teams'],
         queryFn: getAllTeams,
+        staleTime: 1000 * 60 * 15,  // stale 시간: 15분
+        gcTime: 1000 * 60 * 15,  // 캐시 삭제 기간 : 15분 간격
     });
 
     return (
@@ -23,8 +26,9 @@ const TotalCards = () => {
       </div>
 
         <section
-          className="mx-0 grid max-w-screen-xl grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-        >
+          className="mx-0 grid max-w-screen-xl grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {isLoading && <LoadingSpinner />}
+            {isError && <p>데이터를 불러오지 못했습니다.</p>}
           {teams?.map((team) => (
             <TeamCard
               key={team.teamId}

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -4,21 +4,10 @@ import useAuth from "../../hooks/useAuth";
 import {useQuery} from "@tanstack/react-query"
 import {getAllTeams, getSubmissionStatus} from "../../apis/teams";
 import {TeamListItemResponseDto} from "../../types/DTO/teams/teamListDto";
-import {SubmissionStatusResponseDto} from "../../types/DTO/teams/submissionStatusDto";
-import {Link} from "react-router-dom";
-import { TbPencil } from "react-icons/tb";
+import LeaderSection from "@pages/main/LeaderSection";
 
 
 const TotalCards = () => {
-
-    const { isLeader, user } = useAuth();
-    const {
-        data: submissionData,
-    } = useQuery<SubmissionStatusResponseDto>({
-        queryKey: ['submissionStatus'],
-        queryFn: getSubmissionStatus,
-        enabled: isLeader,
-    });
 
     const {
         data: teams,
@@ -27,28 +16,14 @@ const TotalCards = () => {
         queryFn: getAllTeams,
     });
 
-    const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
-
     return (
       <div id="projects" className="flex flex-col gap-4">
           <div className="flex justify-between items-center px-4">
             <h3 id="projects" className="text-sm font-bold">현재 투표진행중인 작품</h3>
-              {isLeader && submissionData?.teamId && (
-            <Link
-              to={`/teams/edit/${submissionData.teamId}`}
-              className="flex items-center gap-2 bg-mainGreen text-white font-inter font-bold text-[18px] leading-[100%] rounded-full px-5 py-3"
-            >
-              <TbPencil size={16} strokeWidth={2} />
-              프로젝트 에디터
-            </Link>
-
-            )}
+            <LeaderSection />
       </div>
 
-        {showLeaderMessage && <LeaderMessage leaderName={user?.name ?? '팀장'} />}
-
         <section
-          aria-labelledby="allCards"
           className="mx-0 grid max-w-screen-xl grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
         >
           {teams?.map((team) => (

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -3,8 +3,8 @@ import LeaderMessage from "@pages/main/LeaderMessage";
 import useAuth from "../../hooks/useAuth";
 import {useQuery} from "@tanstack/react-query"
 import {getAllTeams, getSubmissionStatus} from "../../apis/teams";
-import {TeamListItemDto} from "../../types/DTO/teamListDto";
-import {SubmissionStatusDto} from "../../types/DTO/submissionStatusDto";
+import {TeamListItemResponseDto} from "../../types/DTO/teams/teamListDto";
+import {SubmissionStatusResponseDto} from "../../types/DTO/teams/submissionStatusDto";
 import {Link} from "react-router-dom";
 import { TbPencil } from "react-icons/tb";
 
@@ -14,7 +14,7 @@ const TotalCards = () => {
     const { isLeader, user } = useAuth();
     const {
         data: submissionData,
-    } = useQuery<SubmissionStatusDto>({
+    } = useQuery<SubmissionStatusResponseDto>({
         queryKey: ['submissionStatus'],
         queryFn: getSubmissionStatus,
         enabled: isLeader,
@@ -22,7 +22,7 @@ const TotalCards = () => {
 
     const {
         data: teams,
-    } = useQuery<TeamListItemDto[]>({
+    } = useQuery<TeamListItemResponseDto[]>({
         queryKey: ['teams'],
         queryFn: getAllTeams,
     });
@@ -31,9 +31,9 @@ const TotalCards = () => {
 
     return (
       <div id="projects" className="flex flex-col gap-4">
-        {isLeader && submissionData?.teamId && (
           <div className="flex justify-between items-center px-4">
             <h3 id="projects" className="text-sm font-bold">현재 투표진행중인 작품</h3>
+              {isLeader && submissionData?.teamId && (
             <Link
               to={`/teams/edit/${submissionData.teamId}`}
               className="flex items-center gap-2 bg-mainGreen text-white font-inter font-bold text-[18px] leading-[100%] rounded-full px-5 py-3"
@@ -41,8 +41,9 @@ const TotalCards = () => {
               <TbPencil size={16} strokeWidth={2} />
               프로젝트 에디터
             </Link>
-          </div>
-        )}
+
+            )}
+      </div>
 
         {showLeaderMessage && <LeaderMessage leaderName={user?.name ?? '팀장'} />}
 

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -8,7 +8,6 @@ import LeaderSection from "@pages/main/LeaderSection";
 
 
 const TotalCards = () => {
-
     const {
         data: teams,
     } = useQuery<TeamListItemResponseDto[]>({
@@ -32,7 +31,7 @@ const TotalCards = () => {
               teamId={team.teamId}
               teamName={team.teamName}
               projectName={team.projectName}
-              liked={team.liked}
+              isLiked={team.liked}
             />
           ))}
         </section>

--- a/src/types/DTO/teams/submissionStatusDto.ts
+++ b/src/types/DTO/teams/submissionStatusDto.ts
@@ -1,4 +1,4 @@
-export interface SubmissionStatusDto {
+export interface SubmissionStatusResponseDto {
     teamId: number;
     teamName: string;
     projectName: string;

--- a/src/types/DTO/teams/teamListDto.ts
+++ b/src/types/DTO/teams/teamListDto.ts
@@ -1,4 +1,4 @@
-export interface TeamListItemDto {
+export interface TeamListItemResponseDto {
     teamId: number;
     teamName: string;
     projectName: string;


### PR DESCRIPTION
### 개요
코드리뷰 토대로 메인페이지 코드 리팩토링 및 style 약간 수정

### 목적
메인페이지 api 연동 PR 코드리뷰 토대로 리팩토링

### 변경사항
- DTO/teams 디렉토리에 Dto 파일 추가
- LeaderSection 컴포넌트 분리 : 팀장 메시지 + 에디터 버튼
- 메인페이지 로딩 시 로딩스피너 추가 
- TeamCard와 내부 요소 반응형으로 크기 변경 

### (옵션) 화면 이미지 등
<img width="149" alt="로딩스핀" src="https://github.com/user-attachments/assets/5de58578-8628-43ca-95a2-79085443a741" />

