### PR TITLE
Feat: 헤더 히스토리 드롭다운 구현

### DIFF
--- a/src/apis/contests.ts
+++ b/src/apis/contests.ts
@@ -1,0 +1,7 @@
+import { ContestResponseDto } from 'types/DTO';
+import apiClient from './apiClient';
+
+export const getAllContests = async (): Promise<ContestResponseDto[]> => {
+  const res = await apiClient.get('/contests');
+  return res.data;
+};

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -4,7 +4,7 @@ import { BiCog } from 'react-icons/bi';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { useToast } from 'hooks/useToast';
-import { useState } from 'react';
+import HeaderMenu from './HeaderMenu';
 
 const Header = () => {
   const navigate = useNavigate();
@@ -56,26 +56,3 @@ const Header = () => {
 };
 
 export default Header;
-
-const HeaderMenu = () => {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <div className="flex-1 font-semibold md:text-lg lg:text-xl">
-      <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
-        <span className="hover:text-mainGreen cursor-pointer">히스토리</span>
-        {isOpen && (
-          <div className="border-subGreen absolute top-full z-50 w-fit border-2 bg-white text-nowrap">
-            <ul className="text-base font-normal">
-              <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
-                제6회PNU창의융합SW해커톤
-              </li>
-              <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
-                제5회PNU창의융합SW해커톤
-              </li>
-            </ul>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-};

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -4,6 +4,7 @@ import { BiCog } from 'react-icons/bi';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { useToast } from 'hooks/useToast';
+import { useState } from 'react';
 
 const Header = () => {
   const navigate = useNavigate();
@@ -18,20 +19,23 @@ const Header = () => {
 
   return (
     <header className="border-lightGray lg:h-header md:h-header xs:h-8 z-20 flex w-full min-w-[350px] items-center justify-between border-b bg-white px-4 py-2 sm:h-16">
-      <div className="mx-auto flex w-full items-center justify-between px-4 sm:px-8 lg:px-16">
+      <div className="mx-auto flex w-full items-center justify-between gap-4 px-4 sm:px-8 md:gap-8 lg:gap-16 lg:px-16">
         <Link to="/">
-          <img className="h-10 w-auto max-sm:hidden" src="/Logo.svg" alt="부산대학교 SW성과관리시스템 로고" />
+          <img className="w-auto max-sm:hidden md:h-9 lg:h-10" src="/Logo.svg" alt="부산대학교 SW성과관리시스템 로고" />
           <img
-            className="h-10 w-auto sm:hidden"
+            className="h-8 w-auto sm:hidden"
             src="/swOpsLogo-sm.png"
             alt="부산대학교 SW성과관리시스템 로고 (작은 버전)"
           />
         </Link>
-        <div className="flex items-center justify-between gap-8">
+
+        <HeaderMenu />
+
+        <div className="flex items-center justify-between gap-2 md:gap-4 lg:gap-8">
           {isAdmin && (
             <Link to="/admin" className="flex items-center gap-2 hover:cursor-pointer">
-              <BiCog className="text-mainGreen text-exsm cursor-pointer" />
-              <span className="text-exsm">관리자 페이지</span>
+              <BiCog className="text-mainGreen cursor-pointer text-sm" />
+              <span className="text-exsm hidden md:inline">관리자 페이지</span>
             </Link>
           )}
           {user?.name && (
@@ -52,3 +56,26 @@ const Header = () => {
 };
 
 export default Header;
+
+const HeaderMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div className="flex-1 font-semibold md:text-lg lg:text-xl">
+      <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
+        <span className="hover:text-mainGreen cursor-pointer">히스토리</span>
+        {isOpen && (
+          <div className="border-subGreen absolute top-full z-50 w-fit border-2 bg-white text-nowrap">
+            <ul className="text-base font-normal">
+              <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
+                제6회PNU창의융합SW해커톤
+              </li>
+              <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
+                제5회PNU창의융합SW해커톤
+              </li>
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/layout/HeaderMenu.tsx
+++ b/src/layout/HeaderMenu.tsx
@@ -18,22 +18,22 @@ const HistoryMenu = () => {
 
   return (
     <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
-      <Link to="/contest" className="hover:text-mainGreen cursor-pointer text-nowrap">
+      <Link to="/contest" className="hover:text-mainGreen block p-4 text-nowrap">
         히스토리
       </Link>
       {isOpen && data && (
-        <div className="border-subGreen absolute top-full z-50 w-fit border-2 bg-white text-nowrap">
-          <ul className="text-base font-normal">
-            {data?.map((item) => (
+        <ul className="border-subGreen absolute z-50 w-fit border-2 bg-white text-base font-normal text-nowrap">
+          {data?.map((item) => (
+            <li key={item.contestId}>
               <Link
                 to={`/contest/${item.contestId}`}
-                className="hover:text-mainGreen block cursor-pointer px-4 py-2 hover:bg-gray-100"
+                className="hover:text-mainGreen hover:bg-whiteGray block p-4 transition-colors duration-200 ease-in"
               >
                 {item.contestName}
               </Link>
-            ))}
-          </ul>
-        </div>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/layout/HeaderMenu.tsx
+++ b/src/layout/HeaderMenu.tsx
@@ -1,4 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAllContests } from 'apis/contests';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 const HeaderMenu = () => {
   return (
@@ -11,19 +14,22 @@ export default HeaderMenu;
 
 const HistoryMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { data } = useQuery({ queryKey: ['contests'], queryFn: getAllContests });
 
   return (
     <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
       <span className="hover:text-mainGreen cursor-pointer">히스토리</span>
-      {isOpen && (
+      {isOpen && data && (
         <div className="border-subGreen absolute top-full z-50 w-fit border-2 bg-white text-nowrap">
           <ul className="text-base font-normal">
-            <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
-              제6회PNU창의융합SW해커톤
-            </li>
-            <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
-              제5회PNU창의융합SW해커톤
-            </li>
+            {data?.map((item) => (
+              <Link
+                to={`/contest/${item.contestId}`}
+                className="hover:text-mainGreen block cursor-pointer px-4 py-2 hover:bg-gray-100"
+              >
+                {item.contestName}
+              </Link>
+            ))}
           </ul>
         </div>
       )}

--- a/src/layout/HeaderMenu.tsx
+++ b/src/layout/HeaderMenu.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+const HeaderMenu = () => {
+  return (
+    <div className="flex-1 font-semibold md:text-lg lg:text-xl">
+      <HistoryMenu />
+    </div>
+  );
+};
+export default HeaderMenu;
+
+const HistoryMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
+      <span className="hover:text-mainGreen cursor-pointer">히스토리</span>
+      {isOpen && (
+        <div className="border-subGreen absolute top-full z-50 w-fit border-2 bg-white text-nowrap">
+          <ul className="text-base font-normal">
+            <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
+              제6회PNU창의융합SW해커톤
+            </li>
+            <li className="hover:text-mainGreen cursor-pointer px-4 py-2 hover:bg-gray-100">
+              제5회PNU창의융합SW해커톤
+            </li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/layout/HeaderMenu.tsx
+++ b/src/layout/HeaderMenu.tsx
@@ -18,7 +18,9 @@ const HistoryMenu = () => {
 
   return (
     <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
-      <span className="hover:text-mainGreen cursor-pointer">히스토리</span>
+      <Link to="/contest" className="hover:text-mainGreen cursor-pointer">
+        히스토리
+      </Link>
       {isOpen && data && (
         <div className="border-subGreen absolute top-full z-50 w-fit border-2 bg-white text-nowrap">
           <ul className="text-base font-normal">

--- a/src/layout/HeaderMenu.tsx
+++ b/src/layout/HeaderMenu.tsx
@@ -18,7 +18,7 @@ const HistoryMenu = () => {
 
   return (
     <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
-      <Link to="/contest" className="hover:text-mainGreen cursor-pointer">
+      <Link to="/contest" className="hover:text-mainGreen cursor-pointer text-nowrap">
         히스토리
       </Link>
       {isOpen && data && (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,9 +9,9 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import queryClient from 'stores/queryClient';
 import { Toaster } from '@components/Toaster';
 
-// if (process.env.NODE_ENV === 'development') {
-//   await worker.start();
-// }
+if (process.env.NODE_ENV === 'development') {
+  await worker.start();
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/mocks/data/contests.ts
+++ b/src/mocks/data/contests.ts
@@ -1,0 +1,14 @@
+import { ContestResponseDto } from 'types/DTO';
+
+export const mockContestsResponse: ContestResponseDto[] = [
+  {
+    contestId: 1,
+    contestName: '제6회PNU창의융합SW해커톤',
+    updatedAt: '2025-06-28T14:30:00Z',
+  },
+  {
+    contestId: 2,
+    contestName: '제5회PNU창의융합SW해커톤',
+    updatedAt: '2025-06-20T09:15:45Z',
+  },
+];

--- a/src/mocks/data/contests.ts
+++ b/src/mocks/data/contests.ts
@@ -11,4 +11,14 @@ export const mockContestsResponse: ContestResponseDto[] = [
     contestName: '제5회PNU창의융합SW해커톤',
     updatedAt: '2025-06-20T09:15:45Z',
   },
+  {
+    contestId: 3,
+    contestName: '제4회PNU창의융합SW해커톤',
+    updatedAt: '2025-06-20T09:15:45Z',
+  },
+  {
+    contestId: 4,
+    contestName: '제3회PNU창의융합SW해커톤',
+    updatedAt: '2025-06-20T09:15:45Z',
+  },
 ];

--- a/src/mocks/handlers/contests.ts
+++ b/src/mocks/handlers/contests.ts
@@ -1,0 +1,8 @@
+import { mockContestsResponse } from '@mocks/data/contests';
+import { http, HttpResponse } from 'msw';
+
+export const contestsHandler = [
+  http.get('/api/contests', () => {
+    return HttpResponse.json(mockContestsResponse);
+  }),
+];

--- a/src/mocks/handlers/contests.ts
+++ b/src/mocks/handlers/contests.ts
@@ -1,8 +1,10 @@
 import { mockContestsResponse } from '@mocks/data/contests';
 import { http, HttpResponse } from 'msw';
 
+const base = import.meta.env.VITE_API_BASE_URL ?? '';
+
 export const contestsHandler = [
-  http.get('/api/contests', () => {
+  http.get(`${base}/api/contests`, () => {
     return HttpResponse.json(mockContestsResponse);
   }),
 ];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,6 @@
+import { contestsHandler } from './contests';
 import { signInHandlers } from './sign-in';
 import { signUpHandlers } from './sign-up';
 import { teamsHandlers } from './teams';
 
-export const handlers = [...teamsHandlers, ...signInHandlers, ...signUpHandlers];
+export const handlers = [...contestsHandler];

--- a/src/types/DTO/contestsDto.ts
+++ b/src/types/DTO/contestsDto.ts
@@ -1,0 +1,5 @@
+export interface ContestResponseDto {
+  contestId: number;
+  contestName: string;
+  updatedAt: string;
+}

--- a/src/types/DTO/index.ts
+++ b/src/types/DTO/index.ts
@@ -3,6 +3,7 @@ export * from './signUpDto';
 export * from './dashboardDto';
 export * from './teamsLikeDto';
 export * from './voteRateDto';
+export * from './contestsDto';
 
 export type { DashboardTeamResponseDto } from './dashboardDto';
 export type { TeamLikeResponseDto } from './teamsLikeDto';


### PR DESCRIPTION
### 개요
헤더 히스토리 드롭다운 구현

### 목적
헤더 히스토리 드롭다운 구현

### 변경 사항
- /contests API msw 핸들러 정의 및 msw 활성화
- HeaderMenu 컴포넌트 구현
 - Hover 시 드롭다운 open
 - '히스토리', 드롭다운 아이템 클릭 시 /contest 또는 /contest/{contestId}로 라우팅
 - '히스토리'클릭 시 라우팅 처리하였기 때문에 Api 예외처리는 하지 않음
- 헤더 메뉴 표현을 위해 Header 로고 크기 반응형 처리 및 md breakpoint에서 '관리자 페이지' 텍스트 제거

### 참고 이미지
[PC]
![image](https://github.com/user-attachments/assets/c1bc7622-1a70-40ce-b0c2-d929a73e8ef2)

