### PR TITLE
fix: 로그인, 로그아웃, 좋아요 시 메인 페이지 refetch되도록 querykey 수정

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,14 +1,13 @@
-import Notice from "@pages/main/Notice";
-import TotalCards from "@pages/main/TotalCards";
-import LeaderSection from "@pages/main/LeaderSection";
+import Notice from '@pages/main/Notice';
+import TotalCards from '@pages/main/TotalCards';
 
 const MainPage = () => {
   return (
-      <div className="relative flex flex-col gap-20">
-        <Notice/>
-          <TotalCards />
-      </div>
-  )
-}
+    <div className="relative flex flex-col gap-20">
+      <Notice />
+      <TotalCards />
+    </div>
+  );
+};
 
 export default MainPage;

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -1,59 +1,53 @@
-import TeamCard from "@pages/main/TeamCard";
-import {useQuery} from "@tanstack/react-query"
-import {getAllTeams} from "../../apis/teams";
-import {TeamListItemResponseDto} from "../../types/DTO/teams/teamListDto";
-import LeaderSection from "@pages/main/LeaderSection";
-import LoadingSpinner from "@pages/main/LoadingSpinner";
-import { useRef } from "react";
-
+import TeamCard from '@pages/main/TeamCard';
+import { useQuery } from '@tanstack/react-query';
+import { getAllTeams } from '../../apis/teams';
+import { TeamListItemResponseDto } from '../../types/DTO/teams/teamListDto';
+import LeaderSection from '@pages/main/LeaderSection';
+import LoadingSpinner from '@pages/main/LoadingSpinner';
+import useAuth from 'hooks/useAuth';
 
 const TotalCards = () => {
-    const {
-        data: teams,
-        isLoading,
-        isError,
-    } = useQuery<TeamListItemResponseDto[]>({
-        queryKey: ['teams'],
-        queryFn: getAllTeams,
-        staleTime: 1000 * 60 * 15,  // stale 시간: 15분
-        gcTime: 1000 * 60 * 15,  // 캐시 삭제 기간 : 15분 간격
-    });
+  const { user } = useAuth();
+  const {
+    data: teams,
+    isLoading,
+    isError,
+  } = useQuery<TeamListItemResponseDto[]>({
+    queryKey: ['teams', user?.id ?? 'guest'],
+    queryFn: getAllTeams,
+    staleTime: 1000 * 60 * 15, // stale 시간: 15분
+    gcTime: 1000 * 60 * 15, // 캐시 삭제 기간 : 15분 간격
+  });
 
-    return (
+  return (
+    <div id="projects" className="flex flex-col gap-4">
+      <div className="flex items-center justify-between px-4">
+        <h3 id="projects" className="md:text-md text-sm font-bold lg:text-xl">
+          현재 투표진행중인 작품
+        </h3>
+        <h3 id="projects" className="md:text-md text-sm font-bold lg:text-xl">
+          {user?.id ?? 'null'}
+        </h3>
+      </div>
+      <div className="absolute top-10 left-50 z-50 sm:top-0 sm:left-55 md:top-0 md:left-50 md:left-65 md:left-70 lg:top-10 xl:top-30">
+        <LeaderSection />
+      </div>
 
-        <div id="projects" className="flex flex-col gap-4">
-            <div className="flex justify-between items-center px-4">
-                <h3 id="projects" className="text-sm md:text-md lg:text-xl font-bold">
-                    현재 투표진행중인 작품</h3>
-            </div>
-            <div className="absolute z-50
-              top-10 left-50
-              sm:top-0 sm:left-55
-              md:top-0 md:left-50
-              lg:top-10 md:left-70
-              xl:top-30 md:left-65
-              ">
-                <LeaderSection />
-            </div>
-
-
-            <section
-                className="mx-0 grid max-w-screen-xl grid-cols-1 gap-8 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                {isLoading && <LoadingSpinner />}
-                {isError && <p>데이터를 불러오지 못했습니다.</p>}
-                {teams?.map((team) => (
-                    <TeamCard
-                        key={team.teamId}
-                        teamId={team.teamId}
-                        teamName={team.teamName}
-                        projectName={team.projectName}
-                        isLiked={team.liked}
-                    />
-                ))}
-            </section>
-        </div>
-    );
-
+      <section className="mx-0 grid max-w-screen-xl grid-cols-1 gap-8 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {isLoading && <LoadingSpinner />}
+        {isError && <p>데이터를 불러오지 못했습니다.</p>}
+        {teams?.map((team) => (
+          <TeamCard
+            key={team.teamId}
+            teamId={team.teamId}
+            teamName={team.teamName}
+            projectName={team.projectName}
+            isLiked={team.liked}
+          />
+        ))}
+      </section>
+    </div>
+  );
 };
 
 export default TotalCards;

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import useAuth from 'hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { patchLikeToggle } from 'apis/projectViewer';
@@ -17,10 +17,13 @@ const LikeSection = ({ teamId, isLiked: initIsLiked }: LikeSectionProps) => {
   const [isLiked, setIsLiked] = useState(initIsLiked);
   const navigate = useNavigate();
 
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
   const likeMutation = useMutation({
     mutationFn: (nextIsLiked: boolean) => patchLikeToggle({ teamId, isLiked: nextIsLiked }),
     onSuccess: () => {
       setIsLiked((prev) => !prev);
+      queryClient.invalidateQueries({ queryKey: ['teams', user?.id ?? 'guest'] });
     },
   });
 


### PR DESCRIPTION
### 개요
fix: 로그인, 로그아웃, 좋아요 시 메인 페이지 refetch되도록 querykey 수정

### 목적
로그인, 로그아웃, 좋아요 시 메인 페이지에서 불러오는 프로젝트 전체 목록 조회 요청을 재시도할 수 있도록 queryKey 변경

### 변경사항
- TotalCards에서 queryKey 변경
- LikeSection에서 invalidate query