### PR TITLE
Design: 팀장 메세지 반응형 스타일링 적용

### DIFF
--- a/src/components/RoundedButton.tsx
+++ b/src/components/RoundedButton.tsx
@@ -6,7 +6,7 @@ const RoundedButton = ({ className = '', children, ...props }: Props) => {
   return (
     <button
       {...props}
-      className={`border-lightGray hover:bg-mainGreen rounded-full border p-3 hover:text-white ${className}`}
+      className={`border-lightGray hover:bg-mainGreen rounded-full border p-1 hover:text-white md:p-3 ${className}`}
     >
       {children}
     </button>

--- a/src/components/RoundedButton.tsx
+++ b/src/components/RoundedButton.tsx
@@ -6,7 +6,7 @@ const RoundedButton = ({ className = '', children, ...props }: Props) => {
   return (
     <button
       {...props}
-      className={`border-lightGray hover:bg-mainGreen min-w-32 rounded-full border p-3 hover:text-white ${className}`}
+      className={`border-lightGray hover:bg-mainGreen rounded-full border p-3 hover:text-white ${className}`}
     >
       {children}
     </button>

--- a/src/pages/find/FindEmailForm.tsx
+++ b/src/pages/find/FindEmailForm.tsx
@@ -28,7 +28,7 @@ const FindEmailForm = ({ studentNumber, setStudentNumber, onSubmit, isLoading }:
           }}
         />
       </div>
-      <RoundedButton onClick={onSubmit} className="mx-auto" disabled={isLoading}>
+      <RoundedButton onClick={onSubmit} className="mx-auto min-w-32" disabled={isLoading}>
         {isLoading ? <Spinner className="inline-block h-5 w-5 align-middle" /> : '아이디 찾기'}
       </RoundedButton>
     </div>

--- a/src/pages/find/FindEmailResult.tsx
+++ b/src/pages/find/FindEmailResult.tsx
@@ -13,7 +13,7 @@ const FindEmailResult = ({ email }: Props) => {
         입니다.
       </p>
       <Link to={'/signin'}>
-        <RoundedButton>로그인</RoundedButton>
+        <RoundedButton className="min-w-32">로그인</RoundedButton>
       </Link>
     </div>
   );

--- a/src/pages/find/PasswordTab.tsx
+++ b/src/pages/find/PasswordTab.tsx
@@ -71,7 +71,9 @@ const PasswordTab = () => {
       </div>
 
       <div className="col-span-3 mt-8 flex justify-center gap-4">
-        <RoundedButton type="submit">비밀번호 변경</RoundedButton>
+        <RoundedButton type="submit" className="min-w-32">
+          비밀번호 변경
+        </RoundedButton>
       </div>
     </form>
   );

--- a/src/pages/main/LeaderMessage.tsx
+++ b/src/pages/main/LeaderMessage.tsx
@@ -6,10 +6,10 @@ interface LeaderProps {
 
 const LeaderMessage = ({ leaderName }: LeaderProps) => {
   return (
-    <div className="text-mainRed flex items-center flex items-center gap-2 flex-1 overflow-hidden">
-      <BiError className="w-10 h-10 flex-shrink-0" />
-      <span className="truncate text-sm">
-        <strong className="text-xl">{leaderName}</strong> 팀장님, 에디터에서 프로젝트 정보를 작성해 주세요!
+    <div className="text-mainRed flex flex-1 items-center gap-1 overflow-hidden sm:gap-2">
+      <BiError className="text-xl sm:text-4xl" />
+      <span className="truncate text-xs sm:text-sm">
+        <strong className="sm:text-xl">{leaderName}</strong> 팀장님, 에디터에서 프로젝트 정보를 작성해 주세요!
       </span>
     </div>
   );

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -23,7 +23,7 @@ const LeaderSection = () => {
       <LeaderMessage leaderName={user?.name ?? '팀장'} />
       <Link to={`/teams/edit/${submissionData?.teamId}`}>
         <RoundedButton className="flex items-center gap-1">
-          <TbPencil className="text-xl" />
+          <TbPencil className="text-lg sm:text-xl" />
           <span className="hidden whitespace-nowrap md:inline">작성하러 가기</span>
         </RoundedButton>
       </Link>

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -17,7 +17,7 @@ const LeaderSection = () => {
 
   const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
 
-  // if (!showLeaderMessage) return null;
+  if (!showLeaderMessage) return null;
   return (
     <div className="flex w-full items-center justify-between gap-2 rounded-lg bg-white p-2 text-sm shadow-md sm:gap-4 sm:p-4">
       <LeaderMessage leaderName={user?.name ?? '팀장'} />

--- a/src/pages/main/LeaderSection.tsx
+++ b/src/pages/main/LeaderSection.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { SubmissionStatusResponseDto } from '../../types/DTO/teams/submissionStatusDto';
 import { Link } from 'react-router-dom';
 import { TbPencil } from 'react-icons/tb';
+import RoundedButton from '@components/RoundedButton';
 
 const LeaderSection = () => {
   const { isLeader, user } = useAuth();
@@ -14,30 +15,17 @@ const LeaderSection = () => {
     enabled: isLeader,
   });
 
-
-
   const showLeaderMessage = isLeader && submissionData?.isSubmitted === false;
 
-  if (!showLeaderMessage) return null;
-
+  // if (!showLeaderMessage) return null;
   return (
-    <div className="flex items-center justify-between gap-4 w-full lg:w-fit
-                 overflow-hidden
-                 rounded-lg bg-white p-4
-                 shadow-[0_4px_12px_rgba(0,0,0,0.2)]
-                 text-sm">
+    <div className="flex w-full items-center justify-between gap-2 rounded-lg bg-white p-2 text-sm shadow-md sm:gap-4 sm:p-4">
       <LeaderMessage leaderName={user?.name ?? '팀장'} />
-
       <Link to={`/teams/edit/${submissionData?.teamId}`}>
-        <button className="flex items-center justify-center
-                          border border-lightGray hover:bg-mainGreen hover:text-white
-                          rounded-full p-2
-                          md:px-4 md:py-3 md:gap-2">
-          <TbPencil size={30} />
-          <span className="hidden md:inline whitespace-nowrap">
-            작성하러 가기</span>
-        </button>
-
+        <RoundedButton className="flex items-center gap-1">
+          <TbPencil className="text-xl" />
+          <span className="hidden whitespace-nowrap md:inline">작성하러 가기</span>
+        </RoundedButton>
       </Link>
     </div>
   );


### PR DESCRIPTION
### 개요
팀장 메세지 반응형 스타일링 적용

### 목적
팀장 메세지에 반응형 스타일링을 적용한다.

### 변경 사항
- LeaderSection, LeaderMessage
  - 반응형 텍스트 크기, 버튼 크기 적용
- RoundedButton
  - min width 제거 후 RoundedButton 사용 컴포넌트에서 min-w 관리하도록 변경

### 참고 이미지
|전체 화면|모바일|
|---|---|
|<img width="1656" alt="image" src="https://github.com/user-attachments/assets/5c0fb574-c18c-4688-9f3b-45830356e948" />|<img width="383" alt="image" src="https://github.com/user-attachments/assets/99d4f2b4-7c72-4eeb-b380-58e2415559c0" />|

