### PR TITLE
Fix: 팀원 추가 API 호출 시 DTO 사용

### DIFF
--- a/src/apis/projectEditor.ts
+++ b/src/apis/projectEditor.ts
@@ -44,8 +44,8 @@ export const deletePreview = async (teamId: number, body: PreviewDeleteRequestDt
   return response.data;
 };
 
-export const postMember = async (teamId: number, teamMemberName: string) => {
-  const response = await apiClient.post(`/teams/${teamId}/members`, teamMemberName);
+export const postMember = async (teamId: number, body: TeamMemberCreateRequestDto) => {
+  const response = await apiClient.post(`/teams/${teamId}/members`, body);
   return response.data;
 };
 

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -173,7 +173,9 @@ const ProjectEditorPage = () => {
         (member) => !teamMembers.some((existing) => existing.teamMemberId === member.teamMemberId),
       );
 
-      const addMemberPromises = addedMembers.map(async (member) => await postMember(teamId, member.teamMemberName));
+      const addMemberPromises = addedMembers.map(
+        async (member) => await postMember(teamId, { teamMemberName: member.teamMemberName }),
+      );
       const removeMemberPromises = removedMembers.map(
         async (member) => await deleteMember(teamId, member.teamMemberId),
       );


### PR DESCRIPTION
### 📝 개요
- 팀원 추가 API 호출 시 DTO 사용 오류로 `권한이 없습니다.` 메시지 뜨던 오류를 해결하였습니다.

### ✨ 변경 사항
- API 호출 인자를 `teamMemberName: string`에서 `body: TeamMemberCreateRequestDto`로 변경하였습니다.

### 📸 참고 이미지/영상 (선택)

https://github.com/user-attachments/assets/46722834-7ff6-4541-a0c6-7bc9fe2d0689

