### PR TITLE
Feature: Youtube iframe into carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@react-hookz/web": "^25.1.1",
         "@tailwindcss/postcss": "^4.1.7",
         "@tailwindcss/vite": "^4.1.7",
         "@tanstack/react-query": "^5.77.2",
@@ -25,7 +26,6 @@
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.0",
-        "react-swipeable": "^7.0.2",
         "recharts": "^2.15.3",
         "vite-tsconfig-paths": "^5.1.4",
         "zustand": "^5.0.5"
@@ -1041,6 +1041,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@react-hookz/web": {
+      "version": "25.1.1",
+      "resolved": "https://registry.npmjs.org/@react-hookz/web/-/web-25.1.1.tgz",
+      "integrity": "sha512-o1BA+5Z8PCuAnxF7+2TZI+xGBtzyLw8z/flD8AMeJXILYTM8HkI0g41oM7IW/qjUDKx30HKceQQpCKqFGj+iIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ver0/deep-equal": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "js-cookie": "^3.0.5",
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "js-cookie": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2394,6 +2416,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@ver0/deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ver0/deep-equal/-/deep-equal-1.0.0.tgz",
+      "integrity": "sha512-XKIlF1i6UJiyTL52mDrSDDgRX7Qr5yJ7ts9zn2liZEmhiAEum4XKrJRAWmHdFwCQeGBU+rb+/b0ldw/9V8lOWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.10.0",
@@ -6074,15 +6105,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-swipeable": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
-      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@react-hookz/web": "^25.1.1",
     "@tailwindcss/postcss": "^4.1.7",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.77.2",
@@ -27,7 +28,6 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.0",
-    "react-swipeable": "^7.0.2",
     "recharts": "^2.15.3",
     "vite-tsconfig-paths": "^5.1.4",
     "zustand": "^5.0.5"

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useSwipeable } from 'react-swipeable';
+import { useMediaQuery } from '@react-hookz/web';
 import { getThumbnail } from 'apis/projectEditor';
 import { getPreviewImages } from 'apis/projectViewer';
 import { PreviewImagesResponseDto } from 'types/DTO/projectViewerDto';
@@ -13,40 +13,140 @@ interface CarouselSectionProps {
   youtubeUrl: string;
 }
 
