### PR TITLE
fix: 관리자 공지사항 목록에서 날짜가 잘리는 문제 수정

### DIFF
--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -39,7 +39,7 @@ const ManageNoticeListTab = () => {
               label: '편집일시',
               width: '20%',
               key: 'updatedAt',
-              render: (row) => row.updatedAt.replace('T', ' ').slice(0, 16),
+              render: (row) => row.updatedAt,
             },
             { label: '제목', width: '50%', key: 'title' },
           ]}


### PR DESCRIPTION
### 📝 개요
관리자 공지사항 목록에서 날짜가 잘리는 문제 수정

### 🎯 목적
관리자 공지사항 목록에서 날짜가 잘리는 문제 수정

### ✨ 변경 사항
관리자 공지사항 목록에서 날짜가 잘리는 문제 수정