### PR TITLE
Fix: 대회에 수정 대한 관리자 수정/삭제 기능 보강

### DIFF
--- a/src/pages/admin/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestAdminTab.tsx
@@ -130,22 +130,11 @@ const ContestAdminTab = () => {
           rows={state.contestTeams}
           actions={(row) => (
             <>
-              <Button
-                className="bg-mainRed h-[35px] w-full min-w-[70px]"
-                onClick={() => {
-                  if (state.currentContestId == 1)
-                    toast('현재 진행 중인 대회의 프로젝트를 삭제할 수 없습니다.', 'error');
-                  state.currentContestId !== 1 && handleDeleteTeam(row.teamId);
-                }}
-              >
+              <Button className="bg-mainRed h-[35px] w-full min-w-[70px]" onClick={() => handleDeleteTeam(row.teamId)}>
                 삭제하기
               </Button>
               <Button
-                onClick={() => {
-                  if (state.currentContestId == 1)
-                    toast('현재 진행 중인 대회의 프로젝트를 수정할 수 없습니다.', 'info');
-                  state.currentContestId !== 1 && navigate(`/teams/edit/${row.teamId}`);
-                }}
+                onClick={() => navigate(`/teams/edit/${row.teamId}`)}
                 className="bg-mainGreen h-[35px] w-full min-w-[70px]"
               >
                 수정하기

--- a/src/pages/project-editor/AdminInputSection/ContestMenu.tsx
+++ b/src/pages/project-editor/AdminInputSection/ContestMenu.tsx
@@ -47,22 +47,20 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
   return (
     <div className="relative w-full max-w-sm text-sm">
       <button
-        className="border-lightGray flex w-full items-center justify-between rounded-md border-2 px-5 py-3 text-left hover:cursor-pointer"
+        className="border-lightGray focus:ring-subGreen focus:border-subGreen flex w-full items-center justify-between rounded-md border-2 px-5 py-3 text-left duration-150 hover:cursor-pointer focus:outline-none"
         onClick={() => {
           if (selectedContest?.contestId == 1) {
             toast('현재 진행 중인 대회의 프로젝트의 소속을 변경할 수 없습니다.', 'info');
-          } else {
-            toast('프로젝트 소속 대회를 변경할 수 없습니다.', 'info');
           }
-          // if (selectedContest?.contestId !== 1) {
-          //   setIsOpen((prev) => !prev);
-          // }
+          if (selectedContest?.contestId !== 1) {
+            setIsOpen((prev) => !prev);
+          }
         }}
       >
         <span className={selectedContest ? '' : 'text-midGray'}>
           {selectedContest?.contestName || '대회를 선택해주세요.'}
         </span>
-        <FaChevronDown className={`hover:text-[rgb(172,222,191)] ${isOpen ? 'text-mainGreen' : 'text-lightGray'}`} />
+        <FaChevronDown className={`${isOpen ? 'text-subGreen' : 'text-lightGray'}`} />
       </button>
 
       {isOpen && contests && (

--- a/src/pages/project-editor/OverviewInput.tsx
+++ b/src/pages/project-editor/OverviewInput.tsx
@@ -21,6 +21,11 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
     }
   };
 
+  const handleOverviewBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const trimmed = e.target.value.trim();
+    setOverview(trimmed);
+  };
+
   return (
     <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
       <div className="text-midGray flex w-25 gap-1">
@@ -34,6 +39,7 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
           className="placeholder-lightGray ring-lightGray h-40 max-h-40 min-h-40 w-full resize-none overflow-auto rounded bg-gray-100 px-4 py-3 text-sm transition-all duration-300 ease-in-out focus-within:ring-1 focus:outline-none"
           value={overview ?? ''}
           onChange={handleOverviewChange}
+          onBlur={handleOverviewBlur}
         />
         <div className={`text-right text-xs ${overview?.length === MAX_OVERVIEW ? 'text-red-500' : 'text-gray-500'}`}>
           {overview?.length} / {MAX_OVERVIEW}자

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -132,6 +132,7 @@ const ProjectEditorPage = () => {
       if (isAdmin) {
         if (!projectName) return '프로젝트명이 입력되지 않았어요.';
         if (!teamName) return '팀명이 입력되지 않았어요.';
+        if (contestId !== 1 && !overview) return '프로젝트 소개글이 작성되지 않았어요.';
       }
       if (isLeaderOfThisTeam) {
         if (!thumbnail && !previews.length) return '썸네일과 프리뷰 이미지가 모두 업로드되지 않았어요.';

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -222,7 +222,7 @@ const ProjectEditorPage = () => {
 
   return (
     <div className="px-5">
-      <div className="text-title font-bold">프로젝트 생성/수정</div>
+      <div className="text-title font-bold">프로젝트 {contestId !== 1 ? '생성/수정' : '수정'}</div>
       <div className="h-10" />
       {isAdmin && contestId !== 1 && (
         <AdminInputSection

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -137,11 +137,11 @@ const ProjectEditorPage = () => {
         if (!thumbnail && !previews.length) return '썸네일과 프리뷰 이미지가 모두 업로드되지 않았어요.';
         if (!thumbnail) return '썸네일이 업로드 되지 않았어요.';
         if (!previews.length) return '프리뷰 이미지가 업로드 되지 않았어요.';
+        if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
+        if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
+        if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
       }
-      if (!githubUrl) return '깃허브 링크가 입력되지 않았어요.';
-      if (!youtubeUrl) return '유튜브 링크가 입력되지 않았어요.';
 
-      if (!overview) return '프로젝트 소개글이 작성되지 않았어요.';
       if (prodUrl && !isValidProjectUrl(prodUrl)) return '유효한 프로젝트 주소를 입력하세요.';
       if (!isValidGithubUrl(githubUrl)) return '유효한 깃헙 URL을 입력하세요.';
       if (!isValidYoutubeUrl(youtubeUrl)) return '유효한 유튜브 URL을 입력하세요.';
@@ -223,7 +223,7 @@ const ProjectEditorPage = () => {
     <div className="px-5">
       <div className="text-title font-bold">프로젝트 생성/수정</div>
       <div className="h-10" />
-      {isAdmin && (
+      {isAdmin && contestId !== 1 && (
         <AdminInputSection
           contestId={contestId}
           setContestId={setContestId}
@@ -239,7 +239,7 @@ const ProjectEditorPage = () => {
         />
       )}
 
-      {isLeaderOfThisTeam && (
+      {(isLeaderOfThisTeam || (isAdmin && contestId === 1)) && (
         <IntroSection
           projectName={projectName}
           teamName={teamName}
@@ -258,27 +258,22 @@ const ProjectEditorPage = () => {
         youtubeUrl={youtubeUrl}
         setYoutubeUrl={setYoutubeUrl}
       />
-      {isLeaderOfThisTeam && (
-        <>
-          <div className="h-15" />
-          <ImageUploaderSection
-            thumbnail={thumbnail}
-            setThumbnail={setThumbnail}
-            previews={previews}
-            setPreviews={setPreviews}
-            setThumbnailToDelete={setThumbnailToDelete}
-            previewsToDelete={previewsToDelete}
-            setPreviewsToDelete={setPreviewsToDelete}
-          />
-        </>
-      )}
 
       <div className="h-15" />
 
+      <ImageUploaderSection
+        thumbnail={thumbnail}
+        setThumbnail={setThumbnail}
+        previews={previews}
+        setPreviews={setPreviews}
+        setThumbnailToDelete={setThumbnailToDelete}
+        previewsToDelete={previewsToDelete}
+        setPreviewsToDelete={setPreviewsToDelete}
+      />
+
+      <div className="h-15" />
       <OverviewInput overview={overview} setOverview={setOverview} />
-
       <div className="h-20" />
-
       <div className="flex justify-end gap-5 sm:gap-10">
         <button
           onClick={() => navigate(-1)}

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -73,7 +73,7 @@ const IntroSection = ({
           <div className="text-title min-w-0 leading-none font-bold">{projectName}</div>
           <div className="text-smbold font-bold text-[#4B5563]">{teamName}</div>
         </div>
-        {(isLeaderOfThisTeam || (isAdmin && contestId !== 1)) && (
+        {(isLeaderOfThisTeam || isAdmin) && (
           <div className="flex pt-3">
             <button
               onClick={() => navigate(`/teams/edit/${teamId}`)}


### PR DESCRIPTION
### 📝 개요
```
기능 파악에 착오가 있어 해당 부분을 추가 작업한 PR입니다.
```

### 🎯 목적
- 관리자 기능 추가를 위함

### ✨ 변경 사항
- 현재 진행 중인 대회
  - 수정 가능하도록 변경
  - 팀장과 동일한 UI 제공
  - 입력값 검증 완화
    - 관리자: 필드가 비어있어도 저장 가능하나, 입력한 값에 대해서는 검증 수행
    - 팀장: 필수 필드 미입력 시 저장 불가
  - 삭제 가능하도록 변경
  - 프로젝트 생성 시, 생성 페이지로 이동하지 않고 토스트 메시지 표시
    - 단, 히스토리 프로젝트는 생성 가능
- 히스토리 대회
  - 프로젝트 생성 시: 소속 대회 변경 가능 (현재 진행 중인 대회는 선택 불가)
  - 프로젝트 수정 시: 생성 시와 동일하게 필드 확장
    - 대회명, 프로젝트명, 팀명, 팀장, 팀원의 추가 필드
- `isLeaderOfThisTeam`를 렌더링 조건으로 갖던 컴포넌트를 `isLeaderOfThisTeam | isAdmin`으로 바꾸는 등
- 현재 대회가 가능/불가능할 경우 `isAdmin && (contestId === 1)` 또는 `isAdmin && (contestId !== 1)`과 같이 조건부 렌더링

### 🔬 리뷰 요구 사항 (선택)
- 따로 없습니다!

### 💬 논의 사항 (선택)
- 관리자도 페이지 수정 시 팀장과 동일하게 입력 필드를 모두 채우지 않으면 저장이 불가능하도록 해야할까요?

### 📸 참고 이미지/영상 (선택)

https://github.com/user-attachments/assets/8ad23a03-380a-4d38-8a99-fcb701376017

