### PR TITLE
Design: 로그인/회원가입 1차 QA 개선사항 반영

### DIFF
--- a/src/components/RoundedButton.tsx
+++ b/src/components/RoundedButton.tsx
@@ -6,7 +6,7 @@ const RoundedButton = ({ className = '', children, ...props }: Props) => {
   return (
     <button
       {...props}
-      className={`border-lightGray hover:bg-mainGreen w-32 rounded-full border p-3 hover:text-white ${className}`}
+      className={`border-lightGray hover:bg-mainGreen min-w-32 rounded-full border p-3 hover:text-white ${className}`}
     >
       {children}
     </button>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  className?: string;
+}
+
+const Spinner = ({ className = 'w-10 h-10' }: Props) => {
+  return (
+    <div className={`border-t-mainGreen m-auto animate-spin rounded-full border-4 border-gray-200 ${className}`} />
+  );
+};
+
+export default Spinner;

--- a/src/pages/find/FindEmailForm.tsx
+++ b/src/pages/find/FindEmailForm.tsx
@@ -29,7 +29,7 @@ const FindEmailForm = ({ studentNumber, setStudentNumber, onSubmit, isLoading }:
         />
       </div>
       <RoundedButton onClick={onSubmit} className="mx-auto flex justify-center" disabled={isLoading}>
-        {!isLoading ? <Spinner className="inline-block h-5 w-5" /> : '아이디 찾기'}
+        {isLoading ? <Spinner className="inline-block h-5 w-5" /> : '아이디 찾기'}
       </RoundedButton>
     </div>
   );

--- a/src/pages/find/FindEmailForm.tsx
+++ b/src/pages/find/FindEmailForm.tsx
@@ -28,8 +28,8 @@ const FindEmailForm = ({ studentNumber, setStudentNumber, onSubmit, isLoading }:
           }}
         />
       </div>
-      <RoundedButton onClick={onSubmit} className="mx-auto flex justify-center" disabled={isLoading}>
-        {isLoading ? <Spinner className="inline-block h-5 w-5" /> : '아이디 찾기'}
+      <RoundedButton onClick={onSubmit} className="mx-auto" disabled={isLoading}>
+        {isLoading ? <Spinner className="inline-block h-5 w-5 align-middle" /> : '아이디 찾기'}
       </RoundedButton>
     </div>
   );

--- a/src/pages/find/FindEmailForm.tsx
+++ b/src/pages/find/FindEmailForm.tsx
@@ -1,5 +1,6 @@
 import Input from '@components/Input';
 import RoundedButton from '@components/RoundedButton';
