### PR TITLE
design: 메인페이지 반응형 수정

### DIFF
--- a/src/pages/main/LeaderMessage.tsx
+++ b/src/pages/main/LeaderMessage.tsx
@@ -6,9 +6,9 @@ interface LeaderProps {
 
 const LeaderMessage = ({ leaderName }: LeaderProps) => {
   return (
-    <div className="text-mainRed flex items-center gap-1 break-keep">
+    <div className="text-mainRed flex items-center flex items-center gap-2 flex-1 overflow-hidden">
       <BiError className="w-10 h-10 flex-shrink-0" />
-      <span className="px-4 text-sm">
+      <span className="truncate text-sm">
         <strong className="text-xl">{leaderName}</strong> 팀장님, 에디터에서 프로젝트 정보를 작성해 주세요!
       </span>
     </div>

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -21,15 +21,18 @@ const LeaderSection = () => {
   if (!showLeaderMessage) return null;
 
   return (
-    <div className="flex w-fit items-center gap-4 rounded-lg bg-white p-4
-    shadow-[0_4px_12px_rgba(0,0,0,0.2)] text-sm">
+    <div className="flex items-center justify-between gap-4 w-full lg:w-fit
+                 overflow-hidden
+                 rounded-lg bg-white p-4
+                 shadow-[0_4px_12px_rgba(0,0,0,0.2)]
+                 text-sm">
       <LeaderMessage leaderName={user?.name ?? '팀장'} />
 
       <Link to={`/teams/edit/${submissionData?.teamId}`}>
         <button className="flex items-center justify-center
                           border border-lightGray hover:bg-mainGreen hover:text-white
                           rounded-full p-2
-                          md:w-auto md:h-auto md:aspect-auto md:px-4 md:py-3 md:gap-2">
+                          md:px-4 md:py-3 md:gap-2">
           <TbPencil size={30} />
           <span className="hidden md:inline whitespace-nowrap">
             작성하러 가기</span>

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -5,7 +5,6 @@ import { useQuery } from '@tanstack/react-query';
 import { SubmissionStatusResponseDto } from '../../types/DTO/teams/submissionStatusDto';
 import { Link } from 'react-router-dom';
 import { TbPencil } from 'react-icons/tb';
-import RoundedButton from '@components/RoundedButton';
 
 const LeaderSection = () => {
   const { isLeader, user } = useAuth();
@@ -27,11 +26,14 @@ const LeaderSection = () => {
       <LeaderMessage leaderName={user?.name ?? '팀장'} />
 
       <Link to={`/teams/edit/${submissionData?.teamId}`}>
-        <RoundedButton className="flex w-fit items-center gap-1">
+        <button className="flex items-center justify-center
+                          border border-lightGray hover:bg-mainGreen hover:text-white
+                          rounded-full p-2
+                          md:w-auto md:h-auto md:aspect-auto md:px-4 md:py-3 md:gap-2">
           <TbPencil size={30} />
-          <span className="hidden md:inline break-keep">
+          <span className="hidden md:inline whitespace-nowrap">
             작성하러 가기</span>
-        </RoundedButton>
+        </button>
 
       </Link>
     </div>

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,8 +1,18 @@
 import Notice from '@pages/main/Notice';
 import TotalCards from '@pages/main/TotalCards';
 import LeaderSection from '@pages/main/LeaderSection';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const MainPage = () => {
+
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [location.pathname]);
+
+
   return (
     <div className="flex flex-col gap-6 sm:gap-10">
       <Notice />

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -22,36 +22,37 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => 
         boxShadow: '4px 4px 10px rgba(0,0,0,0.1)',
       }}
     >
-      {!imageError ? (
-        <div className="aspect-[3/2] object-cover">
+      <div className="aspect-[3/2] object-cover relative">
+        {!imageError ? (
           <img
             src={thumbnailUrl}
             alt="썸네일"
             className="h-full w-full object-cover object-center"
             onError={() => setImageError(true)}
           />
-        </div>
-      ) : (
-        <div className="bg-lightGray flex aspect-[3/2] w-full items-center justify-center">
-          <div className="text-midGray flex h-full w-full items-center justify-center text-sm">썸네일</div>
-        </div>
-      )}
-
-      <div className="p-3">
-        <div className="font-semibold text-black text-[clamp(0.85rem,2.5vw,1.2rem)] break-keep overflow-hidden text-ellipsis">
-          {projectName}
-        </div>
-        <div className="text-midGray text-[clamp(0.8rem,2vw,1rem)] truncate overflow-hidden">
-          {teamName}
-        </div>
-        <div className="flex justify-end">
-          {isLiked ? (
-            <FaHeart color="red" size="clamp(1.5rem, 2vw, 2rem)" />
           ) : (
-            <FaHeart color="lightGray" size="clamp(1.5rem, 2vw, 2rem)" />
+          <div className="bg-lightGray flex aspect-[3/2] w-full items-center justify-center">
+          <div className="text-midGray flex h-full w-full items-center justify-center text-sm">썸네일</div>
+          </div>
+          )}
+
+        <div className="absolute top-3 right-3 z-10">
+          {isLiked && (
+            <FaHeart color="red" size="clamp(1.5rem, 2vw, 1.8rem)" />
           )}
         </div>
       </div>
+
+        <div className="p-3">
+          <div
+            className="font-semibold text-black text-[clamp(0.85rem,2.5vw,1.2rem)] break-keep overflow-hidden text-ellipsis">
+            {projectName}
+          </div>
+          <div className="text-midGray text-[clamp(0.8rem,2vw,1rem)] truncate overflow-hidden">
+            {teamName}
+          </div>
+
+        </div>
     </Link>
   );
 };

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -38,8 +38,12 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => 
       )}
 
       <div className="p-3">
-        <div className="text-[clamp(1rem,1.5vw,1.5rem)] font-semibold text-black">{projectName}</div>
-        <div className="text-midGray text-base text-[clamp(1rem,1.4vw,1.4rem)]">{teamName}</div>
+        <div className="font-semibold text-black text-[clamp(0.85rem,2.5vw,1.2rem)] break-keep overflow-hidden text-ellipsis">
+          {projectName}
+        </div>
+        <div className="text-midGray text-[clamp(0.8rem,2vw,1rem)] truncate overflow-hidden">
+          {teamName}
+        </div>
         <div className="flex justify-end">
           {isLiked ? (
             <FaHeart color="red" size="clamp(1.5rem, 2vw, 2rem)" />

--- a/src/pages/main/TeamCardSkeleton.tsx
+++ b/src/pages/main/TeamCardSkeleton.tsx
@@ -1,27 +1,27 @@
 const TeamCardSkeleton = () => {
     return (
-        <section className="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-8">
-            <div
-                className="border-lightGray flex aspect-[5/6] w-full flex-col overflow-hidden rounded-xl border animate-pulse"
-                style={{
-                    boxShadow: "6px 6px 12px rgba(0,0,0,0.1)",
-                }}
-            >
-                <div className="aspect-[3/2] w-full bg-lightGray"/>
-
-                <div className="relative flex flex-1 flex-col justify-between p-4">
-                    <div className="flex flex-col gap-2">
-                        <div className="rounded bg-lightGray h-[clamp(1rem,1.5vw,1.5rem)] w-[clamp(40%,50%,75%)]"/>
-                        <div className="rounded bg-lightGray h-[clamp(0.8rem,1.2vw,1.25rem)] w-[clamp(clamp(30%,40%,50%))]"/>
-                    </div>
-
-                    <div className="flex justify-end">
-                        <div className="rounded-full bg-lightGray w-[clamp(1.25rem,2vw,1.5rem)] h-[clamp(1.25rem,2vw,1.5rem)]"/>
-                    </div>
-                </div>
+      <section className="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-8">
+        <div
+          className="border-lightGray flex aspect-[5/6] w-full animate-pulse flex-col overflow-hidden rounded-xl border"
+          style={{
+            boxShadow: '6px 6px 12px rgba(0,0,0,0.1)',
+          }}
+        >
+          <div className="bg-lightGray relative aspect-[3/2] w-full">
+            <div className="absolute top-2 right-2 z-10">
+              <div className="h-[clamp(1.5rem,2vw,2rem)] w-[clamp(1.5rem,2vw,2rem)] rounded-full bg-midGray" />
             </div>
-        </section>
+          </div>
+
+          <div className="relative flex flex-1 flex-col justify-between p-4">
+            <div className="flex flex-col gap-2">
+              <div className="bg-lightGray h-[clamp(0.85rem,2.5vw,1.2rem)] w-[clamp(40%,60%,90%)] rounded" />
+              <div className="bg-lightGray h-[clamp(0.8rem,2vw,1rem)] w-[clamp(30%,40%,70%)] rounded" />
+            </div>
+          </div>
+        </div>
+      </section>
     );
 };
 
-            export default TeamCardSkeleton;
+export default TeamCardSkeleton;


### PR DESCRIPTION
### 개요
6/26 회의 후 개선사항 적용 

### 목적
반응형으로 수정 

### 변경사항
- 팀장 메시지 에디터 버튼 반응형 구현 (RoundedButton -> button 으로 변경)
- 팀장 메시지 ellipsis 처리 
-  메인페이지 접근 시 scrollToTop 적용 (라우터 true -> useLocation 추가)
-  카드 내부 텍스트 반응형 구현 (최소 사이즈까지 축소->ellipsis)
- 좋아요 버튼 오른쪽 상단 배치 (isLiked==False인 경우 출력x)
- 팀카드 스켈레톤 반응형 수정   

### 이미지
<img width="1087" alt="12" src="https://github.com/user-attachments/assets/b5d24b8b-3f7f-47f8-be8f-1fde3b4bfff1" />
<img width="281" alt="13" src="https://github.com/user-attachments/assets/cb45d059-0082-4409-8a0c-765cfe08c2b6" />
