### PR TITLE
Design: viewer reactive UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
   --color-lightGray: #e2e2e2;
   --color-whiteGray: #f9f9f9;
   --color-mainRed: #ec523e;
+  --color-subGreen: #d1f3e1;
 
   --font-base: Inter, system-ui, sans-serif;
 

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -1,9 +1,13 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useMediaQuery } from '@react-hookz/web';
+
 import { getThumbnail } from 'apis/projectEditor';
 import { getPreviewImages } from 'apis/projectViewer';
 import { PreviewImagesResponseDto } from 'types/DTO/projectViewerDto';
+
+import Spinner from '@components/Spinner';
+
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import { FaSadTear } from 'react-icons/fa';
 
@@ -105,9 +109,9 @@ const MediaRenderer = ({
   return (
     <>
       {!imageLoaded && (
-        <div className="absolute inset-0 flex h-full w-full items-center justify-center bg-white">
-          <div className="h-6 w-6 animate-spin rounded-full border-2 border-[#D1F3E1] border-t-transparent" />
-        </div>
+      <div className="absolute inset-0 flex h-full w-full items-center justify-center bg-white">
+        <Spinner />
+      </div>
       )}
       <img
         src={currentImage}

--- a/src/pages/project-viewer/CommentSection/CommentListSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentListSection.tsx
@@ -25,7 +25,8 @@ const CommentListSection = ({ teamId, memberId }: CommentListSectionProps) => {
   const deleteMutation = useMutation({
     mutationFn: (request: CommentDeleteRequestDto) => deleteComment(request),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments', teamId] }), toast('댓글이 삭제되었어요.');
+      queryClient.invalidateQueries({ queryKey: ['comments', teamId] });
+      toast('댓글이 삭제되었어요.');
     },
   });
 

--- a/src/pages/project-viewer/CommentSection/CommentSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentSection.tsx
@@ -7,7 +7,7 @@ import CommentListSection from './CommentListSection';
 
 interface CommentSectionProps {
   teamId: number;
-  memberId: number;
+  memberId?: number;
 }
 
 const CommentSection = ({ teamId, memberId }: CommentSectionProps) => {
@@ -27,16 +27,15 @@ const CommentSection = ({ teamId, memberId }: CommentSectionProps) => {
   }
 
   return (
-    <div className="flex flex-col">
-      {isSignedIn && (
-        <>
+    <>
+      {memberId !== undefined && (
+        <div className="flex flex-col">
           <CommentFormSection teamId={teamId} />
           <div className="h-20" />
-        </>
+          <CommentListSection teamId={teamId} memberId={memberId} />
+        </div>
       )}
-
-      <CommentListSection teamId={teamId} memberId={memberId} />
-    </div>
+    </>
   );
 };
 

--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -1,34 +1,60 @@
+import { useState } from 'react';
 import { FaCrown } from 'react-icons/fa6';
-import { IoPerson } from 'react-icons/io5';
+import { IoEllipsisHorizontal, IoPerson } from 'react-icons/io5';
 
 interface DetailSectionProps {
-  overview: string;
+  overview?: string;
   leaderName: string;
   participants: string[];
 }
 
 const DetailSection = ({ overview, leaderName, participants }: DetailSectionProps) => {
+  const hasOverview = overview?.trim();
+  const safeOverview = overview ?? '';
+  const INIT_LENGTH = 500;
+
+  const [isFolded, setIsFolded] = useState(true);
+  const shouldTruncate = safeOverview.length > INIT_LENGTH;
+  const visibleText = isFolded && shouldTruncate ? safeOverview.slice(0, INIT_LENGTH) : safeOverview;
+
   return (
     <>
-      <div className="flex flex-col gap-3">
-        <div className="text-title font-bold">Overview</div>
-        <div className="text-sm leading-[1.8]">{overview}</div>
-      </div>
-      <div className="h-20" />
+      {hasOverview && (
+        <>
+          <div className="flex flex-col gap-3">
+            <div className="text-title font-bold">Overview</div>
+            <div className="bg-whiteGray rounded-md p-4 text-sm leading-[1.7]">
+              {visibleText}
+              {shouldTruncate && (
+                <button
+                  className="bg-subGreen text-mainGreen mx-3 cursor-pointer rounded-full px-3 py-1 text-xs hover:bg-emerald-100"
+                  onClick={() => setIsFolded(!isFolded)}
+                >
+                  {isFolded ? <IoEllipsisHorizontal /> : '간략히'}
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="h-20" />
+        </>
+      )}
+
       <div className="flex flex-col gap-3">
         <div className="text-title font-bold">Participants</div>
         <span className="flex items-center gap-3">
-          <FaCrown className="text-amber-300" />
-          <span className="text-sm">{leaderName}</span>
+          <FaCrown className="text-amber-300" size={20} />
+          <span className="bg-whiteGray rounded-full px-3 py-1 text-sm whitespace-nowrap">{leaderName}</span>
         </span>
-        <span className="flex items-center gap-3">
-          <IoPerson className="text-blue-400" />
-          {participants.map((name, index) => (
-            <span key={index} className="text-sm">
-              {name}
-            </span>
-          ))}
-        </span>
+        <div className="flex items-start gap-3 sm:items-center">
+          <IoPerson className="mt-2 shrink-0 text-blue-400 sm:mt-0" size={20} />
+          <div className="flex flex-wrap gap-2 sm:gap-3">
+            {participants.map((name, index) => (
+              <span key={index} className="bg-whiteGray rounded-full px-3 py-1 text-sm whitespace-nowrap">
+                {name}
+              </span>
+            ))}
+          </div>
+        </div>
       </div>
     </>
   );

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -3,8 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import useAuth from 'hooks/useAuth';
 import { useUserStore } from 'stores/useUserStore';
 
+import { FaGithub, FaYoutube } from 'react-icons/fa';
 import { GoPencil } from 'react-icons/go';
-import { IoMdLink } from 'react-icons/io';
+import { RiLink } from 'react-icons/ri';
+import { FiExternalLink } from 'react-icons/fi';
 
 interface IntroSectionProps {
   teamId: number;
@@ -15,17 +17,32 @@ interface IntroSectionProps {
   youtubeUrl: string;
 }
 
-const UrlButton = ({ url }: { url: string }) => (
-  <a
-    href={url}
-    target="_blank"
-    rel="noopener noreferrer"
-    className="border-mainGreen flex w-full max-w-100 min-w-50 items-center gap-3 truncate rounded-full border px-3 py-1 focus:outline-none sm:w-auto"
-  >
-    <IoMdLink className="text-mainGreen shrink-0" />
-    <span className="text-exsm hover:text-mainGreen min-w-0 truncate text-gray-700">{url}</span>
-  </a>
-);
+const UrlButton = ({ url }: { url: string }) => {
+  const getIconAndText = () => {
+    if (url.includes('github.com')) {
+      return { icon: <FaGithub className="text-mainGreen" />, text: 'GitHub' };
+    }
+    if (url.includes('youtube.com') || url.includes('youtu.be')) {
+      return { icon: <FaYoutube className="text-mainGreen" />, text: 'Youtube' };
+    }
+    return { icon: <RiLink className="text-mainGreen" />, text: url };
+  };
+
+  const { icon, text } = getIconAndText();
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="border-mainGreen flex w-40 max-w-40 min-w-40 items-center justify-around gap-3 truncate rounded-full border px-3 py-1 focus:outline-none sm:w-auto"
+    >
+      <span className="shrink-0">{icon}</span>
+      <span className="text-exsm hover:text-mainGreen w-20 truncate text-gray-700">{text}</span>
+      <FiExternalLink className="text-subGreen" />
+    </a>
+  );
+};
 
 const IntroSection = ({ teamId, leaderId, projectName, teamName, githubUrl, youtubeUrl }: IntroSectionProps) => {
   const { isLeader } = useAuth();
@@ -33,25 +50,29 @@ const IntroSection = ({ teamId, leaderId, projectName, teamName, githubUrl, yout
   const navigate = useNavigate();
 
   return (
-    <div className="flex w-full flex-wrap justify-between gap-4">
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-3">
-          <div className="min-w-0 text-[28px] font-bold break-words sm:text-[36px]">{projectName}</div>
-          {isLeader && memberId === leaderId && (
+    <div className="flex w-full flex-wrap gap-4">
+      <div className="flex justify-start gap-5">
+        <div className="flex min-w-0 flex-col gap-2">
+          <div className="min-w-0 text-[28px] font-bold sm:text-[36px]">{projectName}</div>
+          <div className="text-smbold font-bold text-[#4B5563]">{teamName}</div>
+        </div>
+        {isLeader && memberId === leaderId && (
+          <div className="flex pt-3">
             <button
               onClick={() => navigate(`/teams/edit/${teamId}`)}
-              className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex items-center gap-2 rounded-full border px-4 py-1 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60"
+              className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 items-center gap-2 rounded-full border px-4 py-1 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60"
             >
               <GoPencil />
-              수정하기
+              <span className="hidden sm:inline">수정하기</span>
             </button>
-          )}
-        </div>
-        <div className="text-smbold font-bold break-words text-[#4B5563]">{teamName}</div>
+          </div>
+        )}
       </div>
-      <div className="flex w-full max-w-full min-w-[150px] flex-col items-end gap-2 sm:w-auto">
+
+      <div className="flex flex-1 flex-col items-end gap-2 sm:w-auto">
         {githubUrl && <UrlButton url={githubUrl} />}
         {youtubeUrl && <UrlButton url={youtubeUrl} />}
+        {youtubeUrl && <UrlButton url="https://personal.url" />}
       </div>
     </div>
   );

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -28,9 +28,10 @@ const ProjectViewerPage = () => {
     queryKey: ['projectDetails', teamId],
     queryFn: async () => {
       if (teamId === null) throw new Error('teamId is null');
-      return await getProjectDetails(teamId);
-      queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
+      return getProjectDetails(teamId);
     },
+    staleTime: 0,
+    refetchOnMount: true,
   });
 
   if (isLoading) {
@@ -70,8 +71,8 @@ const ProjectViewerPage = () => {
       <LikeSection teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />
       <DetailSection overview={data.overview} leaderName={data.leaderName} participants={data.participants} />
-      <div className="h-30" />
-      {memberId != null && <CommentSection teamId={data.teamId} memberId={memberId} />}
+      <div className="h-28" />
+      <CommentSection teamId={data.teamId} memberId={memberId} />
     </div>
   );
 };

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -56,7 +56,7 @@ const ProjectViewerPage = () => {
   if (!data) return <div>데이터를 불러올 수 없습니다.</div>;
 
   return (
-    <div>
+    <div className="px-5">
       <IntroSection
         teamId={data.teamId}
         leaderId={data.leaderId}


### PR DESCRIPTION
### 연관 이슈
- #88 

### 작업 요약
- 뷰어 페이지 반응형으로 보완
  - `IntroSection`, `participants 목록` 
- 말줄임 버튼 구현 등

### 작업 상세설명
- `IntroSection`: 팀명, 프로젝트명을 감싸던 `div`를 재조정하여 전체 `[ProjectName|TeamName]`, `수정하기 버튼`, `URL들`의 구성을 갖춤
- `DetailSection`: 화면 너비에 따라 `participant.name`에 `flex-wrap` 적용 
- `UrlButton`: @Heo-Donghyuk 님의 지난 의견을 반영하여 url이 아닌 대체 텍스트를 넣게 되었습니다. 다만, 악의적인 링크 여부를 사용자가 미리 판단할 수 있도록, 텍스트 안에 일부 url 정보를 포함시켰습니다.

### 미리보기 영상
https://github.com/user-attachments/assets/2f14dc44-f3fa-448d-927a-c63056733133