### PR TITLE
fix: 히스토리 클릭 시 Menu 닫히게 수정

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ const Button = ({ className = '', children, ...props }: Props) => {
   return (
     <button
       className={twMerge(
-        'flex h-12 items-center justify-center rounded-md px-2 py-1 text-center text-sm text-white hover:cursor-pointer',
+        'flex h-12 min-w-[85px] items-center justify-center rounded-md px-2 py-1 text-center text-sm text-white hover:cursor-pointer',
         className,
       )}
       {...props}

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -22,7 +22,7 @@ const AdminPage = () => {
           <Link
             key={tab.path}
             to={`/admin/${tab.path}`}
-            className={`min-w-16 rounded-lg px-4 py-2 text-lg ${
+            className={`flex min-w-[137px] justify-center rounded-lg px-4 py-2 text-lg ${
               pathname.includes(tab.path ?? '') ? 'bg-subGreen text-black' : 'bg-gray-100 text-gray-400'
             }`}
           >

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -85,16 +85,10 @@ const ContestAdminTab = () => {
           rows={contests ?? []}
           actions={(row) => (
             <>
-              <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
-                onClick={() => handleDeleteContest(row.contestId)}
-              >
+              <Button className="bg-mainRed h-[35px] w-full" onClick={() => handleDeleteContest(row.contestId)}>
                 삭제하기
               </Button>
-              <Button
-                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
-                onClick={() => openEditModal(row.contestId)}
-              >
+              <Button className="bg-mainGreen h-[35px] w-full" onClick={() => openEditModal(row.contestId)}>
                 수정하기
               </Button>
             </>
@@ -131,7 +125,7 @@ const ContestAdminTab = () => {
           actions={(row) => (
             <>
               <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
+                className="bg-mainRed h-[35px] w-full"
                 onClick={() => {
                   if (state.currentContestId == 1)
                     toast('현재 진행 중인 대회의 프로젝트를 삭제할 수 없습니다.', 'error');
@@ -146,7 +140,7 @@ const ContestAdminTab = () => {
                     toast('현재 진행 중인 대회의 프로젝트를 수정할 수 없습니다.', 'info');
                   state.currentContestId !== 1 && navigate(`/teams/edit/${row.teamId}`);
                 }}
-                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
+                className="bg-mainGreen h-[35px] w-full"
               >
                 수정하기
               </Button>
@@ -157,7 +151,7 @@ const ContestAdminTab = () => {
         <div className="mt-8 flex w-full flex-row-reverse">
           <Button
             onClick={() => handleCreateTeam(state.currentContestId)}
-            className="bg-mainBlue h-12 w-[20%] min-w-[130px]"
+            className="bg-mainBlue h-12 w-[20%] min-w-[160px]"
           >
             프로젝트 생성하기
           </Button>

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -10,7 +10,6 @@ import Table from '@components/Table';
 import { ContestResponseDto } from 'types/DTO';
 import { TeamListItemResponseDto } from 'types/DTO/teams/teamListDto';
 import { IoIosArrowDown } from 'react-icons/io';
-// import DeleteInfoModal from '@pages/admin/DeleteInfoModal';
 import EditModal from '@pages/admin/EditModal';
 import useContestAdmin from 'hooks/useContestAdmin';
 
@@ -20,33 +19,27 @@ type HistoryMenuProps = {
 };
 
 const HistoryMenu = ({ contestName, onContestChange }: HistoryMenuProps) => {
-  const [isOpen, setIsOpen] = useState(false);
   const { data: contests } = useQuery({ queryKey: ['contests'], queryFn: getAllContests });
 
   return (
-    <div className="relative inline-block" onMouseEnter={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
-      <div className="hover:text-mainGreen flex pt-1 pb-4">
-        <button>{contestName}</button>
-        <IoIosArrowDown className="text-mainGreen text-2xl" />
-      </div>
-
-      {isOpen && contests && (
-        <ul className="border-subGreen absolute z-50 w-fit border-2 bg-white text-base font-normal text-nowrap">
-          {contests.map((contest: ContestResponseDto) => (
-            <li key={contest.contestId}>
-              <button
-                onClick={() => {
-                  onContestChange(contest.contestName, contest.contestId);
-                  setIsOpen(false);
-                }}
-                className="hover:text-mainGreen hover:bg-whiteGray block w-full p-4 transition-colors duration-200 ease-in"
-              >
-                {contest.contestName}
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="relative inline-block">
+      <select
+        value={contestName}
+        onChange={(e) => {
+          const selectedContest = contests?.find((contest) => contest.contestName === e.target.value);
+          if (selectedContest) {
+            onContestChange(selectedContest.contestName, selectedContest.contestId);
+          }
+        }}
+        className="border-subGreen appearance-none rounded border-b-2 bg-white px-4 py-2 pr-10 text-nowrap focus:outline-none"
+      >
+        {contests?.map((contest: ContestResponseDto) => (
+          <option key={contest.contestId} value={contest.contestName}>
+            {contest.contestName}
+          </option>
+        ))}
+      </select>
+      <IoIosArrowDown className="text-mainGreen pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-lg" />
     </div>
   );
 };

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -35,7 +35,10 @@ const HistoryMenu = ({ contestName, onContestChange }: HistoryMenuProps) => {
           {contests.map((contest: ContestResponseDto) => (
             <li key={contest.contestId}>
               <button
-                onClick={() => onContestChange(contest.contestName, contest.contestId)}
+                onClick={() => {
+                  onContestChange(contest.contestName, contest.contestId);
+                  setIsOpen(false);
+                }}
                 className="hover:text-mainGreen hover:bg-whiteGray block w-full p-4 transition-colors duration-200 ease-in"
               >
                 {contest.contestName}

--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -31,7 +31,7 @@ const HistoryMenu = ({ contestName, onContestChange }: HistoryMenuProps) => {
             onContestChange(selectedContest.contestName, selectedContest.contestId);
           }
         }}
-        className="border-subGreen appearance-none rounded border-b-2 bg-white px-4 py-2 pr-10 text-nowrap focus:outline-none"
+        className="border-subGreen cursor-pointer appearance-none rounded border-b-2 bg-white px-4 py-2 pr-10 text-nowrap focus:outline-none"
       >
         {contests?.map((contest: ContestResponseDto) => (
           <option key={contest.contestId} value={contest.contestName}>

--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -45,7 +45,7 @@ const ManageNoticeListTab = () => {
           actions={(row) => (
             <>
               <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
+                className="bg-mainRed h-[35px] w-full"
                 onClick={() => {
                   mutation.mutate(row.noticeId);
                 }}
@@ -53,7 +53,7 @@ const ManageNoticeListTab = () => {
                 삭제하기
               </Button>
               <Button
-                className="bg-mainGreen h-[35px] w-full min-w-[70px]"
+                className="bg-mainGreen h-[35px] w-full"
                 onClick={() => {
                   navigate(`/admin/notice/edit/${row.noticeId}`);
                 }}


### PR DESCRIPTION
### 📝 개요
관리자 대회관리 탭 아래 히스토리 검색 시 Menu 닫히게 수정
### 🎯 목적
클릭했는데 계속 Menu가 안닫혀서 isOpen(false)로 닫히게 수정
### ✨ 변경 사항
button 에 간단히 isOpen 을 false로 수정했습니다.
`onClick={() => {
                  onContestChange(contest.contestName, contest.contestId);
                  setIsOpen(false);
                }}`