### PR TITLE
feat: comment section UI improvements

### DIFF
--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import ConfirmModal from './ConfirmModal';
 import { GoPencil } from 'react-icons/go';
 import { IoIosRemoveCircleOutline } from 'react-icons/io';
 
@@ -29,6 +30,7 @@ const Comment = ({
   currentUserId,
 }: CommentProps) => {
   const [localDesc, setLocalDesc] = useState(comment.description);
+  const [showConfirm, setShowConfirm] = useState(false);
   const editRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -45,69 +47,79 @@ const Comment = ({
   }, [isEditing, comment.description, onCancelEdit]);
 
   return (
-    <div className="border-lightGray relative flex flex-col gap-3 border-b p-5 text-sm" ref={editRef}>
-      <span className="flex justify-between font-bold">
-        {comment.memberName}
-        {comment.memberId === currentUserId && (
-          <div className="text-midGray flex gap-4">
-            <div className="group relative">
+    <>
+      <div className="border-lightGray relative flex flex-col gap-3 border-b p-5 text-sm" ref={editRef}>
+        <span className="flex justify-between font-bold">
+          {comment.memberName}
+          {comment.memberId === currentUserId && (
+            <div className="text-midGray flex gap-4">
+              <div className="group relative">
+                <button
+                  onClick={onStartEdit}
+                  className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'}`}
+                >
+                  <GoPencil size={18} />
+                </button>
+                <div className="bg-mainGreen absolute -top-8 left-1/2 -translate-x-1/2 rounded px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
+                  댓글 수정
+                </div>
+              </div>
+              <div className="group relative">
+                <button onClick={() => setShowConfirm(true)} className="cursor-pointer hover:text-red-500">
+                  <IoIosRemoveCircleOutline size={20} />
+                </button>
+                <div className="absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-red-500 px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
+                  댓글 삭제
+                </div>
+              </div>
+            </div>
+          )}
+        </span>
+
+        {isEditing ? (
+          <div className="flex flex-col gap-5 transition-all duration-300 ease-in-out">
+            <textarea
+              className="bg-whiteGray placeholder:text-lightGray focus:ring-lightGray h-32 w-full resize-none overflow-y-auto rounded p-3 leading-[1.8] transition-all duration-300 ease-in-out focus:ring focus:outline-none"
+              placeholder="댓글을 입력하세요 (최대 255자)"
+              maxLength={255}
+              value={localDesc}
+              onChange={(e) => setLocalDesc(e.target.value)}
+            />
+            <div className="flex justify-end gap-2">
               <button
-                onClick={onStartEdit}
-                className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'}`}
+                className="bg-mainGreen text-exsm text-whiteGray rounded-full px-5 py-1 transition hover:cursor-pointer hover:bg-emerald-600"
+                onClick={() => {
+                  setEditedDescription(localDesc);
+                  handleEdit();
+                }}
               >
-                <GoPencil size={18} />
+                저장
               </button>
-              <div className="bg-mainGreen absolute -top-8 left-1/2 -translate-x-1/2 rounded px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
-                댓글 수정
-              </div>
-            </div>
-
-            <div className="group relative">
-              <button onClick={handleDelete} className="cursor-pointer hover:text-red-500">
-                <IoIosRemoveCircleOutline size={20} />
+              <button
+                className="text-exsm border-lightGray text-midGray hover:bg-lightGray rounded-full border px-5 py-1 transition hover:cursor-pointer"
+                onClick={() => {
+                  setLocalDesc(comment.description);
+                  onCancelEdit();
+                }}
+              >
+                취소
               </button>
-              <div className="absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-red-500 px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
-                댓글 삭제
-              </div>
             </div>
           </div>
+        ) : (
+          <div className="leading-[1.8] break-words transition-all duration-300 ease-in-out">{comment.description}</div>
         )}
-      </span>
-
-      {isEditing ? (
-        <div className="flex flex-col gap-5 transition-all duration-300 ease-in-out">
-          <textarea
-            className="bg-whiteGray placeholder:text-lightGray focus:ring-lightGray h-32 w-full resize-none overflow-y-auto rounded p-3 leading-[1.8] transition-all duration-300 ease-in-out focus:ring focus:outline-none"
-            placeholder="댓글을 입력하세요 (최대 255자)"
-            maxLength={255}
-            value={localDesc}
-            onChange={(e) => setLocalDesc(e.target.value)}
-          />
-          <div className="flex justify-end gap-2">
-            <button
-              className="bg-mainGreen text-exsm text-whiteGray rounded-full px-5 py-1 transition hover:cursor-pointer hover:bg-emerald-600"
-              onClick={() => {
-                setEditedDescription(localDesc);
-                handleEdit();
-              }}
-            >
-              저장
-            </button>
-            <button
-              className="text-exsm border-lightGray text-midGray hover:bg-lightGray rounded-full border px-5 py-1 transition hover:cursor-pointer"
-              onClick={() => {
-                setLocalDesc(comment.description);
-                onCancelEdit();
-              }}
-            >
-              취소
-            </button>
-          </div>
-        </div>
-      ) : (
-        <div className="leading-[1.8] break-words transition-all duration-300 ease-in-out">{comment.description}</div>
-      )}
-    </div>
+      </div>
+      <ConfirmModal
+        isOpen={showConfirm}
+        onConfirm={() => {
+          handleDelete();
+          setShowConfirm(false);
+        }}
+        onCancel={() => setShowConfirm(false)}
+        message="삭제한 댓글은 복구할 수 없습니다."
+      />
+    </>
   );
 };
 

--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -1,5 +1,6 @@
-import { GoKebabHorizontal } from 'react-icons/go';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { GoPencil } from 'react-icons/go';
+import { IoIosRemoveCircleOutline } from 'react-icons/io';
 
 interface CommentProps {
   comment: {
@@ -9,8 +10,6 @@ interface CommentProps {
     description: string;
   };
   isEditing: boolean;
-  isMenuOpen: boolean;
-  toggleMenu: () => void;
   handleEdit: () => void;
   handleDelete: () => void;
   setEditedDescription: (desc: string) => void;
@@ -22,38 +21,71 @@ interface CommentProps {
 const Comment = ({
   comment,
   isEditing,
-  isMenuOpen,
-  toggleMenu,
   handleEdit,
   handleDelete,
   setEditedDescription,
   onStartEdit,
   onCancelEdit,
-  currentUserId
+  currentUserId,
 }: CommentProps) => {
   const [localDesc, setLocalDesc] = useState(comment.description);
+  const editRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (isEditing && editRef.current && !editRef.current.contains(e.target as Node)) {
+        setLocalDesc(comment.description);
+        onCancelEdit();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isEditing, comment.description, onCancelEdit]);
 
   return (
-    <div className="border-lightGray relative flex flex-col gap-2 border-b p-5 text-sm">
+    <div className="border-lightGray relative flex flex-col gap-3 border-b p-5 text-sm" ref={editRef}>
       <span className="flex justify-between font-bold">
         {comment.memberName}
         {comment.memberId === currentUserId && (
-          <button onClick={toggleMenu}>
-            <GoKebabHorizontal size={25}className="rounded-full p-1 text-midGray cursor-pointer hover:bg-gray-100" />
-          </button>
+          <div className="text-midGray flex gap-4">
+            <div className="group relative">
+              <button
+                onClick={onStartEdit}
+                className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'}`}
+              >
+                <GoPencil size={18} />
+              </button>
+              <div className="bg-mainGreen absolute -top-8 left-1/2 -translate-x-1/2 rounded px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
+                댓글 수정
+              </div>
+            </div>
+
+            <div className="group relative">
+              <button onClick={handleDelete} className="cursor-pointer hover:text-red-500">
+                <IoIosRemoveCircleOutline size={20} />
+              </button>
+              <div className="absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-red-500 px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
+                댓글 삭제
+              </div>
+            </div>
+          </div>
         )}
       </span>
 
       {isEditing ? (
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-5 transition-all duration-300 ease-in-out">
           <textarea
-            className="w-full rounded border p-2"
+            className="bg-whiteGray placeholder:text-lightGray focus:ring-lightGray h-32 w-full resize-none overflow-y-auto rounded p-3 leading-[1.8] transition-all duration-300 ease-in-out focus:ring focus:outline-none"
+            placeholder="댓글을 입력하세요 (최대 255자)"
+            maxLength={255}
             value={localDesc}
             onChange={(e) => setLocalDesc(e.target.value)}
           />
-          <div className="flex gap-2">
+          <div className="flex justify-end gap-2">
             <button
-              className="bg-mainGreen rounded px-3 py-1 text-white"
+              className="bg-mainGreen text-exsm text-whiteGray rounded-full px-5 py-1 transition hover:cursor-pointer hover:bg-emerald-600"
               onClick={() => {
                 setEditedDescription(localDesc);
                 handleEdit();
@@ -62,7 +94,7 @@ const Comment = ({
               저장
             </button>
             <button
-              className="rounded border px-3 py-1"
+              className="text-exsm border-lightGray text-midGray hover:bg-lightGray rounded-full border px-5 py-1 transition hover:cursor-pointer"
               onClick={() => {
                 setLocalDesc(comment.description);
                 onCancelEdit();
@@ -73,23 +105,7 @@ const Comment = ({
           </div>
         </div>
       ) : (
-        <div className="leading-[1.8]">{comment.description}</div>
-      )}
-
-      {isMenuOpen && !isEditing && (
-        <div className="border-lightGray absolute right-0 z-10 mt-10 rounded border bg-white p-2 shadow-lg">
-          <button onClick={handleDelete} className="block w-full p-2 text-left hover:bg-gray-100">
-            댓글 삭제
-          </button>
-          <button
-            onClick={() => {
-              onStartEdit();
-            }}
-            className="block w-full p-2 text-left hover:bg-gray-100"
-          >
-            댓글 수정
-          </button>
-        </div>
+        <div className="leading-[1.8] break-words transition-all duration-300 ease-in-out">{comment.description}</div>
       )}
     </div>
   );

--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -81,14 +81,20 @@ const Comment = ({
         </span>
 
         {isEditing ? (
-          <div className="flex flex-col gap-5 transition-all duration-300 ease-in-out">
-            <textarea
-              className="bg-whiteGray placeholder:text-lightGray focus:ring-lightGray h-32 w-full resize-none overflow-y-auto rounded p-3 leading-[1.8] transition-all duration-300 ease-in-out focus:ring focus:outline-none"
-              placeholder="댓글을 입력하세요 (최대 255자)"
-              maxLength={255}
-              value={localDesc}
-              onChange={(e) => setLocalDesc(e.target.value)}
-            />
+          <div className="animate-fade-in flex flex-col gap-5">
+            <div className="bg-whiteGray focus:ring-lightGray flex h-36 flex-col gap-2 rounded p-3 text-sm transition-all duration-300 ease-in-out focus:outline-none">
+              <textarea
+                className="placeholder:text-lightGray w-full flex-1 resize-none focus:outline-none"
+                placeholder="댓글을 입력하세요 (최대 255자)"
+                maxLength={255}
+                value={localDesc}
+                onChange={(e) => setLocalDesc(e.target.value)}
+              />
+              <div className="text-exsm text-midGray text-right">
+                <span className={localDesc.length >= 200 ? 'text-mainRed' : ''}>{localDesc.length}</span> / 255자
+              </div>
+            </div>
+
             <div className="flex justify-end gap-2">
               <button
                 className="bg-mainGreen text-exsm text-whiteGray rounded-full px-5 py-1 transition hover:cursor-pointer hover:bg-emerald-600 focus:bg-emerald-600 focus:outline-none"
@@ -115,9 +121,7 @@ const Comment = ({
             </div>
           </div>
         ) : (
-          <div className="leading-[1.5] break-words text-gray-700 transition-all duration-300 ease-in-out">
-            {comment.description}
-          </div>
+          <div className="break-words text-gray-700 transition-all duration-300 ease-in-out">{comment.description}</div>
         )}
       </div>
       <ConfirmModal

--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -84,7 +84,7 @@ const Comment = ({
           <div className="animate-fade-in flex flex-col gap-5">
             <div className="bg-whiteGray focus:ring-lightGray flex h-36 flex-col gap-2 rounded p-3 text-sm transition-all duration-300 ease-in-out focus:outline-none">
               <textarea
-                className="placeholder:text-lightGray w-full flex-1 resize-none focus:outline-none"
+                className="placeholder:text-lightGray w-full flex-1 resize-none p-2 focus:outline-none"
                 placeholder="댓글을 입력하세요 (최대 255자)"
                 maxLength={255}
                 value={localDesc}

--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import ConfirmModal from './ConfirmModal';
-import { GoPencil } from 'react-icons/go';
-import { IoIosRemoveCircleOutline } from 'react-icons/io';
+import { RiPencilFill } from 'react-icons/ri';
+import { IoRemoveCircle } from 'react-icons/io5';
 
 interface CommentProps {
   comment: {
@@ -48,25 +48,29 @@ const Comment = ({
 
   return (
     <>
-      <div className="border-lightGray relative flex flex-col gap-3 border-b p-5 text-sm" ref={editRef}>
+      <div className="relative flex flex-col gap-3 border-b border-gray-100 p-5 text-sm" ref={editRef}>
         <span className="flex justify-between font-bold">
           {comment.memberName}
           {comment.memberId === currentUserId && (
-            <div className="text-midGray flex gap-4">
+            <div className="text-midGray bg-whiteGray flex items-center gap-3 rounded-md px-3">
               <div className="group relative">
                 <button
                   onClick={onStartEdit}
-                  className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'}`}
+                  className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'} text-lightGray focus:text-mainGreen focus:outline-none`}
                 >
-                  <GoPencil size={18} />
+                  <RiPencilFill size={18} />
                 </button>
                 <div className="bg-mainGreen absolute -top-8 left-1/2 -translate-x-1/2 rounded px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
                   댓글 수정
                 </div>
               </div>
+              <div className="bg-lightGray h-3 w-px" />
               <div className="group relative">
-                <button onClick={() => setShowConfirm(true)} className="cursor-pointer hover:text-red-500">
-                  <IoIosRemoveCircleOutline size={20} />
+                <button
+                  onClick={() => setShowConfirm(true)}
+                  className="text-lightGray hover:text-mainRed focus:text-mainRed cursor-pointer focus:outline-none"
+                >
+                  <IoRemoveCircle size={18} />
                 </button>
                 <div className="absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-red-500 px-2 py-1 text-xs font-normal whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-50">
                   댓글 삭제
@@ -87,8 +91,12 @@ const Comment = ({
             />
             <div className="flex justify-end gap-2">
               <button
-                className="bg-mainGreen text-exsm text-whiteGray rounded-full px-5 py-1 transition hover:cursor-pointer hover:bg-emerald-600"
+                className="bg-mainGreen text-exsm text-whiteGray rounded-full px-5 py-1 transition hover:cursor-pointer hover:bg-emerald-600 focus:bg-emerald-600 focus:outline-none"
                 onClick={() => {
+                  if (localDesc.trim() === comment.description.trim()) {
+                    onCancelEdit();
+                    return;
+                  }
                   setEditedDescription(localDesc);
                   handleEdit();
                 }}
@@ -96,7 +104,7 @@ const Comment = ({
                 저장
               </button>
               <button
-                className="text-exsm border-lightGray text-midGray hover:bg-lightGray rounded-full border px-5 py-1 transition hover:cursor-pointer"
+                className="text-exsm border-lightGray text-midGray hover:bg-lightGray focus:bg-lightGray rounded-full border px-5 py-1 transition hover:cursor-pointer focus:outline-none"
                 onClick={() => {
                   setLocalDesc(comment.description);
                   onCancelEdit();
@@ -107,7 +115,9 @@ const Comment = ({
             </div>
           </div>
         ) : (
-          <div className="leading-[1.8] break-words transition-all duration-300 ease-in-out">{comment.description}</div>
+          <div className="leading-[1.5] break-words text-gray-700 transition-all duration-300 ease-in-out">
+            {comment.description}
+          </div>
         )}
       </div>
       <ConfirmModal

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -66,7 +66,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
 
   return (
     <>
-      <div className="ring-lightGray focus-within:ring-midGray flex flex-col gap-2 rounded p-5 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1">
+      <div className="ring-lightGray focus-within:ring-midGray flex h-36 flex-col gap-2 rounded p-3 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1">
         <textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -82,7 +82,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
       <div className="mt-2 flex justify-end">
         <button
           onClick={handleClick}
-          className="text-mainGreen rounded-full bg-[#D1F3E1] px-10 py-2 font-medium transition-colors duration-200 hover:cursor-pointer hover:bg-[#b2e8cf]"
+          className="text-mainGreen rounded-full bg-[#D1F3E1] px-10 py-2 font-medium transition-colors duration-200 hover:cursor-pointer hover:bg-[#b2e8cf] focus:bg-[#b2e8cf] focus:outline-none"
         >
           등록
         </button>

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -72,7 +72,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
           onChange={(e) => setNewComment(e.target.value)}
           maxLength={255}
           placeholder="프로젝트에 대해 댓글을 남겨보세요."
-          className="placeholder-lightGray w-full flex-1 resize-none focus:outline-none"
+          className="placeholder-lightGray w-full flex-1 resize-none p-2 focus:outline-none"
         />
         <div className="text-exsm text-midGray text-right">
           <span className={newComment.length >= 200 ? 'text-mainRed' : ''}>{newComment.length}</span> / 255자

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import useAuth from 'hooks/useAuth';
+import { useToast } from 'hooks/useToast';
 import { CommentFormRequestDto, CommentDto } from 'types/DTO/projectViewerDto';
 import { postCommentForm } from 'apis/projectViewer';
 
@@ -16,6 +17,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
   const [newComment, setNewComment] = useState('');
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const toast = useToast();
 
   const commentMutation = useMutation<void, Error, string, PreviousComments>({
     mutationFn: (comment) => {
@@ -45,7 +47,10 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
       if (context?.previousComments) {
         queryClient.setQueryData(['comments', teamId], context.previousComments);
       }
-      alert('댓글 등록에 실패했어요.');
+      toast('댓글 등록에 실패했어요.');
+    },
+    onSuccess: () => {
+      toast('댓글이 등록되었어요.');
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['comments', teamId] });
@@ -54,25 +59,32 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
   });
 
   const handleClick = () => {
-    if (!newComment.trim()) return alert('댓글을 입력해주세요.');
+    if (!newComment.trim()) return toast('댓글을 입력해주세요.');
     if (commentMutation.isPending) return;
     commentMutation.mutate(newComment);
   };
 
   return (
     <>
-      <div className="border-midGray flex h-[200px] flex-col justify-between rounded border p-5 text-sm">
+      <div className="ring-lightGray focus-within:ring-midGray flex flex-col gap-2 rounded p-5 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1">
         <textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
+          maxLength={255}
           placeholder="프로젝트에 대해 댓글을 남겨보세요."
-          className="placeholder-lightGray mb-1 w-full flex-1 resize-none focus:outline-none"
+          className="placeholder-lightGray w-full flex-1 resize-none focus:outline-none"
         />
+        <div className="text-exsm text-midGray text-right">
+          <span className={newComment.length >= 200 ? 'text-mainRed' : ''}>{newComment.length}</span> / 255자
+        </div>
+      </div>
+
+      <div className="mt-2 flex justify-end">
         <button
           onClick={handleClick}
-          className="text-mainGreen self-end rounded-full bg-[#D1F3E1] px-15 py-3 font-bold hover:cursor-pointer"
+          className="text-mainGreen rounded-full bg-[#D1F3E1] px-10 py-2 font-medium transition-colors duration-200 hover:cursor-pointer hover:bg-[#b2e8cf]"
         >
-          {commentMutation.isPending ? '등록 중...' : '등록'}
+          등록
         </button>
       </div>
     </>

--- a/src/pages/project-viewer/CommentSection/CommentListSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentListSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useToast } from 'hooks/useToast';
 import Comment from './Comment';
 import { getCommentsList, deleteComment, editComment } from 'apis/projectViewer';
 import { CommentDto, CommentDeleteRequestDto, CommentEditRequestDto } from 'types/DTO/projectViewerDto';
@@ -11,6 +12,7 @@ interface CommentListSectionProps {
 
 const CommentListSection = ({ teamId, memberId }: CommentListSectionProps) => {
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [editingId, setEditingId] = useState<number | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState<number | null>(null);
   const [editedDescription, setEditedDescription] = useState<string>('');
@@ -22,7 +24,9 @@ const CommentListSection = ({ teamId, memberId }: CommentListSectionProps) => {
 
   const deleteMutation = useMutation({
     mutationFn: (request: CommentDeleteRequestDto) => deleteComment(request),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['comments', teamId] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', teamId] }), toast('댓글이 삭제되었어요.');
+    },
   });
 
   const editMutation = useMutation({
@@ -30,6 +34,7 @@ const CommentListSection = ({ teamId, memberId }: CommentListSectionProps) => {
     onSuccess: () => {
       setEditingId(null);
       queryClient.invalidateQueries({ queryKey: ['comments', teamId] });
+      toast('댓글이 편집되었어요.');
     },
   });
 

--- a/src/pages/project-viewer/CommentSection/CommentListSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentListSection.tsx
@@ -44,8 +44,6 @@ const CommentListSection = ({ teamId, memberId }: CommentListSectionProps) => {
             key={comment.commentId}
             comment={comment}
             isEditing={editingId === comment.commentId}
-            isMenuOpen={isMenuOpen === comment.commentId}
-            toggleMenu={() => setIsMenuOpen(isMenuOpen === comment.commentId ? null : comment.commentId)}
             handleEdit={() =>
               editMutation.mutate({
                 teamId,

--- a/src/pages/project-viewer/CommentSection/ConfirmModal.tsx
+++ b/src/pages/project-viewer/CommentSection/ConfirmModal.tsx
@@ -1,0 +1,54 @@
+import { RxCross2 } from 'react-icons/rx';
+import { FaRegTrashAlt } from 'react-icons/fa';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  message?: string; // optional 커스텀 메시지
+}
+
+const ConfirmModal = ({ isOpen, onConfirm, onCancel, message }: ConfirmModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      onClick={onCancel}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="relative w-[320px] rounded-2xl bg-white p-6 shadow-xl transition-all duration-300 ease-in-out"
+      >
+        <button
+          onClick={onCancel}
+          className="absolute top-4 right-4 text-gray-400 hover:cursor-pointer hover:text-gray-600"
+          aria-label="닫기"
+        >
+          <RxCross2 size={20} />
+        </button>
+        <div className="text-mainRed mx-auto my-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+          <FaRegTrashAlt size={24} />
+        </div>
+        <h3 className="text-center text-lg font-semibold text-gray-800">정말 삭제하시겠어요?</h3>
+        <p className="text-exsm mt-2 text-center text-gray-400">{message}</p>
+        <div className="mt-6 flex justify-center gap-3">
+          <button
+            onClick={onCancel}
+            className="text-exsm border-lightGray text-midGray rounded-full border px-5 py-1.5 hover:cursor-pointer hover:bg-gray-100"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            className="text-exsm bg-mainRed rounded-full px-5 py-1.5 text-white hover:cursor-pointer hover:bg-red-500"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;


### PR DESCRIPTION
### 개요
- toast 메시지를 띄웁니다.
  - 댓글 등록/편집/삭제 시
- 기존 댓글 편집/삭제 토글 메뉴를 없애고, 아이콘을 두었습니다.
- 삭제 시 모달창을 띄워 실수로 삭제하는 일이 없도록 하였습니다.
- 편집된 글과 기존 글이 같을 경우 편집되지 않도록 하였습니다.
- 255자의 글자 수 제한을 두었습니다.
  - 댓글 등록창, 댓글 편집창에 적용하였습니다.
  - 우측 하단에서 현재 입력된 글자 수를 확인할 수 있습니다.
  - 글자 수가 200자에 도달하면 빨간색으로 표시됩니다.
  - 255자를 넘으면 타이핑할 수 없습니다.

### 변경사항
https://github.com/user-attachments/assets/8ac8b22b-0973-4b2a-87f6-0fbe0677a1f4