### PR TITLE
fix: main card adjusting

### DIFF
--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -1,60 +1,57 @@
-
-import { FaHeart } from "react-icons/fa";
-import { useState} from "react";
-import {Link} from "react-router-dom";
+import { FaHeart } from 'react-icons/fa';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 interface TeamCardProps {
-    teamId : number;
-    teamName : string;
-    projectName : string;
-    isLiked : boolean;
+  teamId: number;
+  teamName: string;
+  projectName: string;
+  isLiked: boolean;
 }
 
+const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => {
+  const [imageError, setImageError] = useState(false);
 
-const TeamCard = ({teamId, teamName, projectName, isLiked} : TeamCardProps) => {
-    const [imageError, setImageError] = useState(false);
+  const thumbnailUrl = `${import.meta.env.VITE_API_BASE_URL}/api/teams/${teamId}/image/thumbnail`;
 
-    const thumbnailUrl = `${import.meta.env.VITE_API_BASE_URL}/api/teams/${teamId}/image/thumbnail`;
-
-
-    return (
-      <Link
-        to={`/teams/view/${teamId}`}
-        className="border-lightGray flex aspect-[5/6] w-full cursor-pointer flex-col overflow-hidden rounded-xl border transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg"
-        style={{
-            boxShadow: "6px 6px 12px rgba(0,0,0,0.1)"
-        }}
-      >
-        {!imageError ? (
-          <div className="aspect-[3/2] overflow-hidden">
-            <img
-              src={thumbnailUrl}
-              alt="썸네일"
-              className="h-full w-full object-cover object-center"
-              onError={() => setImageError(true)}
-            />
-          </div>
-        ) : (
-          <div className="bg-lightGray flex aspect-[3/2] w-full items-center justify-center">
-            <div className="flex h-full items-center justify-center text-sm text-midGray">썸네일</div>
-          </div>
-        )}
-
-        <div className="relative p-4">
-          <div className="text-[clamp(1rem,1.5vw,1.5rem)] font-semibold text-black">{projectName}</div>
-
-          <div className="text-[clamp(1rem,1.4vw,1.4rem)] text-midGray text-base">{teamName}</div>
-
-          <div className="flex justify-end">
-            {isLiked ? (
-              <FaHeart color="red" size="clamp(1.5rem, 2vw, 2rem)" />
-            ) : (
-              <FaHeart color="lightGray" size="clamp(1.5rem, 2vw, 2rem)" />
-            )}
-          </div>
+  return (
+    <Link
+      to={`/teams/view/${teamId}`}
+      className="border-lightGray flex aspect-[5/6] w-full cursor-pointer flex-col overflow-hidden rounded-xl border transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg"
+      style={{
+        boxShadow: '6px 6px 12px rgba(0,0,0,0.1)',
+      }}
+    >
+      {!imageError ? (
+        <div className="aspect-[3/2] object-cover">
+          <img
+            src={thumbnailUrl}
+            alt="썸네일"
+            className="h-full w-full object-cover object-center"
+            onError={() => setImageError(true)}
+          />
         </div>
-      </Link>
-    );
+      ) : (
+        <div className="bg-lightGray flex aspect-[3/2] w-full items-center justify-center">
+          <div className="text-midGray flex h-full w-full items-center justify-center text-sm">썸네일</div>
+        </div>
+      )}
+
+      <div className="relative p-4">
+        <div className="text-[clamp(1rem,1.5vw,1.5rem)] font-semibold text-black">{projectName}</div>
+
+        <div className="text-midGray text-base text-[clamp(1rem,1.4vw,1.4rem)]">{teamName}</div>
+
+        <div className="flex justify-end">
+          {isLiked ? (
+            <FaHeart color="red" size="clamp(1.5rem, 2vw, 2rem)" />
+          ) : (
+            <FaHeart color="lightGray" size="clamp(1.5rem, 2vw, 2rem)" />
+          )}
+        </div>
+      </div>
+    </Link>
+  );
 };
 
 export default TeamCard;

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -37,11 +37,9 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => 
         </div>
       )}
 
-      <div className="relative p-4">
+      <div className="p-3">
         <div className="text-[clamp(1rem,1.5vw,1.5rem)] font-semibold text-black">{projectName}</div>
-
         <div className="text-midGray text-base text-[clamp(1rem,1.4vw,1.4rem)]">{teamName}</div>
-
         <div className="flex justify-end">
           {isLiked ? (
             <FaHeart color="red" size="clamp(1.5rem, 2vw, 2rem)" />

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -17,9 +17,9 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => 
   return (
     <Link
       to={`/teams/view/${teamId}`}
-      className="border-lightGray flex aspect-[5/6] w-full cursor-pointer flex-col overflow-hidden rounded-xl border transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg"
+      className="border-lightGray flex aspect-[5/6] w-full cursor-pointer flex-col overflow-hidden rounded-xl border-[0.2px] transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg"
       style={{
-        boxShadow: '6px 6px 12px rgba(0,0,0,0.1)',
+        boxShadow: '4px 4px 10px rgba(0,0,0,0.1)',
       }}
     >
       {!imageError ? (

--- a/src/pages/main/TotalCards.tsx
+++ b/src/pages/main/TotalCards.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getAllTeams } from '../../apis/teams';
 import { TeamListItemResponseDto } from '../../types/DTO/teams/teamListDto';
 import useAuth from 'hooks/useAuth';
-import TeamCardSkeleton from "@pages/main/TeamCardSkeleton";
+import TeamCardSkeleton from '@pages/main/TeamCardSkeleton';
 
 const TotalCards = () => {
   const { user } = useAuth();
@@ -26,9 +26,8 @@ const TotalCards = () => {
         </h3>
       </div>
 
-      <section className="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-8">
-        {isLoading &&
-            Array.from({ length: 4 }).map((_, i) => <TeamCardSkeleton key={i} />)}
+      <section className="grid grid-cols-2 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {isLoading && Array.from({ length: 4 }).map((_, i) => <TeamCardSkeleton key={i} />)}
 
         {isError && <p>데이터를 불러오지 못했습니다.</p>}
         {teams?.map((team) => (


### PR DESCRIPTION
### 작업 개요
- 메인 페이지 카드 그리드의 최대 열 개수를 설정하였습니다. (4개)
- 썸네일 간 단차가 안 맞던 문제를 해결하였습니다.
  - div css 스타일 수정하였습니다: `overflow-hidden` -> `object-cover`
- 그림자 약화 및 border thickness 0.3px로 설정하였습니다.