### PR TITLE
design: 팀장용 메세지 디자인 수정

### DIFF
--- a/src/pages/main/LeaderMessage.tsx
+++ b/src/pages/main/LeaderMessage.tsx
@@ -1,25 +1,19 @@
-import { BiError } from "react-icons/bi";
+import { BiError } from 'react-icons/bi';
 
 interface LeaderProps {
-    leaderName : string;
+  leaderName: string;
 }
 
-const LeaderMessage = ({ leaderName } : LeaderProps) => {
-    return(
-        <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-4 text-mainRed">
-                <BiError size={40} />
-                <div className="flex flex-col leading-snug">
-                    <span className="text-sm">
-                      <strong>{leaderName}</strong> 팀장님
-                    </span>
-                    <span className="text-sm">에디터에서 프로젝트 정보를 작성해 주세요!</span>
-                </div>
-            </div>
-
-        </div>
-
-    );
+const LeaderMessage = ({ leaderName }: LeaderProps) => {
+  return (
+    <div className="text-mainRed flex items-center gap-1">
+      <BiError className="text-4xl" />
+      <span className="text-sm">
+        <strong>{leaderName}</strong> 팀장님
+      </span>
+      <span className="text-sm">에디터에서 프로젝트 정보를 작성해 주세요!</span>
+    </div>
+  );
 };
 
 export default LeaderMessage;

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -17,7 +17,7 @@ const LeaderSection = () => {
 
   const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
 
-  // if (!showLeaderMessage) return null;
+  if (!showLeaderMessage) return null;
 
   return (
     <div className="flex w-fit gap-4 rounded-lg bg-white p-3 shadow-[0_4px_12px_rgba(0,0,0,0.2)]">

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -1,43 +1,36 @@
-import LeaderMessage from "@pages/main/LeaderMessage";
-import useAuth from "../../hooks/useAuth";
-import {getSubmissionStatus} from "../../apis/teams";
-import {useQuery} from "@tanstack/react-query";
-import {SubmissionStatusResponseDto} from "../../types/DTO/teams/submissionStatusDto";
-import {Link} from "react-router-dom";
-import {TbPencil} from "react-icons/tb";
+import LeaderMessage from '@pages/main/LeaderMessage';
+import useAuth from '../../hooks/useAuth';
+import { getSubmissionStatus } from '../../apis/teams';
+import { useQuery } from '@tanstack/react-query';
+import { SubmissionStatusResponseDto } from '../../types/DTO/teams/submissionStatusDto';
+import { Link } from 'react-router-dom';
+import { TbPencil } from 'react-icons/tb';
+import RoundedButton from '@components/RoundedButton';
 
 const LeaderSection = () => {
-    const { isLeader, user } = useAuth();
-    const {
-        data: submissionData,
-    } = useQuery<SubmissionStatusResponseDto>({
-        queryKey: ['submissionStatus'],
-        queryFn: getSubmissionStatus,
-        enabled: isLeader,
-    });
+  const { isLeader, user } = useAuth();
+  const { data: submissionData } = useQuery<SubmissionStatusResponseDto>({
+    queryKey: ['submissionStatus'],
+    queryFn: getSubmissionStatus,
+    enabled: isLeader,
+  });
 
-    const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
+  const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
 
-    if (!showLeaderMessage) return null;
+  // if (!showLeaderMessage) return null;
 
-    return (
-        <div className="relative bg-white rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.2)] p-7 w-fit">
-            <div className="absolute -bottom-9 left-10 w-10 h-20 bg-white rotate-63 shadow-[3px_3px_6px_rgba(0,0,0,0.1)] z-0"/>
+  return (
+    <div className="flex w-fit gap-4 rounded-lg bg-white p-3 shadow-[0_4px_12px_rgba(0,0,0,0.2)]">
+      <LeaderMessage leaderName={user?.name ?? '팀장'} />
 
-            <LeaderMessage leaderName={user?.name ?? '팀장'}/>
-
-            <Link
-                to={`/teams/edit/${submissionData?.teamId}`}
-                className="mt-4 px-8 py-4 w-fit border border-midGray rounded-full text-exsm flex items-center gap-2 mx-auto hover:bg-gray-50 transition">
-
-                <TbPencil size={20} strokeWidth={2}/>
-                프로젝트 에디터
-            </Link>
-        </div>
-
-
-    )
-}
-
+      <Link to={`/teams/edit/${submissionData?.teamId}`}>
+        <RoundedButton className="flex w-fit items-center gap-1">
+          <TbPencil size={20} strokeWidth={2} />
+          작성하러 가기
+        </RoundedButton>
+      </Link>
+    </div>
+  );
+};
 
 export default LeaderSection;

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -21,16 +21,14 @@ const TotalCards = () => {
 
   return (
     <div id="projects" className="flex flex-col gap-4">
-      <div className="flex items-center justify-between px-4">
-        <h3 id="projects" className="md:text-md text-sm font-bold lg:text-xl">
+      <div className="my-4 flex items-center justify-between">
+        <h3 id="projects" className="lg:text-title xl:text-title text-sm font-bold md:text-base">
           현재 투표진행중인 작품
         </h3>
-      </div>
-      <div className="absolute top-10 left-50 z-50 sm:top-0 sm:left-55 md:top-0 md:left-50 md:left-65 md:left-70 lg:top-10 xl:top-30">
         <LeaderSection />
       </div>
 
-      <section className="mx-0 grid max-w-screen-xl grid-cols-1 gap-8 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      <section className="mx-0 grid max-w-screen-xl grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {isLoading && <LoadingSpinner />}
         {isError && <p>데이터를 불러오지 못했습니다.</p>}
         {teams?.map((team) => (


### PR DESCRIPTION
### 개요
팀장용 메세지 디자인 수정

### 목적
UI 일관성을 위한 팀장용 메세지 디자인 수정

### 변경사항
- LeaderSection, LeaderMessage 디자인 수정

### 참고 이미지
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/44d0f757-b1db-4209-80e1-93cb4bfb3425" />
