### PR TITLE
style: 팀장 메시지 말풍선 UI 구현 (반응형 x)

### DIFF
--- a/src/pages/main/LeaderMessage.tsx
+++ b/src/pages/main/LeaderMessage.tsx
@@ -1,5 +1,4 @@
 import { BiError } from "react-icons/bi";
-// TODO: lucide-react 써서 말풍선 모양 구현하기
 
 interface LeaderProps {
     leaderName : string;
@@ -7,13 +6,19 @@ interface LeaderProps {
 
 const LeaderMessage = ({ leaderName } : LeaderProps) => {
     return(
-        <div className="relative ml-2 rounded-lg px-4 py-2 text-base text-mainGreen shadow-sm border border-green-200">
-            <span className="flex items-center gap-1">
-                <BiError color="#00A651"/>
-                <strong className="font-bold">{leaderName}</strong> 팀장님, 에디터에서 프로젝트 정보를 작성해주세요!
-            </span>
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-4 text-red-500">
+                <BiError size={40} className="opacity-80"/>
+                <div className="flex flex-col leading-snug">
+                    <span className="text-sm">
+                      <strong>{leaderName}</strong> 팀장님
+                    </span>
+                    <span className="text-sm">에디터에서 프로젝트 정보를 작성해 주세요!</span>
+                </div>
+            </div>
 
         </div>
+
     );
 };
 

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -19,20 +19,24 @@ const LeaderSection = () => {
 
     const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
 
-    if (!isLeader) return null;
+    if (!showLeaderMessage) return null;
 
     return (
-        <>
-            {submissionData?.teamId && (
-            <Link
-                to={`/teams/edit/${submissionData.teamId}`}
-                className="border border-2px px-10 py-5 flex items-center gap-2 bg-mainGreen text-white font-bold text-lg leading-[100%] rounded-full shadow-md hover:brightness-110 transition">
-                <TbPencil size={16} strokeWidth={2} />
-                프로젝트 에디터
-            </Link>
-            )}
-            {showLeaderMessage && (<LeaderMessage leaderName={user?.name ?? '팀장'} />)}
-        </>
+        <div className="absolute top-[150px] left-[280px] z-50">
+            <div className="relative bg-white rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.1)] p-6 w-fit">
+                <div className="absolute -bottom-4 left-6 w-6 h-10 bg-white rotate-60 shadow-[3px_3px_6px_rgba(0,0,0,0.05)] z-0"/>
+
+                <LeaderMessage leaderName={user?.name ?? '팀장'}/>
+
+                <Link
+                    to={`/teams/edit/${submissionData?.teamId}`}
+                    className="mt-4 px-7 py-3 w-fit border border-midGray rounded-full text-sm font-medium flex items-center gap-2 mx-auto hover:bg-gray-50 transition">
+
+                    <TbPencil size={20} strokeWidth={2}/>
+                    프로젝트 에디터
+                </Link>
+            </div>
+        </div>
 
     )
 }

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,11 +1,12 @@
 import Notice from "@pages/main/Notice";
 import TotalCards from "@pages/main/TotalCards";
+import LeaderSection from "@pages/main/LeaderSection";
 
 const MainPage = () => {
   return (
-      <div className="flex flex-col gap-20">
+      <div className="relative flex flex-col gap-20">
         <Notice/>
-        <TotalCards />
+          <TotalCards />
       </div>
   )
 }

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -1,9 +1,10 @@
 import TeamCard from "@pages/main/TeamCard";
 import {useQuery} from "@tanstack/react-query"
-import {getAllTeams, getSubmissionStatus} from "../../apis/teams";
+import {getAllTeams} from "../../apis/teams";
 import {TeamListItemResponseDto} from "../../types/DTO/teams/teamListDto";
 import LeaderSection from "@pages/main/LeaderSection";
 import LoadingSpinner from "@pages/main/LoadingSpinner";
+import { useRef } from "react";
 
 
 const TotalCards = () => {
@@ -19,10 +20,12 @@ const TotalCards = () => {
     });
 
     return (
+
       <div id="projects" className="flex flex-col gap-4">
           <div className="flex justify-between items-center px-4">
-            <h3 id="projects" className="text-sm md:text-md lg:text-xl font-bold">현재 투표진행중인 작품</h3>
-            <LeaderSection />
+            <h3 id="projects" className="text-sm md:text-md lg:text-xl font-bold">
+                현재 투표진행중인 작품</h3>
+              <LeaderSection />
       </div>
 
         <section


### PR DESCRIPTION
### 개요
수정된 디자인 (팀장 메시지) UI 구현 

### 목적
'프로젝트 에디터' 버튼과 팀장 메시지를 말풍선에 합친다
(팀장일 때 & 프로젝트 수정하지 않았을 때)

### 변경사항 & 고민
- 공지사항 배너를 약간 가리는 스타일의 말풍선
- (고민) 반응형으로 구현하려면 react의 `useRef` 를 사용해서 적절한 좌표에 위치 되도록 할 수 있는데, 시험 삼아 해본 결과 적응이 잘 되는지 모르겠습니다 + 코드가 꽤 복잡해짐 이슈
-> 전체 화면 기준으로 x,y 좌표를 정할지, useRef 사용해서 반응형 구현해볼지 고민이 됩니다. 

### (옵션) 화면 이미지 등
<img width="907" alt="image" src="https://github.com/user-attachments/assets/117245a7-bb6e-47e7-8222-7429e762dbcf" />
