### PR TITLE
Design: editor reactive UI

### DIFF
--- a/src/pages/project-editor/EditorSkeleton.tsx
+++ b/src/pages/project-editor/EditorSkeleton.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+const EditorSkeleton = () => {
+  return (
+    <div className="animate-pulse px-5">
+      <div className="h-6 w-40 rounded bg-gray-200" />
+      <div className="h-10" />
+
+      <div className="space-y-3">
+        <div className="h-4 w-32 rounded bg-gray-200" />
+        <div className="h-4 w-48 rounded bg-gray-200" />
+        <div className="h-4 w-56 rounded bg-gray-200" />
+      </div>
+
+      <div className="h-15" />
+
+      <div className="space-y-4">
+        <div className="h-4 w-24 rounded bg-gray-200" />
+        <div className="h-10 w-full rounded bg-gray-200" />
+        <div className="h-4 w-24 rounded bg-gray-200" />
+        <div className="h-10 w-full rounded bg-gray-200" />
+      </div>
+
+      <div className="h-15" />
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="aspect-[3/2] w-full rounded bg-gray-200" />
+        ))}
+      </div>
+
+      <div className="h-15" />
+
+      <div className="space-y-2">
+        <div className="h-4 w-24 rounded bg-gray-200" />
+        <div className="h-40 w-full rounded bg-gray-200" />
+        <div className="h-4 w-20 self-end rounded bg-gray-200" />
+      </div>
+
+      <div className="h-20" />
+
+      <div className="flex justify-end gap-5 sm:gap-10">
+        <div className="h-10 w-20 rounded-full bg-gray-200" />
+        <div className="h-10 w-20 rounded-full bg-gray-200" />
+      </div>
+    </div>
+  );
+};
+
+export default EditorSkeleton;

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useMemo } from 'react';
 import { useToast } from 'hooks/useToast';
+import { HiInformationCircle } from 'react-icons/hi';
 import { FiX } from 'react-icons/fi';
 import { AiFillPicture } from 'react-icons/ai';
