### PR TITLE
Fix: 백엔드 필드명 수정으로 youTubePath 네이밍 통일

### DIFF
--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -94,7 +94,7 @@ const ProjectEditorPage = () => {
       setLeaderName(projectData.leaderName);
       setTeamMembers(projectData.teamMembers);
       setGithubUrl(projectData.githubPath);
-      setYoutubeUrl(projectData.youtubePath);
+      setYoutubeUrl(projectData.youTubePath);
       setProdUrl(projectData.productionPath);
       setOverview(projectData.overview);
     }

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -64,10 +64,10 @@ const ProjectViewerPage = () => {
         teamName={data.teamName}
         prodUrl={data.productionPath}
         githubUrl={data.githubPath}
-        youtubeUrl={data.youtubePath}
+        youtubeUrl={data.youTubePath}
       />
       <div className="h-10" />
-      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youtubePath} />
+      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youTubePath} />
       <div className="h-10" />
       <LikeSection teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -16,7 +16,7 @@ export interface ProjectDetailsResponseDto {
   previewIds: number[];
   productionPath: string | null;
   githubPath: string;
-  youtubePath: string;
+  youTubePath: string;
   isLiked: boolean;
 }
 


### PR DESCRIPTION
### 📝 개요
- `youtubePath`, `youTubePath` 필드명을 `youTubePath`로 통일하는 것으로 전달받았습니다.
- 백엔드에 수정 사항 반영된 것 확인 후 해당 PR을 머지할 예정입니다!

### 🎯 목적
- 필드명을 일관되게 통일하여 코드의 가독성을 높이기 위해서입니다.
