### PR TITLE
design: 관리자페이지 탭 및  버튼 width 수정

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ const Button = ({ className = '', children, ...props }: Props) => {
   return (
     <button
       className={twMerge(
-        'flex h-12 items-center justify-center rounded-md px-2 py-1 text-center text-sm text-white hover:cursor-pointer',
+        'flex h-12 min-w-[85px] items-center justify-center rounded-md px-2 py-1 text-center text-sm text-white hover:cursor-pointer',
         className,
       )}
       {...props}

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -22,7 +22,7 @@ const AdminPage = () => {
           <Link
             key={tab.path}
             to={`/admin/${tab.path}`}
-            className={`min-w-16 rounded-lg px-4 py-2 text-lg ${
+            className={`flex min-w-[137px] justify-center rounded-lg px-4 py-2 text-lg ${
               pathname.includes(tab.path ?? '') ? 'bg-subGreen text-black' : 'bg-gray-100 text-gray-400'
             }`}
           >

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -85,16 +85,10 @@ const ContestAdminTab = () => {
           rows={contests ?? []}
           actions={(row) => (
             <>
-              <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
-                onClick={() => handleDeleteContest(row.contestId)}
-              >
+              <Button className="bg-mainRed h-[35px] w-full" onClick={() => handleDeleteContest(row.contestId)}>
                 삭제하기
               </Button>
-              <Button
-                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
-                onClick={() => openEditModal(row.contestId)}
-              >
+              <Button className="bg-mainGreen h-[35px] w-full" onClick={() => openEditModal(row.contestId)}>
                 수정하기
               </Button>
             </>
@@ -131,7 +125,7 @@ const ContestAdminTab = () => {
           actions={(row) => (
             <>
               <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
+                className="bg-mainRed h-[35px] w-full"
                 onClick={() => {
                   if (state.currentContestId == 1)
                     toast('현재 진행 중인 대회의 프로젝트를 삭제할 수 없습니다.', 'error');
@@ -146,7 +140,7 @@ const ContestAdminTab = () => {
                     toast('현재 진행 중인 대회의 프로젝트를 수정할 수 없습니다.', 'info');
                   state.currentContestId !== 1 && navigate(`/teams/edit/${row.teamId}`);
                 }}
-                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
+                className="bg-mainGreen h-[35px] w-full"
               >
                 수정하기
               </Button>
@@ -157,7 +151,7 @@ const ContestAdminTab = () => {
         <div className="mt-8 flex w-full flex-row-reverse">
           <Button
             onClick={() => handleCreateTeam(state.currentContestId)}
-            className="bg-mainBlue h-12 w-[20%] min-w-[130px]"
+            className="bg-mainBlue h-12 w-[20%] min-w-[160px]"
           >
             프로젝트 생성하기
           </Button>

--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -45,7 +45,7 @@ const ManageNoticeListTab = () => {
           actions={(row) => (
             <>
               <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
+                className="bg-mainRed h-[35px] w-full"
                 onClick={() => {
                   mutation.mutate(row.noticeId);
                 }}
@@ -53,7 +53,7 @@ const ManageNoticeListTab = () => {
                 삭제하기
               </Button>
               <Button
-                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
+                className="bg-mainGreen h-[35px] w-full"
                 onClick={() => {
                   navigate(`/admin/notice/edit/${row.noticeId}`);
                 }}


### PR DESCRIPTION
### 📝 개요
관리자페이지 탭 및  버튼 width 수정
### 🎯 목적
화면 줄어들때 관리자페이지 탭 버튼 찌그러짐 현상
공지사항 및 대회관리 테이블에 버튼도 마찬가지 
### ✨ 변경 사항
탭 버튼 min-w-[137px]로 수정 (min-w-32 이런걸로 할려다가 너무 여백이 많이 생겨 px로 했습니다.)
Notice 테이블 버튼,ContestAdmin 테이블 버튼 전부 min-w-70 삭제하고  Button Component에 min-w-[85px] 추가

### 📸 참고 이미지/영상
<img width="441" alt="스크린샷 2025-07-09 오후 12 00 32" src="https://github.com/user-attachments/assets/c2b1856f-af62-4d08-a813-16c22704958c" />
