### PR TITLE
design: 테이블 헤더 편집제외 왼쪽 정렬

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -21,7 +21,7 @@ function Table<T>({ columns, rows, actions }: Props<T>) {
           {columns.map((col) => (
             <th
               key={col.key}
-              className={`border-r border-b border-gray-300 p-2 text-sm ${col.width ? `w-[${col.width}]` : ''}`}
+              className={`border-r border-b border-gray-300 p-2 text-left text-sm ${col.width ? `w-[${col.width}]` : ''}`}
             >
               {col.label}
             </th>


### PR DESCRIPTION
### 📝 개요
Table 컴포넌트 헤드 왼쪽 정렬
### 🎯 목적
테이블 텍스트 정렬 일관성을 위해 text 왼쪽 정렬
### ✨ 변경 사항
Table 컴포넌트 thead text-left로 수정 했습니다.
편집은 중앙정렬이 더 괜찮아보여서 나뒀습니다.
### 📸 참고 이미지/영상 
<img width="885" alt="스크린샷 2025-07-10 오전 10 58 45" src="https://github.com/user-attachments/assets/632e7671-44a3-40ba-ac54-49affaf5f95b" />