+import Spinner from '@components/Spinner';
 import { useCallback } from 'react';
 
 interface Props {
@@ -11,7 +12,6 @@ interface Props {
 
 const FindEmailForm = ({ studentNumber, setStudentNumber, onSubmit, isLoading }: Props) => {
   const isNumber = useCallback((value: string) => /^\d*$/.test(value), []);
-  // TODO : isLoading 사용하여 RoundedButton에 로딩 스피너 적용시키기
 
   return (
     <div className="flex flex-col gap-8">
@@ -28,8 +28,8 @@ const FindEmailForm = ({ studentNumber, setStudentNumber, onSubmit, isLoading }:
           }}
         />
       </div>
-      <RoundedButton onClick={onSubmit} className="mx-auto">
-        아이디 찾기
+      <RoundedButton onClick={onSubmit} className="mx-auto flex justify-center" disabled={isLoading}>
+        {!isLoading ? <Spinner className="inline-block h-5 w-5" /> : '아이디 찾기'}
       </RoundedButton>
     </div>
   );

--- a/src/pages/find/IdTab.tsx
+++ b/src/pages/find/IdTab.tsx
@@ -10,7 +10,7 @@ const IdTab = () => {
   const [studentNumber, setStudentNumber] = useState('');
   const toast = useToast();
 
-  const { data, refetch, isFetching, isError } = useQuery<FindEmailResponsetDto>({
+  const { data, refetch, isLoading, isError } = useQuery<FindEmailResponsetDto>({
     queryKey: ['findEmail', studentNumber],
     queryFn: () => getFindEmail({ studentId: studentNumber }),
     enabled: false,
@@ -31,7 +31,7 @@ const IdTab = () => {
       studentNumber={studentNumber}
       setStudentNumber={setStudentNumber}
       onSubmit={handleSubmit}
-      isLoading={isFetching}
+      isLoading={isLoading}
     />
   );
 };

--- a/src/pages/signin/SignInForm.tsx
+++ b/src/pages/signin/SignInForm.tsx
@@ -21,8 +21,8 @@ const SignInForm = () => {
       signIn(data.token);
       navigate('/');
     },
-    onError: (error) => {
-      toast(`로그인 실패: ${error.message}`, 'error');
+    onError: (error: any) => {
+      toast(error.response.data.message || '로그인에 실패했어요.', 'error');
     },
   });
 

--- a/src/pages/signup/EmailRow.tsx
+++ b/src/pages/signup/EmailRow.tsx
@@ -72,7 +72,7 @@ const EmailRow = ({ email, setEmail, isEmailVerified, setIsMailSent, startCooldo
         type="button"
         onClick={handleSendCode}
         disabled={mutation.isPending || isEmailVerified}
-        className="border-lightGray hover:bg-lightGray rounded-lg border p-3 px-4"
+        className="border-lightGray hover:bg-lightGray min-w-32 rounded-lg border p-3 px-4"
       >
         {isFirstSend ? '인증코드 전송' : '재전송'}
       </button>

--- a/src/pages/signup/EmailRow.tsx
+++ b/src/pages/signup/EmailRow.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { EmailVerificationRequestDTO } from 'types/DTO';
 import { isPNUEmail } from 'utils/email';
 import { useToast } from 'hooks/useToast';
+import Spinner from '@components/Spinner';
 
 interface Props {
   email: string;
@@ -75,7 +76,13 @@ const EmailRow = ({ email, setEmail, isEmailVerified, setIsMailSent, startCooldo
         disabled={mutation.isPending || isEmailVerified}
         className="border-lightGray hover:bg-lightGray min-w-32 rounded-lg border p-3 px-4"
       >
-        {isFirstSend ? '인증코드 전송' : '재전송'}
+        {mutation.isPending ? (
+          <Spinner className="inline-block h-5 w-5 align-middle" />
+        ) : isFirstSend ? (
+          '인증코드 전송'
+        ) : (
+          '재전송'
+        )}
       </button>
     </>
   );

--- a/src/pages/signup/EmailRow.tsx
+++ b/src/pages/signup/EmailRow.tsx
@@ -60,6 +60,7 @@ const EmailRow = ({ email, setEmail, isEmailVerified, setIsMailSent, startCooldo
       </label>
       <div>
         <Input
+          name="email"
           disabled={isEmailVerified}
           className="disabled:bg-whiteGray disabled:text-midGray"
           placeholder="example@pusan.ac.kr"

--- a/src/pages/signup/EmailVerifyRow.tsx
+++ b/src/pages/signup/EmailVerifyRow.tsx
@@ -51,6 +51,7 @@ const EmailVerifyRow = ({
       <label />
       <div className="relative">
         <Input
+          name="emailverify"
           disabled={isEmailVerified}
           className="disabled:bg-whiteGray disabled:text-midGray"
           placeholder="인증코드 입력"

--- a/src/pages/signup/PasswordRow.tsx
+++ b/src/pages/signup/PasswordRow.tsx
@@ -7,6 +7,7 @@ interface Props {
 }
 
 const PasswordRow = ({ value, setValue, error }: Props) => {
+  const PASSWORD_PLACEHOLDER = '영어, 숫자, 특수문자 포함 8~16자';
   return (
     <>
       <label className="flex items-center gap-1">
@@ -14,7 +15,7 @@ const PasswordRow = ({ value, setValue, error }: Props) => {
         <span className="text-midGray">비밀번호</span>
       </label>
       <div>
-        <PasswordInput value={value} onChange={(e) => setValue(e.target.value)} />
+        <PasswordInput value={value} onChange={(e) => setValue(e.target.value)} placeholder={PASSWORD_PLACEHOLDER} />
         <p className="text-mainRed mt-1">{error}</p>
       </div>
       <div />

--- a/src/pages/signup/SignUpForm.tsx
+++ b/src/pages/signup/SignUpForm.tsx
@@ -88,10 +88,10 @@ const SignUpForm = () => {
       </div>
 
       <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4 md:col-span-3">
-        <RoundedButton type="button" onClick={() => navigate(-1)} className="w-full sm:w-auto">
+        <RoundedButton type="button" onClick={() => navigate(-1)} className="w-full px-10 sm:w-auto">
           취소
         </RoundedButton>
-        <RoundedButton className="bg-lightGray w-full sm:w-auto" type="submit">
+        <RoundedButton className="bg-lightGray w-full px-10 sm:w-auto" type="submit">
           가입
         </RoundedButton>
       </div>

--- a/src/pages/signup/StudentNumberRow.tsx
+++ b/src/pages/signup/StudentNumberRow.tsx
@@ -15,6 +15,7 @@ const StudentNumberRow = ({ value, setValue, error }: Props) => {
       </label>
       <div>
         <Input
+          inputMode="numeric"
           value={value}
           onChange={(e) => {
             const input = e.target.value;


### PR DESCRIPTION
### 개요
로그인/회원가입 1차 QA 개선사항 반영

### 목적
1차 QA 후 로그인/회원가입 화면에서 필요한 개선사항을 반영한다.

### 변경 사항
- 공통 컴포넌트
  - 공통 Spinner 컴포넌트 정의
- 로그인 오류 문구 개선: 404... -> 서버 에러 메세지로 변경
- 회원가입 시 비밀번호 규칙을 사전에 확인할 수 있도록 Input의 placeholder에 추가
- 모바일 환경에서 학번 입력 시 숫자 키패드가 뜰 수 있도록 inputMode decimal 설정
- (피드백: 아이디 찾기 토스트 메시지가 너무 느림)
  - 네트워크 응답 속도가 느린 경우 + 실패 시 tanstack query의 retry로 인해 toast가 느리다고 느껴질 수 있음 -> 로딩 스피너 추가하여 해결
- 이메일 인증 버튼 클릭 시 Spinner 처리
- 이메일 인증 버튼 클릭 시 버튼 내부 텍스트 변경에 따른 버튼 크기 변경 -> min width 적용하여 크기 변경이 없도록 수정

### 논의 사항
- 피드백 : 이메일 도메인이 @pusan.ac.kr 고정이라면 텍스트 필드에서 제외
  - UI디자인이 나와있지 않고, Input 우측에 @pusan.ac.kr 텍스트를 배치하면 안이쁠 것 같음
  - Input 내에서 @pusan.ac.kr을 붙이는 로직을 추가할 수는 있다. (꼭 필요한지는 의문)