### PR TITLE
hotfix: Header 관리자 페이지 이동 버튼 Link로 교체

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 const Header = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { isSignedIn, signOut, user, isAdmin } = useAuth();
+  const { isSignedIn, signOut, isAdmin } = useAuth();
 
   const handleLogout = () => {
     const confirmLogout = window.confirm('로그아웃 하시겠습니까?');
@@ -17,11 +17,6 @@ const Header = () => {
     }
   };
 
-  const handleAdminPage = () => {
-    navigate('/admin');
-    return;
-  };
-
   return (
     <header className="h-header min-h-header border-lightGray z-20 flex w-full items-center justify-between border-b bg-white px-4">
       <Link to="/">
@@ -29,13 +24,18 @@ const Header = () => {
       </Link>
       <div className="flex items-center justify-between gap-8">
         {isAdmin ? (
-          <div
-            className="flex items-center gap-2 hover:cursor-pointer"
-            onClick={location.pathname != '/admin' ? handleAdminPage : undefined}
-          >
-            <BiCog className="text-mainGreen text-exsm cursor-pointer" />
-            <span className="text-exsm">관리자 페이지</span>
-          </div>
+          // 이미 /admin 경로에 있다면 Link가 아닌 div로 감싸서 클릭 이벤트를 막음
+          location.pathname !== '/admin' ? (
+            <Link to="/admin" className="flex items-center gap-2 hover:cursor-pointer">
+              <BiCog className="text-mainGreen text-exsm cursor-pointer" />
+              <span className="text-exsm">관리자 페이지</span>
+            </Link>
+          ) : (
+            <div className="flex items-center gap-2 hover:cursor-pointer">
+              <BiCog className="text-mainGreen text-exsm cursor-pointer" />
+              <span className="text-exsm">관리자 페이지</span>
+            </div>
+          )
         ) : null}
         <button
           onClick={isSignedIn ? handleLogout : () => navigate('/signin')}


### PR DESCRIPTION
### 개요
Header 관리자 페이지 이동 버튼 Link로 교체
### 목적
Header 관리자 페이지 이동 버튼 Link로 교체
### 변경사항
Header div onClick={} 에서 Link to로 교체
+) 이미 /admin일때 div로 클릭 안되게끔