### PR TITLE
Feat: 프로젝트 생성 컴포넌트

### DIFF
--- a/src/apis/projectEditor.ts
+++ b/src/apis/projectEditor.ts
@@ -46,3 +46,8 @@ export const deleteMember = async (teamId: number, memberId: number) => {
   const response = await apiClient.delete(`/teams/${teamId}/members/${memberId}`);
   return response.data;
 };
+
+export const createProjectDetails = async (body: ProjectDetailsEditDto) => {
+  const response = await apiClient.post('/teams', body);
+  return response.data;
+};

--- a/src/apis/projectEditor.ts
+++ b/src/apis/projectEditor.ts
@@ -7,10 +7,17 @@ export const patchProjectDetails = async (teamId: number, body: ProjectDetailsEd
 };
 
 export const getThumbnail = async (teamId: number): Promise<string> => {
-  const response = await apiClient.get(`/teams/${teamId}/image/thumbnail`, {
-    responseType: 'blob',
-  });
-  return URL.createObjectURL(response.data);
+  try {
+    const response = await apiClient.get(`/teams/${teamId}/image/thumbnail`, {
+      responseType: 'blob',
+    });
+    return URL.createObjectURL(response.data);
+  } catch (error: any) {
+    if (error.response?.status === 409) {
+      throw new Error('Thumbnail 409 Error');
+    }
+    throw error;
+  }
 };
 
 export const postThumbnail = async (teamId: number, formData: FormData) => {

--- a/src/apis/projectViewer.ts
+++ b/src/apis/projectViewer.ts
@@ -24,8 +24,12 @@ export const getPreviewImages = async (teamId: number, imageIds: number[]): Prom
       });
       const objectUrl = URL.createObjectURL(response.data);
       imageUrls.push(objectUrl);