-import { MdBrokenImage } from 'react-icons/md';
+import { MdOutlineFileUpload, MdBrokenImage } from 'react-icons/md';
 import { PreviewImage } from './ProjectEditorPage';
 
 interface ImageUploaderSectionProps {
@@ -109,33 +110,41 @@ const ImageUploaderSection = ({
 
   return (
     <div className="flex gap-10 text-sm">
-      <div className="text-midGray flex w-25 gap-1">
-        <span className="mr-1 text-red-500">*</span>
-        <span>썸네일</span>
+      <div className="flex flex-col items-start gap-3">
+        <div className="text-midGray flex w-25 gap-1">
+          <span className="mr-1 text-red-500">*</span>
+          <span>썸네일</span>
+        </div>
+        <div className="group relative inline-block">
+          <span className="inline-flex cursor-help items-center gap-1 rounded-full bg-sky-50 px-2 py-1 text-xs text-sky-400">
+            <HiInformationCircle /> 가이드
+          </span>
+          <div className="absolute top-full left-1/2 z-10 mt-3 w-max -translate-x-1/2 rounded bg-sky-50 p-3 text-xs text-sky-400 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-100">
+            3:2 비율 (예: 1500×1000)이<br></br>가장 예쁘게 보여져요!
+          </div>
+        </div>
       </div>
-      <div className="flex w-full flex-1 flex-col gap-3 md:flex-row">
+
+      <div className="flex w-full flex-1 flex-col gap-3 xl:flex-row">
         <div
-          className="border-midGray text-midGray flex min-h-[250px] flex-1 flex-col items-center justify-evenly rounded border p-10 text-center"
+          className="border-midGray text-midGray sm:items-around flex flex-1 flex-col items-center justify-between gap-2 rounded border p-6 text-center"
           onDrop={handleDrop}
           onDragOver={handleDragOver}
         >
-          <p>
-            파일을 이곳에 끌어놓아주세요.
-            <br />
-            Drag & Drop images here.
-          </p>
-          <p className="text-midGray my-2">OR</p>
-          <label className="text-mainGreen cursor-pointer rounded-full bg-[#D1F3E1] px-15 py-4 text-sm font-bold">
-            파일 업로드
+          <p className="text-xs sm:inline sm:text-sm">파일을 이곳에 끌어놓아주세요.</p>
+          <p className="text-midGray my-2 text-xs sm:inline sm:text-sm">OR</p>
+          <label className="text-mainGreen flex cursor-pointer rounded-full bg-[#D1F3E1] p-4 text-sm font-bold">
+            <MdOutlineFileUpload className="sm:hidden" />
+            <span className="hidden px-4 sm:inline">파일 업로드</span>
             <input type="file" accept="image/*" multiple className="hidden" onChange={handleImageUpload} />
           </label>
         </div>
-        <div className="grid flex-1 grid-cols-3 gap-3 text-center sm:grid-cols-2">
+        <div className="grid flex-1 grid-cols-1 gap-3 text-center sm:grid-cols-2">
           {paddedImages.map((img, index) =>
             img ? (
               <div
                 key={index}
-                className="border-lightGray relative flex h-[120px] w-full items-center justify-center overflow-hidden rounded border text-xs text-gray-400"
+                className="border-lightGray relative flex aspect-[3/2] w-full items-center justify-center overflow-hidden rounded border text-xs text-gray-400"
               >
                 {img.url === 'ERROR' ? (
                   <MdBrokenImage size={30} className="text-red-300" />
@@ -162,7 +171,7 @@ const ImageUploaderSection = ({
             ) : (
               <div
                 key={index}
-                className="border-lightGray text-title text-lightGray relative flex h-[120px] w-full items-center justify-center rounded border border-dashed"
+                className="border-lightGray text-title text-lightGray relative flex aspect-[3/2] w-full items-center justify-center rounded border border-dashed"
               >
                 <AiFillPicture />
                 {index === 0 && (

--- a/src/pages/project-editor/IntroSection.tsx
+++ b/src/pages/project-editor/IntroSection.tsx
@@ -9,7 +9,7 @@ interface IntroSectionProps {
 
 const IntroSection = ({ projectName, teamName, leaderName, participants }: IntroSectionProps) => {
   return (
-    <div className="flex gap-10 text-sm">
+    <div className="flex gap-10 truncate text-sm">
       <div className="text-midGray flex w-25 flex-col gap-3 pl-3">
         <span>프로젝트</span>
         <span>팀명</span>

--- a/src/pages/project-editor/OverviewInput.tsx
+++ b/src/pages/project-editor/OverviewInput.tsx
@@ -21,9 +21,8 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
     }
   };
 
-  // ring-lightGray focus-within:ring-midGray flex h-36 flex-col gap-2 rounded p-3 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1"
   return (
-    <div className="flex gap-10 text-sm">
+    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
       <div className="text-midGray flex w-25 gap-1">
         <span className="mr-1 text-red-500">*</span>
         <span className="w-full">Overview</span>

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -22,6 +22,7 @@ import IntroSection from './IntroSection';
 import UrlInput from './UrlInputSection';
 import ImageUploaderSection from './ImageUploaderSection';
 import OverviewInput from './OverviewInput';
+import EditorSkeleton from './EditorSkeleton';
 
 export interface PreviewImage {
   id?: number;
@@ -98,7 +99,7 @@ const ProjectEditorPage = () => {
   }, [previewData, projectData]);
 
   if (!teamId) return <div>팀 정보를 불러올 수 없습니다.</div>;
-  if (isProjectLoading) return <div>로딩 중...</div>;
+  if (isProjectLoading) return <EditorSkeleton />;
   if (isProjectError || !projectData) return <div>데이터를 가져오지 못했습니다.</div>;
   if (memberId !== projectData.leaderId) return <div>접근 권한이 없습니다.</div>;
 
@@ -198,10 +199,16 @@ const ProjectEditorPage = () => {
 
       <div className="h-20" />
 
-      <div className="flex justify-center">
+      <div className="flex justify-end gap-5 sm:gap-10">
+        <button
+          onClick={() => navigate(-1)}
+          className="border-mainGreen hover:bg-whiteGray focus:bg-subGreen text-mainGreen rounded-full border px-4 py-2 font-bold hover:cursor-pointer focus:outline-none sm:px-15 sm:py-4"
+        >
+          취소
+        </button>
         <button
           onClick={handleSave}
-          className="bg-mainGreen rounded-full px-15 py-4 text-sm font-bold text-white hover:cursor-pointer hover:bg-green-700 focus:bg-green-400 focus:outline-none"
+          className="bg-mainGreen rounded-full px-4 py-2 text-sm font-bold text-white hover:cursor-pointer hover:bg-green-700 focus:bg-green-400 focus:outline-none sm:px-15 sm:py-4"
         >
           저장
         </button>

--- a/src/pages/project-editor/UrlInputSection.tsx
+++ b/src/pages/project-editor/UrlInputSection.tsx
@@ -11,7 +11,7 @@ interface UrlInputSectionProps {
 
 const UrlInputSection = ({ githubUrl, setGithubUrl, youtubeUrl, setYoutubeUrl }: UrlInputSectionProps) => {
   return (
-    <div className="flex gap-10 text-sm">
+    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
       <div className="text-midGray flex w-25">
         <span className="mr-1 text-red-500">*</span>
         <span>URL</span>


### PR DESCRIPTION
### 연관 이슈
- #85 

### 작업 요약
- 에디터 페이지의 url 입력부, 이미지 업로더, overview 입력창에 대한 반응형 구현을 하였습니다.
- 이미지 비율(3:2)에 대한 안내를 위해 `가이드` 호버 시 안내 문구가 뜨도록 디자인하였습니다.
- 기존에 없던 취소 버튼을 추가 구현하였습니다. `navigate(-1)`

### 작업 상세설명
- `ImageUploaderSection`: 파일 드롭창 내 버튼을 너비 축소 시 아이콘으로 대체되도록 수정하였습니다.
  - 너비 축소에 따라 grid-col 수가 적어지도록 (최소 1개) 구현하였습니다.

### 미리보기 영상
- 에디터 페이지 반응형 구현

  https://github.com/user-attachments/assets/d3fbf741-4ae9-4561-aac3-4c93475b69ea

- 이미지 업로드 가이드

  ![photo-guide](https://github.com/user-attachments/assets/096cd2ed-df23-4fa7-9fd1-7149fb61fbc7)
