### PR TITLE
Fix: invalidate query 적용

### DIFF
--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -140,13 +140,12 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl }: CarouselSectionProp
   });
 
   const previewUrls = previewData?.imageUrls ?? [];
-  const imageUrls: string[] = [
-    ...(youtubeUrl ? ['youtube'] : []),
-    ...(thumbnailUrl ? [thumbnailUrl] : []),
-    ...previewUrls,
-  ];
-
   const embedUrl = useMemo(() => getEmbedUrl(youtubeUrl), [youtubeUrl]);
+  const imageUrls: string[] = useMemo(() => {
+    const result = [...(embedUrl ? ['youtube'] : []), ...(thumbnailUrl ? [thumbnailUrl] : []), ...previewUrls];
+    return result;
+  }, [embedUrl, thumbnailUrl, previewUrls]);
+
   const currentImage = useMemo(() => imageUrls[currentIndex] || null, [imageUrls, currentIndex]);
 
   useEffect(() => {

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import useAuth from 'hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -11,9 +10,8 @@ interface LikeSectionProps {
   isLiked: boolean;
 }
 
-const LikeSection = ({ teamId, isLiked: initIsLiked }: LikeSectionProps) => {
+const LikeSection = ({ teamId, isLiked }: LikeSectionProps) => {
   const { isSignedIn } = useAuth();
-  const [isLiked, setIsLiked] = useState(initIsLiked);
   const navigate = useNavigate();
   const toast = useToast();
 
@@ -22,10 +20,9 @@ const LikeSection = ({ teamId, isLiked: initIsLiked }: LikeSectionProps) => {
   const likeMutation = useMutation({
     mutationFn: (nextIsLiked: boolean) => patchLikeToggle({ teamId, isLiked: nextIsLiked }),
     onSuccess: () => {
-      const nextLiked = !isLiked;
-      setIsLiked((prev) => !prev);
+      queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
       queryClient.invalidateQueries({ queryKey: ['teams', user?.id ?? 'guest'] });
-      toast(nextLiked ? '좋아요를 눌렀어요.' : '좋아요를 취소했어요.');
+      toast(!isLiked ? '좋아요를 눌렀어요.' : '좋아요를 취소했어요.');
     },
   });
 

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useQuery, QueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTeamId } from 'hooks/useTeamId';
 import { useUserStore } from 'stores/useUserStore';
 import { getProjectDetails } from 'apis/projectViewer';
@@ -22,12 +22,14 @@ import {
 const ProjectViewerPage = () => {
   const teamId = useTeamId();
   const memberId = useUserStore((state) => state.user?.id);
+  const queryClient = useQueryClient();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['projectDetails', teamId],
     queryFn: async () => {
       if (teamId === null) throw new Error('teamId is null');
       return await getProjectDetails(teamId);
+      queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
     },
   });
 


### PR DESCRIPTION
## 작업 개요
- 좋아요 정보를 반영하는 `LikeSection.tsx`에 `invalidate query`를 적용하여 최신 정보 반영하도록 함
  - 기존 initLiked 제거없이 뷰어 페이지로부터 props 받음 (버그 수정)
- Youtube URL의 embed URL이 유효하지 않을 경우 캐러셀에 띄우지 않음