### PR TITLE
design: 특수문자 안내 문구 수정

### DIFF
--- a/src/pages/find/useFindPasswordFormState.ts
+++ b/src/pages/find/useFindPasswordFormState.ts
@@ -32,7 +32,8 @@ export const useFindPasswordFormState = () => {
     const errors: SignUpFormError = {};
     if (!isPNUEmail(formState.email)) errors.email = '부산대학교 이메일(@pusan.ac.kr)이 아닙니다.';
     else if (!formState.isEmailVerified) errors.email = '이메일 인증이 필요합니다.';
-    if (!isValidPassword(formState.password)) errors.password = '8~16자, 영어, 숫자, 특수문자를 포함하여야 합니다.';
+    if (!isValidPassword(formState.password))
+      errors.password = '8~16자, 영어, 숫자, 특수문자(@$!%*#?&~)를 포함하여야 합니다.';
     if (formState.password !== formState.passwordConfirm) errors.passwordConfirm = '비밀번호가 일치하지 않습니다.';
     return errors;
   };

--- a/src/pages/signup/useSignUpFormState.ts
+++ b/src/pages/signup/useSignUpFormState.ts
@@ -38,7 +38,8 @@ export const useSignUpFormState = () => {
     if (!formState.studentNumber.trim()) errors.studentNumber = '학번을 입력해주세요.';
     if (!isPNUEmail(formState.email)) errors.email = '부산대학교 이메일(@pusan.ac.kr)이 아닙니다.';
     else if (!formState.isEmailVerified) errors.email = '이메일 인증이 필요합니다.';
-    if (!isValidPassword(formState.password)) errors.password = '8~16자, 영어, 숫자, 특수문자를 포함하여야 합니다.';
+    if (!isValidPassword(formState.password))
+      errors.password = '8~16자, 영어, 숫자, 특수문자(@$!%*#?&~)를 포함하여야 합니다.';
     if (formState.password !== formState.passwordConfirm) errors.passwordConfirm = '비밀번호가 일치하지 않습니다.';
     return errors;
   };


### PR DESCRIPTION
### 📝 개요
design: 특수문자 안내 문구 수정

### 🎯 목적
특수문자 안내 문구 수정

### ✨ 변경 사항
- 회원가입, 비밀번호 찾기 시 비밀번호 형식 오류 시 문구 변경
```
8~16자, 영어, 숫자, 특수문자를 포함하여야 합니다. → 8~16자, 영어, 숫자, 특수문자(@$!%*#?&~)를 포함하여야 합니다.
```