### PR TITLE
Fix: 댓글 낙관적 업데이트로 수정, 헤더 admin 계정일때만 관리자페이지 노출

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -17,16 +17,7 @@ const Header = () => {
   };
 
   const handleAdminPage = () => {
-    console.log('user: ', user);
-    if (!isSignedIn) {
-      alert('로그인 후 이용해주세요.');
-      return;
-    }
-    if (user?.roles?.includes('ROLE_팀장')) {
-      navigate('/monitor');
-      return;
-    }
-    alert('관리자만 접근할 수 있습니다.');
+    navigate('/admin');
     return;
   };
 
@@ -36,13 +27,15 @@ const Header = () => {
         <img className="hover:cursor-pointer" src={logo} alt="대회 로고" onClick={() => navigate('/')} />
       </div>
       <div className="flex items-center justify-between gap-8">
-        <div
-          className="flex items-center gap-2 hover:cursor-pointer"
-          onClick={location.pathname != '/monitor' ? handleAdminPage : undefined}
-        >
-          <BiCog className="text-mainGreen text-exsm cursor-pointer" />
-          <span className="text-exsm">관리자 페이지</span>
-        </div>
+        {isAdmin ? (
+          <div
+            className="flex items-center gap-2 hover:cursor-pointer"
+            onClick={location.pathname != '/admin' ? handleAdminPage : undefined}
+          >
+            <BiCog className="text-mainGreen text-exsm cursor-pointer" />
+            <span className="text-exsm">관리자 페이지</span>
+          </div>
+        ) : null}
         <button
           onClick={isSignedIn ? handleLogout : () => navigate('/signin')}
           className="text-exsm border-lightGray mr-8 rounded-full border px-4 py-2 hover:cursor-pointer"

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -31,21 +31,14 @@ const AdminPage = () => {
       </div>
     );
   }
