### PR TITLE
design: Header mobile 화면 높이 수정

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
   };
 
   return (
-    <header className="h-header min-h-header border-lightGray z-20 flex w-full min-w-[350px] items-center justify-between border-b bg-white px-4">
+    <header className="border-lightGray lg:h-header md:h-header xs:h-8 z-20 flex w-full min-w-[350px] items-center justify-between border-b bg-white px-4 py-2 sm:h-16">
       <div className="mx-auto flex w-full items-center justify-between px-4 sm:px-8 lg:px-16">
         <Link to="/">
           <img className="h-10 w-auto max-sm:hidden" src="/Logo.svg" alt="부산대학교 SW성과관리시스템 로고" />


### PR DESCRIPTION
### 개요
Header mobile 화면 높이 수정
### 목적
Header mobile 화면 높이 수정
### 변경사항
헤더 css 수정
lg:h-header md:h-header xs:h-8 sm:h-16
### 화면 이미지
<img width="817" alt="스크린샷 2025-06-26 오후 9 41 39" src="https://github.com/user-attachments/assets/342e7f57-310d-42ce-84fe-d3f9e33c5f4d" />

<img width="575" alt="스크린샷 2025-06-26 오후 9 42 00" src="https://github.com/user-attachments/assets/7b80252c-0e4e-40f8-a9de-2f3762c5ec97" />
