### PR TITLE
Refactor: 관리자 페이지 탭 간 공통 레이아웃 적용, 접근 권한 관리

### DIFF
--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,12 +1,22 @@
 import { Outlet, Link, useParams, useResolvedPath, useLocation } from 'react-router-dom';
 import AdminTabs from '@route/AdminTabs';
+import useAuth from 'hooks/useAuth';
 
 const AdminPage = () => {
+  const { isAdmin } = useAuth();
   const adminTabs = AdminTabs;
   const { pathname } = useLocation();
 
+  if (!isAdmin) {
+    return (
+      <div className="w-full rounded bg-white p-6 text-center shadow-md">
+        <p className="text-mainRed text-xl">관리자 권한이 없습니다.</p>
+      </div>
+    );
+  }
+
   return (
-    <div>
+    <>
       <div className="mb-8 flex gap-4">
         {adminTabs.map((tab) => (
           <Link
@@ -23,7 +33,7 @@ const AdminPage = () => {
       <div className="flex flex-col gap-12 px-4 py-8">
         <Outlet />
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -20,7 +20,9 @@ const AdminPage = () => {
           </Link>
         ))}
       </div>
-      <Outlet />
+      <div className="flex flex-col gap-12 px-4 py-8">
+        <Outlet />
+      </div>
     </div>
   );
 };

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -60,7 +60,7 @@ const ContestAdminTab = () => {
   } = useContestAdmin();
 
   return (
-    <div className="max-w-container flex flex-col gap-12 px-4 py-8">
+    <>
       {/* {state.isModalOpen && <DeleteInfoModal closeModal={closeDeleteModal} />} */}
       {state.isEditModalOpen && <EditModal closeModal={closeEditModal} editId={state.editContestId} />}
 
@@ -136,7 +136,7 @@ const ContestAdminTab = () => {
           <Button className="bg-mainBlue h-12 w-[20%] min-w-[130px]">프로젝트 생성하기</Button>
         </div>
       </section>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/admin/OngoingContestsTab.tsx
+++ b/src/pages/admin/OngoingContestsTab.tsx
@@ -8,29 +8,18 @@ import { DashboardTeamResponseDto, TeamLikeResponseDto } from 'types/DTO';
 import useAuth from 'hooks/useAuth';
 
 const OngoingContestsTab = () => {
-  const { isAdmin } = useAuth();
   const { data: dashboardData, isLoading: isDashboardLoading } = useQuery<DashboardTeamResponseDto[]>({
     queryKey: ['dashboard'],
     queryFn: getDashboard,
-    enabled: isAdmin,
     staleTime: 0,
     refetchOnMount: true,
   });
   const { data: rankingData, isLoading: isRankingLoading } = useQuery<TeamLikeResponseDto[]>({
     queryKey: ['ranking'],
     queryFn: getRanking,
-    enabled: isAdmin,
     staleTime: 0,
     refetchOnMount: true,
   });
-
-  if (!isAdmin) {
-    return (
-      <div className="mx-auto w-full rounded bg-white p-6 text-center shadow-md">
-        <p className="text-red-500">관리자 권한이 없습니다.</p>
-      </div>
-    );
-  }
 
   if (isDashboardLoading || isRankingLoading) {
     return <p className="text-center text-gray-400">로딩 중...</p>;

--- a/src/pages/admin/OngoingContestsTab.tsx
+++ b/src/pages/admin/OngoingContestsTab.tsx
@@ -44,11 +44,11 @@ const OngoingContestsTab = () => {
     );
   }
   return (
-    <div className="max-w-container flex flex-col gap-12 px-4 py-8">
+    <>
       <ProjectSubmissionTable submissions={dashboardData} type="project" />
       <ProjectSubmissionTable submissions={rankingData} type="vote" />
       <VoteRate />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
### 📝 개요
관리자 페이지 탭 간 공통 레이아웃 적용, 접근 권한 관리

### 🎯 목적
코드 일관성 유지를 위한 관리자 페이지 탭 간 공통 레이아웃 적용, 접근 권한 관리

### ✨ 변경 사항
- AdminPage에서 Tab을 감싸는 공통 레이아웃 적용하여 탭 간 padding, margin 일치
- AdminPage에서 관리자 권한 확인 로직을 관리하여 탭 여부와 관계 없이 접근 권한 관리