-    } catch (error) {
-      imageUrls.push('ERROR');
+    } catch (error: any) {
+      if (error.response?.status === 409) {
+        imageUrls.push('ERROR_409');
+      } else {
+        imageUrls.push('ERROR');
+      }
     }
   }
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ const Button = ({ className = '', children, ...props }: Props) => {
   return (
     <button
       className={twMerge(
-        'flex h-12 items-center justify-center rounded-md px-2 py-1 text-center text-sm text-white',
+        'flex h-12 items-center justify-center rounded-md px-2 py-1 text-center text-sm text-white hover:cursor-pointer',
         className,
       )}
       {...props}

--- a/src/hooks/useContestAdmin.ts
+++ b/src/hooks/useContestAdmin.ts
@@ -1,6 +1,8 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { getAllContests, postAllContests, deleteContest } from 'apis/contests';
+import { createProjectDetails } from 'apis/projectEditor';
 import { getAllTeams, deleteTeams } from 'apis/teams';
 import { useToast } from 'hooks/useToast';
 import { TeamListItemResponseDto } from 'types/DTO/teams/teamListDto';
@@ -42,6 +44,7 @@ const useContestAdmin = () => {
   });
 
   const toast = useToast();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   useEffect(() => {
@@ -122,6 +125,36 @@ const useContestAdmin = () => {
     }
   };
 
+  const handleCreateTeam = async (teamId: number) => {
+    try {
+      // await createProjectDetails({
+      //   contestId: contestId,
+      //   teamName: teamName,
+      //   projectName: projectName,
+      //   leaderName: leaderName,
+      //   overview,
+      //   productionPath: prodUrl,
+      //   githubPath: githubUrl,
+      //   youTubePath: youtubeUrl,
+      // });
+      const response = await createProjectDetails({
+        contestId: teamId,
+        teamName: '팀 이름',
+        projectName: '프로젝트 이름',
+        leaderName: '팀장 이름',
+        overview: '프로젝트 소개글',
+        productionPath: '',
+        githubPath: 'https://github.com/2025-PNU-SW-Hackathon',
+        youTubePath: 'https://youtu.be/CYoK_cuG8lU',
+      });
+      const createdTeamId = response.teamId;
+      toast('저장이 완료되었습니다.', 'success');
+      navigate(`/teams/edit/${createdTeamId}`);
+    } catch (err: any) {
+      toast(err?.response?.data?.message || '저장 중 오류가 발생했습니다.', 'error');
+    }
+  };
+
   const closeDeleteModal = () => setState((prev) => ({ ...prev, isModalOpen: false }));
   const openEditModal = (contestId: number) =>
     setState((prev) => ({
@@ -137,6 +170,7 @@ const useContestAdmin = () => {
     toast,
     handleAddContest,
     handleDeleteContest,
+    handleCreateTeam,
     handleContestChange,
     handleDeleteTeam,
     closeDeleteModal,

--- a/src/hooks/useId.ts
+++ b/src/hooks/useId.ts
@@ -5,3 +5,9 @@ export const useTeamId = (): number | null => {
   const parsedTeamId = Number(teamId);
   return !teamId || isNaN(parsedTeamId) ? null : parsedTeamId;
 };
+
+export const useContestId = (): number | null => {
+  const { contestId } = useParams<{ contestId: string }>();
+  const parsedContestId = Number(contestId);
+  return !contestId || isNaN(parsedContestId) ? null : parsedContestId;
+};

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { getAllContests } from 'apis/contests';
 import Input from '@components/Input';
@@ -58,6 +59,7 @@ const ContestAdminTab = () => {
     closeEditModal,
     setContestName,
   } = useContestAdmin();
+  const navigate = useNavigate();
 
   return (
     <>
@@ -127,13 +129,23 @@ const ContestAdminTab = () => {
               <Button className="bg-mainRed h-[35px] w-full min-w-[70px]" onClick={() => handleDeleteTeam(row.teamId)}>
                 삭제하기
               </Button>
-              <Button className="bg-mainGreen h-[35px] w-full min-w-[70px]">수정하기</Button>
+              <Button
+                onClick={() => navigate(`/teams/edit/${row.teamId}`)}
+                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
+              >
+                수정하기
+              </Button>
             </>
           )}
         />
 
         <div className="mt-8 flex w-full flex-row-reverse">
-          <Button className="bg-mainBlue h-12 w-[20%] min-w-[130px]">프로젝트 생성하기</Button>
+          <Button
+            onClick={() => navigate(`/admin/contest/create/${state.currentContestId}`)}
+            className="bg-mainBlue h-12 w-[20%] min-w-[130px]"
+          >
+            프로젝트 생성하기
+          </Button>
         </div>
       </section>
     </>

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -130,11 +130,22 @@ const ContestAdminTab = () => {
           rows={state.contestTeams}
           actions={(row) => (
             <>
-              <Button className="bg-mainRed h-[35px] w-full min-w-[70px]" onClick={() => handleDeleteTeam(row.teamId)}>
+              <Button
+                className="bg-mainRed h-[35px] w-full min-w-[70px]"
+                onClick={() => {
+                  if (state.currentContestId == 1)
+                    toast('현재 진행 중인 대회의 프로젝트를 삭제할 수 없습니다.', 'error');
+                  state.currentContestId !== 1 && handleDeleteTeam(row.teamId);
+                }}
+              >
                 삭제하기
               </Button>
               <Button
-                onClick={() => navigate(`/teams/edit/${row.teamId}`)}
+                onClick={() => {
+                  if (state.currentContestId == 1)
+                    toast('현재 진행 중인 대회의 프로젝트를 수정할 수 없습니다.', 'info');
+                  state.currentContestId !== 1 && navigate(`/teams/edit/${row.teamId}`);
+                }}
                 className="bg-mainGreen h-[35px] w-full min-w-[70px]"
               >
                 수정하기
@@ -145,7 +156,6 @@ const ContestAdminTab = () => {
 
         <div className="mt-8 flex w-full flex-row-reverse">
           <Button
-            // onClick={() => navigate(`/admin/contest/create/${state.currentContestId}`)}
             onClick={() => handleCreateTeam(state.currentContestId)}
             className="bg-mainBlue h-12 w-[20%] min-w-[130px]"
           >

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { useToast } from 'hooks/useToast';
 import { getAllContests } from 'apis/contests';
+import { createProjectDetails } from 'apis/projectEditor';
 import Input from '@components/Input';
 import Button from '@components/Button';
 import Table from '@components/Table';
@@ -54,12 +56,14 @@ const ContestAdminTab = () => {
     handleDeleteContest,
     handleContestChange,
     handleDeleteTeam,
+    handleCreateTeam,
     // closeDeleteModal,
     openEditModal,
     closeEditModal,
     setContestName,
   } = useContestAdmin();
   const navigate = useNavigate();
+  const toast = useToast();
 
   return (
     <>
@@ -141,7 +145,8 @@ const ContestAdminTab = () => {
 
         <div className="mt-8 flex w-full flex-row-reverse">
           <Button
-            onClick={() => navigate(`/admin/contest/create/${state.currentContestId}`)}
+            // onClick={() => navigate(`/admin/contest/create/${state.currentContestId}`)}
+            onClick={() => handleCreateTeam(state.currentContestId)}
             className="bg-mainBlue h-12 w-[20%] min-w-[130px]"
           >
             프로젝트 생성하기

--- a/src/pages/project-editor/AdminInputSection/AdminInputSection.tsx
+++ b/src/pages/project-editor/AdminInputSection/AdminInputSection.tsx
@@ -10,6 +10,8 @@ interface AdminInputSectionProps {
   setProjectName: (projectName: string) => void;
   teamName: string;
   setTeamName: (teamName: string) => void;
+  leaderName: string;
+  setLeaderName: (teamName: string) => void;
   teamMembers: TeamMember[];
   onMemberAdd: (newMemberName: string) => void;
   onMemberRemove: (index: number) => void;
@@ -22,6 +24,8 @@ const AdminInputSection = ({
   setProjectName,
   teamName,
   setTeamName,
+  leaderName,
+  setLeaderName,
   teamMembers,
   onMemberAdd,
   onMemberRemove,
@@ -63,6 +67,21 @@ const AdminInputSection = ({
             value={teamName}
             onChange={(e) => setTeamName(e.target.value)}
             placeholder="팀 이름을 입력해주세요."
+            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 px-5 py-3 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-center sm:gap-10">
+        <div className="text-midGray flex w-25 gap-1">
+          <span className="mr-1 text-red-500">*</span>
+          <span className="w-full">팀장명</span>
+        </div>
+        <div className="flex flex-1 flex-col">
+          <input
+            type="text"
+            value={leaderName}
+            onChange={(e) => setLeaderName(e.target.value)}
+            placeholder="팀장 이름을 입력해주세요."
             className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 px-5 py-3 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
           />
         </div>

--- a/src/pages/project-editor/AdminInputSection/ContestMenu.tsx
+++ b/src/pages/project-editor/AdminInputSection/ContestMenu.tsx
@@ -2,6 +2,8 @@ import { useState, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useOutsideClick } from 'hooks/useOutsideClick';
 
+import { useToast } from 'hooks/useToast';
+
 import { getAllContests } from 'apis/contests';
 import { ContestResponseDto } from 'types/DTO';
 
@@ -15,6 +17,7 @@ interface ContestMenuProps {
 }
 
 const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
+  const toast = useToast();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLUListElement | null>(null);
 
@@ -45,7 +48,14 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
     <div className="relative w-full max-w-sm text-sm">
       <button
         className="border-lightGray flex w-full items-center justify-between rounded-md border-2 px-5 py-3 text-left hover:cursor-pointer"
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => {
+          if (selectedContest?.contestId == 1) {
+            toast('현재 진행 중인 대회의 프로젝트의 소속을 변경할 수 없습니다.', 'info');
+          }
+          if (selectedContest?.contestId !== 1) {
+            setIsOpen((prev) => !prev);
+          }
+        }}
       >
         <span className={selectedContest ? '' : 'text-midGray'}>
           {selectedContest?.contestName || '대회를 선택해주세요.'}

--- a/src/pages/project-editor/AdminInputSection/ContestMenu.tsx
+++ b/src/pages/project-editor/AdminInputSection/ContestMenu.tsx
@@ -51,10 +51,12 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
         onClick={() => {
           if (selectedContest?.contestId == 1) {
             toast('현재 진행 중인 대회의 프로젝트의 소속을 변경할 수 없습니다.', 'info');
+          } else {
+            toast('프로젝트 소속 대회를 변경할 수 없습니다.', 'info');
           }
-          if (selectedContest?.contestId !== 1) {
-            setIsOpen((prev) => !prev);
-          }
+          // if (selectedContest?.contestId !== 1) {
+          //   setIsOpen((prev) => !prev);
+          // }
         }}
       >
         <span className={selectedContest ? '' : 'text-midGray'}>

--- a/src/pages/project-editor/AdminInputSection/MembersInput.tsx
+++ b/src/pages/project-editor/AdminInputSection/MembersInput.tsx
@@ -41,7 +41,7 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
   }, [teamMembers]);
 
   return (
-    <div className="grid w-full grid-cols-1 gap-3 text-sm md:grid-cols-2">
+    <div className="grid w-full grid-cols-1 gap-3 text-sm lg:grid-cols-2">
       {Array.from({ length: MAX_MEMBERS }).map((_, idx) => (
         <div
           key={idx}

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -148,6 +148,13 @@ const ImageUploaderSection = ({
               >
                 {img.url === 'ERROR' ? (
                   <MdBrokenImage size={30} className="text-red-300" />
+                ) : img.url === 'ERROR_409' ? (
+                  <div className="text-lightGray border-lightGray flex h-full w-full flex-col items-center justify-center gap-5 border">
+                    <MdBrokenImage size={30} className="text-red-300" />
+                    <span className="text-xs">
+                      서버에서 이미지 변환 중입니다.<br></br>나중에 시도해 주세요.
+                    </span>
+                  </div>
                 ) : (
                   <img
                     src={getImageSrc(img.url)}

--- a/src/pages/project-editor/ProjectCreatorPage.tsx
+++ b/src/pages/project-editor/ProjectCreatorPage.tsx
@@ -187,18 +187,6 @@ const ProjectCreatorPage = () => {
 
       <div className="h-15" />
 
-      <ImageUploaderSection
-        thumbnail={thumbnail}
-        setThumbnail={setThumbnail}
-        previews={previews}
-        setPreviews={setPreviews}
-        setThumbnailToDelete={setThumbnailToDelete}
-        previewsToDelete={previewsToDelete}
-        setPreviewsToDelete={setPreviewsToDelete}
-      />
-
-      <div className="h-15" />
-
       <OverviewInput overview={overview} setOverview={setOverview} />
 
       <div className="h-20" />

--- a/src/pages/project-editor/ProjectCreatorPage.tsx
+++ b/src/pages/project-editor/ProjectCreatorPage.tsx
@@ -1,0 +1,289 @@
+import React, { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import useAuth from 'hooks/useAuth';
+import { useTeamId } from 'hooks/useTeamId';
+import { useToast } from 'hooks/useToast';
+
+import { getProjectDetails, getPreviewImages } from 'apis/projectViewer';
+import {
+  getThumbnail,
+  patchProjectDetails,
+  postPreview,
+  postThumbnail,
+  deletePreview,
+  deleteThumbnail,
+  postMember,
+  deleteMember,
+} from 'apis/projectEditor';
+
+import { TeamMember, ProjectDetailsResponseDto } from 'types/DTO/projectViewerDto';
+
+import { isValidGithubUrl, isValidYoutubeUrl, isValidProjectUrl } from './urlValidators';
+import IntroSection from './IntroSection';
+import UrlInput from './UrlInputSection';
+import ImageUploaderSection from './ImageUploaderSection';
+import OverviewInput from './OverviewInput';
+import { EditorDetailSkeleton } from './EditorSkeleton';
+
+import AdminInputSection from '@pages/project-editor/AdminInputSection/AdminInputSection';
+
+export interface PreviewImage {
+  id?: number;
+  url: string | File;
+}
+
+const ProjectCreatorPage = () => {
+  const isAdmin = useAuth();
+  const teamId = useTeamId();
+  const [contestId, setContestId] = useState<number | null>(null);
+  const [teamName, setTeamName] = useState('');
+  const [projectName, setProjectName] = useState('');
+  const [leaderName, setLeaderName] = useState('');
+  const [thumbnail, setThumbnail] = useState<string | File | undefined>();
+  const [thumbnailToDelete, setThumbnailToDelete] = useState<boolean>(false);
+  const [previews, setPreviews] = useState<PreviewImage[]>([]);
+  const [previewsToDelete, setPreviewsToDelete] = useState<number[]>([]);
+  const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
+  const [prodUrl, setProdUrl] = useState<string | null>(null);
+  const [githubUrl, setGithubUrl] = useState('');
+  const [youtubeUrl, setYoutubeUrl] = useState('');
+  const [overview, setOverview] = useState('');
+  const toast = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const {
+    data: projectData,
+    isLoading: isProjectLoading,
+    isError: isProjectError,
+  } = useQuery<ProjectDetailsResponseDto>({
+    queryKey: ['projectEditorInfo', teamId],
+    queryFn: async () => {
+      if (teamId === null) throw new Error('teamId is null');
+      return await getProjectDetails(teamId);
+    },
+    enabled: teamId !== null,
+  });
+
+  const { data: thumbnailUrl } = useQuery({
+    queryKey: ['thumbnail', teamId],
+    queryFn: async () => {
+      if (teamId === null) throw new Error('teamId is null');
+      return await getThumbnail(teamId);
+    },
+    enabled: teamId !== null,
+  });
+
+  const { data: previewData } = useQuery({
+    queryKey: ['previewImages', teamId, projectData?.previewIds],
+    queryFn: async () => {
+      if (teamId === null || !projectData?.previewIds) throw new Error('previewIds 없음');
+      return await getPreviewImages(teamId, projectData.previewIds);
+    },
+    enabled: teamId !== null && !!projectData?.previewIds?.length,
+  });
+
+  useEffect(() => {
+    if (projectData) {
+      setContestId(projectData.contestId);
+      setTeamName(projectData.teamName);
+      setProjectName(projectData.projectName);
+      setLeaderName(projectData.leaderName);
+      setTeamMembers(projectData.teamMembers);
+      setGithubUrl(projectData.githubPath);
+      setYoutubeUrl(projectData.youTubePath);
+      setProdUrl(projectData.productionPath);
+      setOverview(projectData.overview);
+    }
+  }, [projectData]);
+
+  useEffect(() => {
+    if (thumbnailUrl && typeof thumbnailUrl === 'string') {
+      setThumbnail(thumbnailUrl);
+    }
+  }, [thumbnailUrl]);
+
+  useEffect(() => {
+    if (previewData?.imageUrls && projectData?.previewIds) {
+      const paired = previewData.imageUrls.map((url, index) => ({
+        id: projectData.previewIds?.[index],
+        url,
+      }));
+      setPreviews(paired);
+    }
+  }, [previewData, projectData]);
+
+  if (!teamId) return <div>팀 정보를 불러올 수 없습니다.</div>;
+
+  if (isProjectLoading) return <EditorDetailSkeleton />;
+  if (isProjectError || !projectData) return <div>데이터를 가져오지 못했습니다.</div>;
+
+  if (!isAdmin) {
+    return <div>접근 권한이 없습니다.</div>;
+  }
+
+  const handleSave = async () => {
+    const contestIdToSubmit = contestId;
+    const validateProjectInputs = () => {
+      if (isAdmin) {
+        if (!projectName) return '프로젝트명이 입력되지 않았어요.';
+        if (!teamName) return '팀명이 입력되지 않았어요.';
+      }
+      if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
+      if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
+      if (!thumbnail && !previews.length) return '썸네일과 프리뷰 이미지가 모두 업로드되지 않았어요.';
+      if (!thumbnail) return '썸네일이 업로드 되지 않았어요.';
+      if (!previews.length) return '프리뷰 이미지가 업로드 되지 않았어요.';
+      if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
+      if (prodUrl && !isValidProjectUrl(prodUrl)) return '유효한 프로젝트 주소를 입력하세요.';
+      if (!isValidGithubUrl(githubUrl)) return '유효한 깃헙 URL을 입력하세요.';
+      if (!isValidYoutubeUrl(youtubeUrl)) return '유효한 유튜브 URL을 입력하세요.';
+      return null;
+    };
+
+    const errorMessage = validateProjectInputs();
+    if (errorMessage) {
+      toast(errorMessage, 'error');
+      return;
+    }
+
+    try {
+      await patchProjectDetails(teamId, {
+        contestId: isAdmin ? (contestIdToSubmit ?? projectData.contestId) : projectData.contestId,
+        teamName: isAdmin ? teamName : projectData.teamName,
+        projectName: isAdmin ? projectName : projectData.projectName,
+        leaderName: isAdmin ? leaderName : projectData.leaderName,
+        overview,
+        productionPath: prodUrl,
+        githubPath: githubUrl,
+        youTubePath: youtubeUrl,
+      });
+
+      const addedMembers = teamMembers.filter(
+        (member) => !projectData.teamMembers.some((existing) => existing.teamMemberId === member.teamMemberId),
+      );
+      const removedMembers = projectData.teamMembers.filter(
+        (member) => !teamMembers.some((existing) => existing.teamMemberId === member.teamMemberId),
+      );
+
+      const addMemberPromises = addedMembers.map(async (member) => await postMember(teamId, member.teamMemberName));
+      const removeMemberPromises = removedMembers.map(
+        async (member) => await deleteMember(teamId, member.teamMemberId),
+      );
+
+      await Promise.all([...addMemberPromises, ...removeMemberPromises]);
+
+      if (thumbnailToDelete) {
+        await deleteThumbnail(teamId);
+      }
+      if (thumbnail instanceof File) {
+        const formData = new FormData();
+        formData.append('image', thumbnail);
+        await postThumbnail(teamId, formData);
+      }
+
+      if (previewsToDelete.length > 0) {
+        await deletePreview(teamId, { imageIds: previewsToDelete });
+      }
+      const newFiles = previews.filter((p) => p.url instanceof File).map((p) => p.url as File);
+      if (newFiles.length > 0) {
+        const formData = new FormData();
+        newFiles.forEach((file) => formData.append('images', file));
+        await postPreview(teamId, formData);
+      }
+      queryClient.invalidateQueries({ queryKey: ['projectEditorInfo', teamId] });
+      queryClient.invalidateQueries({ queryKey: ['thumbnail', teamId] });
+      queryClient.invalidateQueries({ queryKey: ['previewImages', teamId] });
+      queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
+      toast('저장이 완료되었습니다.', 'success');
+      isLeaderOfThisTeam && navigate(`/teams/view/${teamId}`);
+    } catch (err: any) {
+      toast(err?.response?.data?.message || '저장 중 오류가 발생했습니다.', 'error');
+    }
+  };
+
+  const onMemberAdd = (newMemberName: string) => {
+    setTeamMembers((prevMembers) => [...prevMembers, { teamMemberId: Date.now(), teamMemberName: newMemberName }]);
+  };
+
+  const onMemberRemove = (index: number) => {
+    setTeamMembers((prevMembers) => prevMembers.filter((_, idx) => idx !== index));
+  };
+
+  return (
+    <div className="px-5">
+      <div className="text-title font-bold">프로젝트 생성/수정</div>
+      <div className="h-10" />
+      {isAdmin && (
+        <AdminInputSection
+          contestId={contestId}
+          setContestId={setContestId}
+          projectName={projectName}
+          setProjectName={setProjectName}
+          teamName={teamName}
+          setTeamName={setTeamName}
+          teamMembers={teamMembers}
+          onMemberAdd={onMemberAdd}
+          onMemberRemove={onMemberRemove}
+        />
+      )}
+
+      {isLeaderOfThisTeam && (
+        <IntroSection
+          projectName={projectName}
+          teamName={teamName}
+          leaderName={leaderName}
+          teamMembers={teamMembers} // WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의
+        />
+      )}
+
+      <div className="h-15" />
+
+      <UrlInput
+        prodUrl={prodUrl}
+        setProdUrl={setProdUrl}
+        githubUrl={githubUrl}
+        setGithubUrl={setGithubUrl}
+        youtubeUrl={youtubeUrl}
+        setYoutubeUrl={setYoutubeUrl}
+      />
+
+      <div className="h-15" />
+
+      <ImageUploaderSection
+        thumbnail={thumbnail}
+        setThumbnail={setThumbnail}
+        previews={previews}
+        setPreviews={setPreviews}
+        setThumbnailToDelete={setThumbnailToDelete}
+        previewsToDelete={previewsToDelete}
+        setPreviewsToDelete={setPreviewsToDelete}
+      />
+
+      <div className="h-15" />
+
+      <OverviewInput overview={overview} setOverview={setOverview} />
+
+      <div className="h-20" />
+
+      <div className="flex justify-end gap-5 sm:gap-10">
+        <button
+          onClick={() => navigate(-1)}
+          className="border-mainGreen hover:bg-whiteGray focus:bg-subGreen text-mainGreen rounded-full border px-4 py-2 font-bold hover:cursor-pointer focus:outline-none sm:px-15 sm:py-4"
+        >
+          취소
+        </button>
+        <button
+          onClick={handleSave}
+          className="bg-mainGreen rounded-full px-4 py-2 text-sm font-bold text-white hover:cursor-pointer hover:bg-green-700 focus:bg-green-400 focus:outline-none sm:px-15 sm:py-4"
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCreatorPage;

--- a/src/pages/project-editor/ProjectCreatorPage.tsx
+++ b/src/pages/project-editor/ProjectCreatorPage.tsx
@@ -62,42 +62,54 @@ const ProjectCreatorPage = () => {
     }
   }, [contestIdFromParams]);
 
-  const handleSave = async () => {
-    const validateProjectInputs = () => {
-      if (isAdmin) {
-        if (!projectName) return '프로젝트명이 입력되지 않았어요.';
-        if (!teamName) return '팀명이 입력되지 않았어요.';
-        if (!leaderName) return '팀장명이 입력되지 않았어요.';
-      }
-      if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
-      if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
-      if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
-      if (prodUrl && !isValidProjectUrl(prodUrl)) return '유효한 프로젝트 주소를 입력하세요.';
-      if (!isValidGithubUrl(githubUrl)) return '유효한 깃헙 URL을 입력하세요.';
-      if (!isValidYoutubeUrl(youtubeUrl)) return '유효한 유튜브 URL을 입력하세요.';
-      return null;
-    };
+  if (!contestId) return <div>생성할 프로젝트 소속을 찾을 수 없습니다.</div>;
 
-    const errorMessage = validateProjectInputs();
-    if (errorMessage) {
-      toast(errorMessage, 'error');
-      return;
-    }
+  const handleSave = async () => {
+    // const validateProjectInputs = () => {
+    //   if (isAdmin) {
+    //     if (!projectName) return '프로젝트명이 입력되지 않았어요.';
+    //     if (!teamName) return '팀명이 입력되지 않았어요.';
+    //     if (!leaderName) return '팀장명이 입력되지 않았어요.';
+    //   }
+    //   if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
+    //   if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
+    //   if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
+    //   if (prodUrl && !isValidProjectUrl(prodUrl)) return '유효한 프로젝트 주소를 입력하세요.';
+    //   if (!isValidGithubUrl(githubUrl)) return '유효한 깃헙 URL을 입력하세요.';
+    //   if (!isValidYoutubeUrl(youtubeUrl)) return '유효한 유튜브 URL을 입력하세요.';
+    //   return null;
+    // };
+
+    // const errorMessage = validateProjectInputs();
+    // if (errorMessage) {
+    //   toast(errorMessage, 'error');
+    //   return;
+    // }
 
     try {
-      await createProjectDetails({
-        contestId: contestId ?? 0,
-        teamName: teamName,
-        projectName: projectName,
-        leaderName: leaderName,
-        overview,
-        productionPath: prodUrl,
-        githubPath: githubUrl,
-        youTubePath: youtubeUrl,
+      // await createProjectDetails({
+      //   contestId: contestId,
+      //   teamName: teamName,
+      //   projectName: projectName,
+      //   leaderName: leaderName,
+      //   overview,
+      //   productionPath: prodUrl,
+      //   githubPath: githubUrl,
+      //   youTubePath: youtubeUrl,
+      // });
+      const response = await createProjectDetails({
+        contestId: contestId,
+        teamName: '팀 이름',
+        projectName: '프로젝트 이름',
+        leaderName: '팀장 이름',
+        overview: '프로젝트 소개글',
+        productionPath: '',
+        githubPath: 'https://github.com/2025-PNU-SW-Hackathon',
+        youTubePath: 'https://youtu.be/CYoK_cuG8lU',
       });
-
+      const createdTeamId = response.teamId;
       toast('저장이 완료되었습니다.', 'success');
-      // isAdmin && navigate(`/teams/view/${teamId}`);
+      isAdmin && navigate(`/teams/edit/${createdTeamId}`);
     } catch (err: any) {
       toast(err?.response?.data?.message || '저장 중 오류가 발생했습니다.', 'error');
     }

--- a/src/pages/project-editor/ProjectCreatorPage.tsx
+++ b/src/pages/project-editor/ProjectCreatorPage.tsx
@@ -41,10 +41,6 @@ const ProjectCreatorPage = () => {
   const [teamName, setTeamName] = useState('');
   const [projectName, setProjectName] = useState('');
   const [leaderName, setLeaderName] = useState('');
-  const [thumbnail, setThumbnail] = useState<string | File | undefined>();
-  const [thumbnailToDelete, setThumbnailToDelete] = useState<boolean>(false);
-  const [previews, setPreviews] = useState<PreviewImage[]>([]);
-  const [previewsToDelete, setPreviewsToDelete] = useState<number[]>([]);
   const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
   const [prodUrl, setProdUrl] = useState<string | null>(null);
   const [githubUrl, setGithubUrl] = useState('');
@@ -71,12 +67,10 @@ const ProjectCreatorPage = () => {
       if (isAdmin) {
         if (!projectName) return '프로젝트명이 입력되지 않았어요.';
         if (!teamName) return '팀명이 입력되지 않았어요.';
+        if (!leaderName) return '팀장명이 입력되지 않았어요.';
       }
       if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
       if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
-      // if (!thumbnail && !previews.length) return '썸네일과 프리뷰 이미지가 모두 업로드되지 않았어요.';
-      // if (!thumbnail) return '썸네일이 업로드 되지 않았어요.';
-      // if (!previews.length) return '프리뷰 이미지가 업로드 되지 않았어요.';
       if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
       if (prodUrl && !isValidProjectUrl(prodUrl)) return '유효한 프로젝트 주소를 입력하세요.';
       if (!isValidGithubUrl(githubUrl)) return '유효한 깃헙 URL을 입력하세요.';
@@ -84,9 +78,6 @@ const ProjectCreatorPage = () => {
       return null;
     };
 
-    //       productionPath: 'https://swedu.pusan.ac.kr
-    //       githubPath: 'https://github.com/2025-PNU-SW-Hackathon
-    //       youTubePath: 'https://youtu.be/CYoK_cuG8lU?si=Ql7WWbzy8wgIpawI
     const errorMessage = validateProjectInputs();
     if (errorMessage) {
       toast(errorMessage, 'error');
@@ -105,44 +96,8 @@ const ProjectCreatorPage = () => {
         youTubePath: youtubeUrl,
       });
 
-      // const addedMembers = teamMembers.filter(
-      //   (member) => !projectData.teamMembers.some((existing) => existing.teamMemberId === member.teamMemberId),
-      // );
-      // const removedMembers = projectData.teamMembers.filter(
-      //   (member) => !teamMembers.some((existing) => existing.teamMemberId === member.teamMemberId),
-      // );
-
-      // const addMemberPromises = addedMembers.map(async (member) => await postMember(teamId, member.teamMemberName));
-      // const removeMemberPromises = removedMembers.map(
-      //   async (member) => await deleteMember(teamId, member.teamMemberId),
-      // );
-
-      // await Promise.all([...addMemberPromises, ...removeMemberPromises]);
-
-      // if (thumbnailToDelete) {
-      //   await deleteThumbnail(teamId);
-      // }
-      // if (thumbnail instanceof File) {
-      //   const formData = new FormData();
-      //   formData.append('image', thumbnail);
-      //   await postThumbnail(teamId, formData);
-      // }
-
-      // if (previewsToDelete.length > 0) {
-      //   await deletePreview(teamId, { imageIds: previewsToDelete });
-      // }
-      // const newFiles = previews.filter((p) => p.url instanceof File).map((p) => p.url as File);
-      // if (newFiles.length > 0) {
-      //   const formData = new FormData();
-      //   newFiles.forEach((file) => formData.append('images', file));
-      //   await postPreview(teamId, formData);
-      // }
-      // queryClient.invalidateQueries({ queryKey: ['projectEditorInfo', teamId] });
-      // queryClient.invalidateQueries({ queryKey: ['thumbnail', teamId] });
-      // queryClient.invalidateQueries({ queryKey: ['previewImages', teamId] });
-      // queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
       toast('저장이 완료되었습니다.', 'success');
-      // isLeaderOfThisTeam && navigate(`/teams/view/${teamId}`);
+      // isAdmin && navigate(`/teams/view/${teamId}`);
     } catch (err: any) {
       toast(err?.response?.data?.message || '저장 중 오류가 발생했습니다.', 'error');
     }

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import useAuth from 'hooks/useAuth';
-import { useTeamId } from 'hooks/useTeamId';
+import { useTeamId } from 'hooks/useId';
 import { useToast } from 'hooks/useToast';
 
 import { getProjectDetails, getPreviewImages } from 'apis/projectViewer';
@@ -94,7 +94,7 @@ const ProjectEditorPage = () => {
       setLeaderName(projectData.leaderName);
       setTeamMembers(projectData.teamMembers);
       setGithubUrl(projectData.githubPath);
-      setYoutubeUrl(projectData.youTubePath);
+      setYoutubeUrl(projectData.youtubePath);
       setProdUrl(projectData.productionPath);
       setOverview(projectData.overview);
     }
@@ -200,7 +200,7 @@ const ProjectEditorPage = () => {
       queryClient.invalidateQueries({ queryKey: ['previewImages', teamId] });
       queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
       toast('저장이 완료되었습니다.', 'success');
-      isLeaderOfThisTeam && navigate(`/teams/view/${teamId}`);
+      (isLeaderOfThisTeam || isAdmin) && navigate(`/teams/view/${teamId}`);
     } catch (err: any) {
       toast(err?.response?.data?.message || '저장 중 오류가 발생했습니다.', 'error');
     }
@@ -226,6 +226,8 @@ const ProjectEditorPage = () => {
           setProjectName={setProjectName}
           teamName={teamName}
           setTeamName={setTeamName}
+          leaderName={leaderName}
+          setLeaderName={setLeaderName}
           teamMembers={teamMembers}
           onMemberAdd={onMemberAdd}
           onMemberRemove={onMemberRemove}

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -253,18 +253,20 @@ const ProjectEditorPage = () => {
         youtubeUrl={youtubeUrl}
         setYoutubeUrl={setYoutubeUrl}
       />
-
-      <div className="h-15" />
-
-      <ImageUploaderSection
-        thumbnail={thumbnail}
-        setThumbnail={setThumbnail}
-        previews={previews}
-        setPreviews={setPreviews}
-        setThumbnailToDelete={setThumbnailToDelete}
-        previewsToDelete={previewsToDelete}
-        setPreviewsToDelete={setPreviewsToDelete}
-      />
+      {isAdmin && (
+        <>
+          <div className="h-15" />
+          <ImageUploaderSection
+            thumbnail={thumbnail}
+            setThumbnail={setThumbnail}
+            previews={previews}
+            setPreviews={setPreviews}
+            setThumbnailToDelete={setThumbnailToDelete}
+            previewsToDelete={previewsToDelete}
+            setPreviewsToDelete={setPreviewsToDelete}
+          />
+        </>
+      )}
 
       <div className="h-15" />
 

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -94,7 +94,7 @@ const ProjectEditorPage = () => {
       setLeaderName(projectData.leaderName);
       setTeamMembers(projectData.teamMembers);
       setGithubUrl(projectData.githubPath);
-      setYoutubeUrl(projectData.youtubePath);
+      setYoutubeUrl(projectData.youTubePath);
       setProdUrl(projectData.productionPath);
       setOverview(projectData.overview);
     }

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -133,11 +133,14 @@ const ProjectEditorPage = () => {
         if (!projectName) return '프로젝트명이 입력되지 않았어요.';
         if (!teamName) return '팀명이 입력되지 않았어요.';
       }
+      if (isLeaderOfThisTeam) {
+        if (!thumbnail && !previews.length) return '썸네일과 프리뷰 이미지가 모두 업로드되지 않았어요.';
+        if (!thumbnail) return '썸네일이 업로드 되지 않았어요.';
+        if (!previews.length) return '프리뷰 이미지가 업로드 되지 않았어요.';
+      }
       if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
       if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
-      if (!thumbnail && !previews.length) return '썸네일과 프리뷰 이미지가 모두 업로드되지 않았어요.';
-      if (!thumbnail) return '썸네일이 업로드 되지 않았어요.';
-      if (!previews.length) return '프리뷰 이미지가 업로드 되지 않았어요.';
+
       if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
       if (prodUrl && !isValidProjectUrl(prodUrl)) return '유효한 프로젝트 주소를 입력하세요.';
       if (!isValidGithubUrl(githubUrl)) return '유효한 깃헙 URL을 입력하세요.';
@@ -253,7 +256,7 @@ const ProjectEditorPage = () => {
         youtubeUrl={youtubeUrl}
         setYoutubeUrl={setYoutubeUrl}
       />
-      {isAdmin && (
+      {isLeaderOfThisTeam && (
         <>
           <div className="h-15" />
           <ImageUploaderSection

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -10,6 +10,7 @@ import Spinner from '@components/Spinner';
 
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import { FaSadTear } from 'react-icons/fa';
+import { CgSandClock } from 'react-icons/cg';
 
 interface CarouselSectionProps {
   teamId: number;
@@ -106,12 +107,21 @@ const MediaRenderer = ({
     return <iframe src={embedUrl} title="Youtube Iframe" allowFullScreen className="absolute inset-0 h-full w-full" />;
   }
 
+  if (currentImage === 'ERROR_409') {
+    return (
+      <div className="text-lightGray border-lightGray flex h-full w-full flex-col items-center justify-center gap-5 border">
+        <CgSandClock size={40} />
+        <span className="text-xs">서버에서 이미지 변환 중입니다. 나중에 시도해 주세요.</span>
+      </div>
+    );
+  }
+
   return (
     <>
       {!imageLoaded && (
-      <div className="absolute inset-0 flex h-full w-full items-center justify-center bg-white">
-        <Spinner />
-      </div>
+        <div className="absolute inset-0 flex h-full w-full items-center justify-center bg-white">
+          <Spinner />
+        </div>
       )}
       <img
         src={currentImage}

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -9,6 +9,7 @@ import { RiLink } from 'react-icons/ri';
 import { FiExternalLink } from 'react-icons/fi';
 
 interface IntroSectionProps {
+  contestId: number;
   teamId: number;
   leaderId: number;
   projectName: string;
@@ -51,6 +52,7 @@ const UrlButton = ({ url }: { url: string }) => {
 };
 
 const IntroSection = ({
+  contestId,
   teamId,
   leaderId,
   projectName,
@@ -59,8 +61,9 @@ const IntroSection = ({
   githubUrl,
   youtubeUrl,
 }: IntroSectionProps) => {
-  const { isLeader } = useAuth();
+  const { isLeader, isAdmin } = useAuth();
   const memberId = useUserStore((state) => state.user?.id);
+  const isLeaderOfThisTeam = isLeader && memberId == leaderId;
   const navigate = useNavigate();
 
   return (
@@ -70,7 +73,7 @@ const IntroSection = ({
           <div className="text-title min-w-0 leading-none font-bold">{projectName}</div>
           <div className="text-smbold font-bold text-[#4B5563]">{teamName}</div>
         </div>
-        {isLeader && memberId === leaderId && (
+        {(isLeaderOfThisTeam || (isAdmin && contestId !== 1)) && (
           <div className="flex pt-3">
             <button
               onClick={() => navigate(`/teams/edit/${teamId}`)}

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -58,6 +58,7 @@ const ProjectViewerPage = () => {
   return (
     <div className="px-5">
       <IntroSection
+        contestId={data.contestId}
         teamId={data.teamId}
         leaderId={data.leaderId}
         projectName={data.projectName}

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useTeamId } from 'hooks/useTeamId';
+import { useTeamId } from 'hooks/useId';
 import { useUserStore } from 'stores/useUserStore';
 import { getProjectDetails } from 'apis/projectViewer';
 
@@ -64,10 +64,10 @@ const ProjectViewerPage = () => {
         teamName={data.teamName}
         prodUrl={data.productionPath}
         githubUrl={data.githubPath}
-        youtubeUrl={data.youTubePath}
+        youtubeUrl={data.youtubePath}
       />
       <div className="h-10" />
-      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youTubePath} />
+      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youtubePath} />
       <div className="h-10" />
       <LikeSection teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -64,10 +64,10 @@ const ProjectViewerPage = () => {
         teamName={data.teamName}
         prodUrl={data.productionPath}
         githubUrl={data.githubPath}
-        youtubeUrl={data.youtubePath}
+        youtubeUrl={data.youTubePath}
       />
       <div className="h-10" />
-      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youtubePath} />
+      <CarouselSection teamId={data.teamId} previewIds={data.previewIds} youtubeUrl={data.youTubePath} />
       <div className="h-10" />
       <LikeSection teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />

--- a/src/route/AdminTabs.tsx
+++ b/src/route/AdminTabs.tsx
@@ -4,6 +4,7 @@ import OngoingContestsTab from '@pages/admin/OngoingContestsTab';
 import ManageNoticeListTab from '@pages/admin/NoticeManageTab/ManageNoticeListTab';
 import NoticeCreateTab from '@pages/admin/NoticeManageTab/NoticeCreateTab';
 import NoticeEditTab from '@pages/admin/NoticeManageTab/NoticeEditTab';
+import ProjectCreatorPage from '@pages/project-editor/ProjectCreatorPage';
 
 const AdminTabs: RouteObject[] = [
   { index: true, path: 'ongoing', element: <OngoingContestsTab />, handle: { label: '진행 중 대회' } },
@@ -19,7 +20,14 @@ const AdminTabs: RouteObject[] = [
       { path: 'create', element: <NoticeCreateTab /> },
     ],
   },
-  { path: 'contest', element: <ContestAdminTab />, handle: { label: '대회 관리' } },
+  {
+    path: 'contest',
+    handle: { label: '대회 관리' },
+    children: [
+      { index: true, element: <ContestAdminTab /> },
+      { path: 'create/:contestId', element: <ProjectCreatorPage /> },
+    ],
+  },
 ];
 
 export default AdminTabs;

--- a/src/route/AdminTabs.tsx
+++ b/src/route/AdminTabs.tsx
@@ -4,7 +4,6 @@ import OngoingContestsTab from '@pages/admin/OngoingContestsTab';
 import ManageNoticeListTab from '@pages/admin/NoticeManageTab/ManageNoticeListTab';
 import NoticeCreateTab from '@pages/admin/NoticeManageTab/NoticeCreateTab';
 import NoticeEditTab from '@pages/admin/NoticeManageTab/NoticeEditTab';
-import ProjectCreatorPage from '@pages/project-editor/ProjectCreatorPage';
 
 const AdminTabs: RouteObject[] = [
   { index: true, path: 'ongoing', element: <OngoingContestsTab />, handle: { label: '진행 중 대회' } },
@@ -23,10 +22,7 @@ const AdminTabs: RouteObject[] = [
   {
     path: 'contest',
     handle: { label: '대회 관리' },
-    children: [
-      { index: true, element: <ContestAdminTab /> },
-      { path: 'create/:contestId', element: <ProjectCreatorPage /> },
-    ],
+    children: [{ index: true, element: <ContestAdminTab /> }],
   },
 ];
 

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -16,7 +16,7 @@ export interface ProjectDetailsResponseDto {
   previewIds: number[];
   productionPath: string | null;
   githubPath: string;
-  youTubePath: string;
+  youtubePath: string;
   isLiked: boolean;
 }
 

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -16,7 +16,7 @@ export interface ProjectDetailsResponseDto {
   previewIds: number[];
   productionPath: string | null;
   githubPath: string;
-  youtubePath: string;
+  youTubePath: string;
   isLiked: boolean;
 }
 


### PR DESCRIPTION
### 📝 개요
- 정상적인 백엔드 API 연결 후 `ProjectEditorPage.tsx`를 재활용하여 아래 문제는 해결되었습니다.
> 우선 프로젝트가 POST 되는 것만 테스트하기 위해 `ProjectCreatorPage.tsx`를 구현하였습니다.
> POST 후 teamId가 발급되고 이전 대회 리스트에도 뜨는 것을 확인했으나 뷰어 페이지에서 렌더링이 안돼서 이 부분은 확인 후 수정하겠습니다.
- 서버에서 webp로 변환 중인 이미지를 `ERROR_409`로 분류하여, 안내 메시지가 뜨도록 구현하였습니다.
- 관리자 페이지에서 수정 또는 삭제 시 아래로 리다이렉트 또는 토스트 메시지가 뜨도록 설계하였습니다.
  - 현재 진행 중인 대회(제6회PNU창의융합해커톤)의 프로젝트들을 수정 또는 삭제하는 경우: 토스트 메시지를 띄웁니다.
  - 이전 대회의 프로젝트들을 수정하는 경우: 팀장 수정 페이지에서 보았던 것처럼 수정 페이지로 리다이렉트됩니다.
- 관리자 페이지에서 프로젝트 생성이 가능하도록 구현하였습니다. 시나리오는 다음과 같습니다.
  - `프로젝트 생성하기` 버튼 클릭 시 POST API 호출하여 `teamId`를 response로 받는다.
  - `response.teamId`를 수정 페이지의 URI 파라미터로 붙여 리다이렉트한다.
  - 수정 페이지에서 프로젝트 편집을 한다.

### 🎯 목적
- 관리자의 기능 추가 구현을 위함입니다.

### ✨ 변경 사항
- 기존 컴포넌트 활용을 위해 `isLeader`, `isAdmin` (useAuth), `isLeaderOfThisTeam`을 활용하였습니다.
- `useContestAdmin` 훅에 `handleCreateTeam` 핸들러를 추가하였습니다.

### 🔬 리뷰 요구 사항 (선택)
- QA에서 부탁드립니다!

### 💬 논의 사항 (선택)
- QA에 남기도록 하겠습니다!

### 📸 참고 이미지/영상 (선택)

https://github.com/user-attachments/assets/acce099f-1350-4d33-8199-f992429712fb

