### PR TITLE
fix: 모바일뷰에서 HeaderMenu가 적절히 동작할 수 있도록 수정

### DIFF
--- a/src/layout/HeaderMenu.tsx
+++ b/src/layout/HeaderMenu.tsx
@@ -18,9 +18,9 @@ const HistoryMenu = () => {
 
   return (
     <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
-      <Link to="/contest" className="hover:text-mainGreen block p-4 text-nowrap">
+      <button type="button" className="hover:text-mainGreen block p-4 text-nowrap" onClick={() => setIsOpen(!isOpen)}>
         히스토리
-      </Link>
+      </button>
       {isOpen && data && (
         <ul className="border-subGreen absolute z-50 w-fit border-2 bg-white text-base font-normal text-nowrap">
           {data?.map((item) => (


### PR DESCRIPTION
### 📝 개요
fix: 모바일뷰에서 HeaderMenu가 적절히 동작할 수 있도록 수정

### 🎯 목적
fix: 모바일뷰에서 HeaderMenu가 적절히 동작할 수 있도록 수정

### ✨ 변경 사항
- '히스토리' 클릭 시 /constest로 이동하지 않고 드롭다운의 상태만 변경하도록 수정