+
   return (
     <div className="max-w-container flex flex-col gap-12 p-8">
-      {/* 프로젝트 등록현황 */}
-      <ProjectSubmissionTable submissions={mockSubmissions} type="project" />
+      <ProjectSubmissionTable submissions={dashboardData} type="project" />
 
-      {/* 좋아요 랭킹 */}
-      <ProjectSubmissionTable submissions={sortedByLikes} type="vote" />
+      <ProjectSubmissionTable submissions={sortedRankingData} type="vote" />
 
-      {/* 투표 참여율 */}
-      <VoteRate
-        pieData={pieData}
-        pieColors={pieColors}
-        totalVotes={1000} // 총 투표수
-        participationRate={pieData[0].value} // 참여율
-      />
+      <VoteRate />
     </div>
   );
 };

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -9,6 +9,22 @@ import useAuth from 'hooks/useAuth';
 
 const AdminPage = () => {
   const { isAdmin } = useAuth();
+  const { data: dashboardData, isLoading: isDashboardLoading } = useQuery<DashboardTeamResponseDto[]>({
+    queryKey: ['dashboard'],
+    queryFn: getDashboard,
+    enabled: isAdmin,
+  });
+  const { data: rankingData, isLoading: isRankingLoading } = useQuery<TeamLikeResponseDto[]>({
+    queryKey: ['ranking'],
+    queryFn: getRanking,
+    enabled: isAdmin,
+  });
+
+  const sortedRankingData = useMemo(
+    () => [...(rankingData ?? [])].sort((a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0)),
+    [rankingData],
+  );
+
   if (!isAdmin) {
     return (
       <div className="mx-auto w-full rounded bg-white p-6 text-center shadow-md">
@@ -17,23 +33,10 @@ const AdminPage = () => {
     );
   }
 
-  const { data: dashboardData, isLoading: isDashboardLoading } = useQuery<DashboardTeamResponseDto[]>({
-    queryKey: ['dashboard'],
-    queryFn: getDashboard,
-  });
-  const { data: rankingData, isLoading: isRankingLoading } = useQuery<TeamLikeResponseDto[]>({
-    queryKey: ['ranking'],
-    queryFn: getRanking,
-  });
-
-  const sortedRankingData = useMemo(
-    () => [...(rankingData ?? [])].sort((a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0)),
-    [rankingData],
-  );
-
   if (isDashboardLoading || isRankingLoading) {
     return <p className="text-center text-gray-400">로딩 중...</p>;
   }
+
   if (!dashboardData || !rankingData) {
     return (
       <div className="mx-auto w-full rounded bg-white p-6 text-center shadow-md">
@@ -45,9 +48,7 @@ const AdminPage = () => {
   return (
     <div className="max-w-container flex flex-col gap-12 p-8">
       <ProjectSubmissionTable submissions={dashboardData} type="project" />
-
       <ProjectSubmissionTable submissions={sortedRankingData} type="vote" />
-
       <VoteRate />
     </div>
   );

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -5,8 +5,18 @@ import { useMemo } from 'react';
 import { getDashboard } from 'apis/dashboard';
 import { getRanking } from 'apis/ranking';
 import { DashboardTeamResponseDto, TeamLikeResponseDto } from 'types/DTO';
+import useAuth from 'hooks/useAuth';
 
 const AdminPage = () => {
+  const { isAdmin } = useAuth();
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto w-full rounded bg-white p-6 text-center shadow-md">
+        <p className="text-red-500">관리자 권한이 없습니다.</p>
+      </div>
+    );
+  }
+
   const { data: dashboardData, isLoading: isDashboardLoading } = useQuery<DashboardTeamResponseDto[]>({
     queryKey: ['dashboard'],
     queryFn: getDashboard,

--- a/src/pages/admin/ProjectSubmissionTable.tsx
+++ b/src/pages/admin/ProjectSubmissionTable.tsx
@@ -31,7 +31,7 @@ const TableBody = ({ submissions, type }: Props) => {
   return (
     <tbody>
       {submissions.map((item: Submission, idx: number) => (
-        <tr key={item.teamId} className="">
+        <tr key={`${item.teamName}-${item.projectName}-${idx}`}  className="">
           <td className="w-[10%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{idx + 1}</td>
           <td className="w-[20%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.teamName}</td>
           <td className="w-[50%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.projectName}</td>

--- a/src/pages/admin/ProjectSubmissionTable.tsx
+++ b/src/pages/admin/ProjectSubmissionTable.tsx
@@ -1,9 +1,10 @@
 interface Submission {
-  id: number;
+  teamId?: number;
+  rank?: number;
   teamName: string;
   projectName: string;
-  isSubmitted: boolean;
-  likes: number;
+  isSubmitted?: boolean;
+  likeCount?: number;
 }
 
 interface Props {
@@ -30,15 +31,16 @@ const TableBody = ({ submissions, type }: Props) => {
   return (
     <tbody>
       {submissions.map((item: Submission, idx: number) => (
-        <tr key={item.id} className="">
+        <tr key={item.teamId} className="">
           <td className="w-[10%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{idx + 1}</td>
           <td className="w-[20%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.teamName}</td>
           <td className="w-[50%] border-r border-b border-gray-300 p-2 py-3 pl-4 text-sm">{item.projectName}</td>
           {type === 'vote' ? (
             <td className="w-[20%] border-b border-gray-300 p-2 py-3 pl-4 text-sm">
-              <div className="flex h-[30px] w-[100px] items-center">
-                <span>좋아요&nbsp;&nbsp;</span>
-                <span className="font-bold">{item.likes.toLocaleString()}</span>개
+              <div className="inline-flex items-center gap-1">
+                <span className="min-w-[50px]">좋아요</span>
+                <span className="font-bold">{item.likeCount?.toLocaleString()}</span>
+                <span>개</span>
               </div>
             </td>
           ) : (

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -1,28 +1,55 @@
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import useAuth from 'hooks/useAuth';
-import { CommentFormRequestDto } from 'types/DTO/projectViewerDto';
+import { CommentFormRequestDto, CommentDto } from 'types/DTO/projectViewerDto';
 import { postCommentForm } from 'apis/projectViewer';
-import { comment } from 'postcss';
 
 interface CommentFormSection {
   teamId: number;
 }
 
+interface PreviousComments {
+  previousComments: CommentDto[] | undefined;
+}
+
 const CommentFormSection = ({ teamId }: CommentFormSection) => {
   const [newComment, setNewComment] = useState('');
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
 
-  const commentMutation = useMutation<void, Error, string>({
-    mutationFn: (comment) =>
-      postCommentForm({
+  const commentMutation = useMutation<void, Error, string, PreviousComments>({
+    mutationFn: (comment) => {
+      const requestDto: CommentFormRequestDto = {
         teamId,
         description: comment,
-      }),
-    onSuccess: () => {
-      setNewComment('');
+      };
+      return postCommentForm(requestDto);
     },
-    onError: () => {
+    onMutate: async (newCommentText) => {
+      await queryClient.cancelQueries({ queryKey: ['comments', teamId] });
+      const previousComments = queryClient.getQueryData<CommentDto[]>(['comments', teamId]);
+
+      const optimisticComment: CommentDto = {
+        commentId: Date.now(),
+        description: newCommentText,
+        memberId: user?.id ?? 0,
+        memberName: user?.name ?? '',
+        teamId,
+      };
+
+      queryClient.setQueryData<CommentDto[]>(['comments', teamId], (old = []) => [...old, optimisticComment]);
+
+      return { previousComments };
+    },
+    onError: (err, newComment, context) => {
+      if (context?.previousComments) {
+        queryClient.setQueryData(['comments', teamId], context.previousComments);
+      }
       alert('댓글 등록에 실패했어요.');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', teamId] });
+      setNewComment('');
     },
   });
 


### PR DESCRIPTION
### 개요
댓글 낙관적 업데이트로 수정, 헤더 admin 계정일때만 관리자페이지 노출
### 목적
댓글 낙관적 업데이트로 수정, 헤더 admin 계정일때만 관리자페이지 노출
### 변경사항
Header : admin계정만 관리자 버튼 노출, isAdmin으로 관리자 체크, /monitor -> /admin으로 수정

AdminPage / ProjectSubmissionTable : 저번 머지 때 없어진 부분 다시 넣음, unique key 에러 해결
+) 관리자 권한 없는데 url로 /admin 으로 접근시 권한없는 div 노출

CommentFormSection : Optimistic Update로 등록된 댓글 바로 보이게끔 
* onMutate : mutaionFn 실행 전 실행되는 부분 -> getQueryData로 전 댓글리스트
* onError : 실패하면 다시 전 댓글리스트로 돌려놓음
* onSettled : 성공,실패에 상관없이 실행
### 화면 이미지
<img width="1163" alt="스크린샷 2025-06-05 오후 9 33 33" src="https://github.com/user-attachments/assets/fc1dc6bb-680a-436b-8880-ce92bc95f93b" />