+const getEmbedUrl = (url: string) => {
+  try {
+    let fixedUrl = url.replace('m.youtube.com', 'www.youtube.com');
+    const urlObj = new URL(fixedUrl);
+
+    let videoId = urlObj.searchParams.get('v');
+
+    if (!videoId) {
+      if (urlObj.hostname === 'youtu.be') {
+        videoId = urlObj.pathname.slice(1);
+      } else if (urlObj.pathname.startsWith('/embed/')) {
+        videoId = urlObj.pathname.split('/embed/')[1];
+      }
+    }
+
+    return videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+  } catch {
+    return null;
+  }
+};
+
+const ArrowButton = ({
+  direction,
+  onClick,
+  size = 50,
+}: {
+  direction: 'left' | 'right';
+  onClick: () => void;
+  size?: number;
+}) => {
+  const Icon = direction === 'left' ? FaChevronLeft : FaChevronRight;
+  return (
+    <button onClick={onClick} className="focus:outline-none">
+      <Icon
+        size={size}
+        className="text-lightGray hover:text-mainGreen rounded-full p-2 transition-colors duration-200 ease-in-out hover:cursor-pointer hover:bg-[#D1F3E1]/25"
+      />
+    </button>
+  );
+};
+
+const IndicatorDots = ({
+  count,
+  currentIndex,
+  onClick,
+}: {
+  count: number;
+  currentIndex: number;
+  onClick: (i: number) => void;
+}) => (
+  <>
+    {Array.from({ length: count }).map((_, index) => (
+      <button
+        key={index}
+        onClick={() => onClick(index)}
+        className={`h-2 w-2 rounded-full transition-all duration-200 hover:cursor-pointer hover:bg-[#D1F3E1] ${
+          currentIndex === index ? 'bg-mainGreen' : 'bg-lightGray'
+        }`}
+      />
+    ))}
+  </>
+);
+
+const MediaRenderer = ({
+  currentImage,
+  embedUrl,
+  imageLoaded,
+  setImageLoaded,
+  setLoadFailed,
+}: {
+  currentImage: string | null;
+  embedUrl: string | null;
+  imageLoaded: boolean;
+  setImageLoaded: (loaded: boolean) => void;
+  setLoadFailed: (failed: boolean) => void;
+}) => {
+  if (!currentImage || currentImage === 'ERROR') {
+    return (
+      <div className="text-midGray flex h-full w-full items-center justify-center">
+        <AiFillPicture size={40} />
+      </div>
+    );
+  }
+
+  if (currentImage === 'youtube' && embedUrl) {
+    return <iframe src={embedUrl} title="Youtube Iframe" allowFullScreen className="absolute inset-0 h-full w-full" />;
+  }
+
+  return (
+    <>
+      {!imageLoaded && (
+        <div className="absolute inset-0 flex h-full w-full items-center justify-center bg-white">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-[#D1F3E1] border-t-transparent" />
+        </div>
+      )}
+      <img
+        src={currentImage}
+        alt="Project image"
+        onLoad={() => setImageLoaded(true)}
+        onError={() => setLoadFailed(true)}
+        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-200 ${
+          imageLoaded ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+    </>
+  );
+};
+
 const CarouselSection = ({ teamId, previewIds, youtubeUrl }: CarouselSectionProps) => {
-  // TODO: 화살표 반응형 처리 구현
-  const {
-    data: thumbnailUrl,
-    isLoading: isThumbnailLoading,
-    error: thumbnailError,
-  } = useQuery<string>({
-    queryKey: ['thumbnail', teamId],
-    queryFn: () => getThumbnail(teamId),
-    // staleTime: 1000 * 60,
-  });
-
-  const {
-    data: previewData,
-    isLoading: isPreviewLoading,
-    error: previewError,
-  } = useQuery<PreviewImagesResponseDto>({
-    queryKey: ['previewImages', teamId, previewIds],
-    queryFn: () => getPreviewImages(teamId, previewIds),
-    enabled: previewIds.length > 0,
-    // staleTime: 1000 * 60,
-  });
-
-  const previewUrls = previewData?.imageUrls ?? [];
-  const imageUrls = [...(!!youtubeUrl ? ['youtube'] : []), ...(thumbnailUrl ? [thumbnailUrl] : []), ...previewUrls];
-
   const [currentIndex, setCurrentIndex] = useState(0);
   const [imageLoaded, setImageLoaded] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
+  const isMobile = useMediaQuery('(max-width:640px)');
 
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-  const [showGuide, setShowGuide] = useState(false);
+  const { data: thumbnailUrl } = useQuery<string>({
+    queryKey: ['thumbnail', teamId],
+    queryFn: () => getThumbnail(teamId),
+  });
 
-  const currentImage = imageUrls[currentIndex] || null;
+  const { data: previewData } = useQuery<PreviewImagesResponseDto>({
+    queryKey: ['previewImages', teamId, previewIds],
+    queryFn: () => getPreviewImages(teamId, previewIds),
+    enabled: previewIds.length > 0,
+  });
+
+  const previewUrls = previewData?.imageUrls ?? [];
+  const imageUrls: string[] = [
+    ...(youtubeUrl ? ['youtube'] : []),
+    ...(thumbnailUrl ? [thumbnailUrl] : []),
+    ...previewUrls,
+  ];
+
+  const embedUrl = useMemo(() => getEmbedUrl(youtubeUrl), [youtubeUrl]);
+  const currentImage = useMemo(() => imageUrls[currentIndex] || null, [imageUrls, currentIndex]);
 
   useEffect(() => {
     setImageLoaded(false);
@@ -61,112 +161,41 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl }: CarouselSectionProp
     };
   }, [thumbnailUrl]);
 
-  useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'auto' });
-  }, []);
-
-  const goToPrev = () => {
-    setCurrentIndex((prev) => (prev === 0 ? imageUrls.length - 1 : prev - 1));
-  };
-
-  const goToNext = () => {
-    setCurrentIndex((prev) => (prev === imageUrls.length - 1 ? 0 : prev + 1));
-  };
-
-  const goToSlide = (index: number) => {
-    setCurrentIndex(index);
-  };
-
-  const handlers = useSwipeable({
-    onSwipedLeft: () => goToNext(),
-    onSwipedRight: () => goToPrev(),
-  });
-
-  useEffect(() => {
-    const handleResize = () => setWindowWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  useEffect(() => {
-    if (windowWidth < 640) {
-      setShowGuide(true);
-      const timer = setTimeout(() => setShowGuide(false), 3000);
-      return () => clearTimeout(timer);
-    } else {
-      setShowGuide(false);
-    }
-  }, [windowWidth]);
+  const goToPrev = () => setCurrentIndex((prev) => (prev === 0 ? imageUrls.length - 1 : prev - 1));
+  const goToNext = () => setCurrentIndex((prev) => (prev === imageUrls.length - 1 ? 0 : prev + 1));
+  const goToSlide = (index: number) => setCurrentIndex(index);
 
   return (
-    <div {...handlers}>
-      {showGuide && (
-        <div className="text-lightGray animate-fadeInUp my-2 text-center text-xs duration-300 ease-out select-none">
-          모바일일 경우 스와이프 해보세요.
-        </div>
-      )}
+    <div className="flex flex-col items-center gap-4">
       <div className="flex items-center justify-center md:gap-10">
-        {imageUrls.length > 1 && (
-          <button onClick={goToPrev} className="focus:outline-none">
-            <FaChevronLeft
-              size={50}
-              className="text-lightGray hover:text-mainGreen hidden rounded-full p-2 transition-colors duration-200 ease-in-out hover:cursor-pointer hover:bg-[#D1F3E1]/25 sm:block"
-            />
-          </button>
-        )}
-        <div className="flex flex-col items-center gap-2">
-          <div className="border-lightGray relative aspect-[3/2] w-[50vw] max-w-[900px] min-w-[300px] overflow-hidden rounded border">
-            {!currentImage || loadFailed ? (
-              <div className="text-midGray flex h-full w-full items-center justify-center">
-                <AiFillPicture size={40} />
-              </div>
-            ) : (
-              <>
-                {!imageLoaded && (
-                  <div className="absolute inset-0 flex h-full w-full items-center justify-center bg-white">
-                    <div className="h-6 w-6 animate-spin rounded-full border-2 border-[#D1F3E1] border-t-transparent" />
-                  </div>
-                )}
-                <img
-                  src={currentImage}
-                  alt="Project image"
-                  onLoad={() => {
-                    setImageLoaded(true);
-                  }}
-                  onError={() => {
-                    setLoadFailed(true);
-                  }}
-                  className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-200 ${
-                    imageLoaded ? 'opacity-100' : 'opacity-0'
-                  }`}
-                />
-              </>
-            )}
-          </div>
-          {imageUrls.length > 1 && (
-            <div className="mt-4 flex w-full max-w-lg justify-center gap-5 px-3 sm:max-w-xl md:max-w-2xl">
-              {imageUrls.map((_, index) => (
-                <button
-                  key={index}
-                  onClick={() => goToSlide(index)}
-                  className={`h-2 w-2 rounded-full transition-all duration-200 hover:cursor-pointer hover:bg-[#D1F3E1] ${
-                    currentIndex === index ? 'bg-mainGreen' : 'bg-lightGray'
-                  }`}
-                />
-              ))}
-            </div>
-          )}
+        {imageUrls.length > 1 && !isMobile && <ArrowButton direction="left" onClick={goToPrev} />}
+
+        <div className="border-lightGray relative aspect-[3/2] w-[50vw] max-w-[900px] min-w-[300px] overflow-hidden rounded">
+          <MediaRenderer
+            currentImage={currentImage}
+            embedUrl={embedUrl}
+            imageLoaded={imageLoaded}
+            setImageLoaded={setImageLoaded}
+            setLoadFailed={setLoadFailed}
+          />
         </div>
 
-        {imageUrls.length > 1 && (
-          <button onClick={goToNext} className="focus:outline-none">
-            <FaChevronRight
-              size={50}
-              className="text-lightGray hover:text-mainGreen hidden rounded-full p-2 transition-colors duration-200 ease-in-out hover:cursor-pointer hover:bg-[#D1F3E1]/25 sm:block"
-            />
-          </button>
-        )}
+        {imageUrls.length > 1 && !isMobile && <ArrowButton direction="right" onClick={goToNext} />}
       </div>
+
+      {imageUrls.length > 1 && (
+        <div
+          className={`mt-4 flex items-center ${!isMobile ? 'justify-center' : 'justify-between'} w-[50vw] max-w-[900px] min-w-[300px] px-3`}
+        >
+          {isMobile && <ArrowButton direction="left" onClick={goToPrev} size={40} />}
+
+          <div className="flex gap-5">
+            <IndicatorDots count={imageUrls.length} currentIndex={currentIndex} onClick={goToSlide} />
+          </div>
+
+          {isMobile && <ArrowButton direction="right" onClick={goToNext} size={40} />}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -9,9 +9,10 @@ import { AiFillPicture } from 'react-icons/ai';
 interface CarouselSectionProps {
   teamId: number;
   previewIds: number[];
+  youtubeUrl: string;
 }
 
-const CarouselSection = ({ teamId, previewIds }: CarouselSectionProps) => {
+const CarouselSection = ({ teamId, previewIds, youtubeUrl }: CarouselSectionProps) => {
   // TODO: 화살표 반응형 처리 구현
   const {
     data: thumbnailUrl,
@@ -35,7 +36,7 @@ const CarouselSection = ({ teamId, previewIds }: CarouselSectionProps) => {
   });
 
   const previewUrls = previewData?.imageUrls ?? [];
-  const imageUrls = thumbnailUrl ? [thumbnailUrl, ...previewUrls] : previewUrls;
+  const imageUrls = [...(!!youtubeUrl ? ['youtube'] : []), ...(thumbnailUrl ? [thumbnailUrl] : []), ...previewUrls];
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -54,7 +55,7 @@ const CarouselSection = ({ teamId, previewIds }: CarouselSectionProps) => {
         URL.revokeObjectURL(thumbnailUrl);
       }
     };
-  }, []);
+  }, [thumbnailUrl]);
 
   const goToPrev = () => {
     setCurrentIndex((prev) => (prev === 0 ? imageUrls.length - 1 : prev - 1));
@@ -80,7 +81,15 @@ const CarouselSection = ({ teamId, previewIds }: CarouselSectionProps) => {
       )}
       <div className="flex flex-col items-center gap-2">
         <div className="border-lightGray relative aspect-[3/2] w-[50vw] max-w-[900px] min-w-[300px] overflow-hidden rounded border">
-          {!currentImage || loadFailed ? (
+          {currentImage === 'youtube' ? (
+            <iframe
+              src={youtubeUrl.replace('watch?v=', 'embed/')}
+              title="YouTube video"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="h-full w-full"
+            />
+          ) : !currentImage || loadFailed ? (
             <div className="text-midGray flex h-full w-full items-center justify-center">
               <AiFillPicture size={40} />
             </div>
@@ -103,6 +112,7 @@ const CarouselSection = ({ teamId, previewIds }: CarouselSectionProps) => {
             </>
           )}
         </div>
+
         {imageUrls.length > 1 && (
           <div className="mt-4 flex w-full max-w-lg justify-center gap-5 px-3 sm:max-w-xl md:max-w-2xl">
             {imageUrls.map((_, index) => (

--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -56,7 +56,7 @@ const Comment = ({
               <div className="group relative">
                 <button
                   onClick={onStartEdit}
-                  className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'} text-lightGray focus:text-mainGreen focus:outline-none`}
+                  className={`cursor-pointer ${isEditing ? 'text-mainGreen' : 'hover:text-mainGreen'} focus:text-mainGreen text-midGray focus:outline-none`}
                 >
                   <RiPencilFill size={18} />
                 </button>
@@ -64,11 +64,11 @@ const Comment = ({
                   댓글 수정
                 </div>
               </div>
-              <div className="bg-lightGray h-3 w-px" />
+              <div className="bg-lightGray h-4 w-px" />
               <div className="group relative">
                 <button
                   onClick={() => setShowConfirm(true)}
-                  className="text-lightGray hover:text-mainRed focus:text-mainRed cursor-pointer focus:outline-none"
+                  className="text-midGray hover:text-mainRed focus:text-mainRed cursor-pointer focus:outline-none"
                 >
                   <IoRemoveCircle size={18} />
                 </button>

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -20,7 +20,7 @@ const UrlButton = ({ url }: { url: string }) => (
     href={url}
     target="_blank"
     rel="noopener noreferrer"
-    className="border-mainGreen flex w-100 max-w-100 items-center gap-3 truncate rounded-full border px-3 py-1 focus:outline-none sm:w-auto"
+    className="border-mainGreen flex w-full max-w-100 min-w-50 items-center gap-3 truncate rounded-full border px-3 py-1 focus:outline-none sm:w-auto"
   >
     <IoMdLink className="text-mainGreen shrink-0" />
     <span className="text-exsm hover:text-mainGreen min-w-0 truncate text-gray-700">{url}</span>

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -36,7 +36,7 @@ const ProjectViewerPage = () => {
         githubUrl={data.githubPath}
       />
       <div className="h-10" />
-      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} />
+      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youtubePath} />
       <div className="h-10" />
       <LikeSection teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />


### PR DESCRIPTION
## 작업 개요
- YoutubeCard로 두던 iframe을 Carousel 이미지들과 병합
  - swipe이 아닌 인디케이터와 방향 버튼을 이용해 모바일 화면 지원
- 공통 컴포넌트
  - 좌우 이미지 이동하는 버튼을 컴포넌트로 분리
  - 인디케이터 분리
- `useMediaQuery` 활용하여 모바일/PC 별 조건부 렌더링

## 미리보기
https://github.com/user-attachments/assets/d210538c-18e3-4ccd-ab62-cae4f0ab7632