### PR TITLE
design: 관리자 Edit 모달 디자인 일치하게 수정

### DIFF
--- a/src/pages/admin/ContestsTab/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestsTab/ContestAdminTab.tsx
@@ -71,7 +71,7 @@ const ContestAdminTab = () => {
         onCancel={closeDeleteModal}
         message={`삭제한 ${deleteModal.type == 'contest' ? '대회' : '팀'}은 복구할 수 없습니다.`}
       />
-      {state.isEditModalOpen && <EditModal closeModal={closeEditModal} editId={state.editContestId} />}
+      <EditModal isOpen={state.isEditModalOpen} closeModal={closeEditModal} editId={state.editContestId} />
 
       <section className="mb-8 min-w-[350px]">
         <h2 className="mb-8 text-2xl font-bold">대회 목록</h2>

--- a/src/pages/admin/ContestsTab/EditModal.tsx
+++ b/src/pages/admin/ContestsTab/EditModal.tsx
@@ -1,24 +1,39 @@
 import Button from '@components/Button';
 import Input from '@components/Input';
 import useEditContest from 'hooks/useEditContest';
+import { RxCross2 } from 'react-icons/rx';
+import { FaRegEdit } from 'react-icons/fa';
 
 type EditModalProps = {
+  isOpen: boolean;
   closeModal: () => void;
   editId: number;
 };
 
-const EditModal = ({ closeModal, editId }: EditModalProps) => {
+const EditModal = ({ isOpen, closeModal, editId }: EditModalProps) => {
   const { contestName, setContestName, isLoading, handleEdit } = useEditContest(editId, closeModal);
+  if (!isOpen) return null;
 
   return (
     <div
       onClick={closeModal}
-      className="fixed top-0 left-0 z-50 flex h-full w-full items-center justify-center bg-black/30"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="border-mainBlue flex flex-col items-center justify-center rounded-xl border-2 bg-white p-10 py-6 opacity-100 shadow-2xl"
+        className="relative w-[640px] rounded-2xl bg-white p-6 shadow-xl transition-all duration-300 ease-in-out"
       >
+        <button
+          onClick={closeModal}
+          className="absolute top-4 right-4 text-gray-400 hover:cursor-pointer hover:text-gray-600"
+          aria-label="닫기"
+        >
+          <RxCross2 size={20} />
+        </button>
+        <div className="text-mainBlue mx-auto my-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
+          <FaRegEdit size={25} />
+        </div>
+        <h3 className="text-center text-lg font-semibold text-gray-800">수정할 대회명을 입력하세요.</h3>
         <div className="mt-8 mb-8 flex w-full justify-between">
           <Input
             type="text"
@@ -28,13 +43,23 @@ const EditModal = ({ closeModal, editId }: EditModalProps) => {
             className="bg-whiteGray mx-4 h-12 w-[70%] rounded-lg"
             disabled={isLoading}
           />
-          <Button className="bg-mainBlue h-12 w-[20%] min-w-[130px]" onClick={handleEdit} disabled={isLoading}>
+        </div>
+        <div className="mx-auto my-4 flex items-center justify-center gap-4">
+          <Button
+            className="border-lightGray text-midGray rounded-full border px-5 py-1.5 hover:bg-gray-100"
+            onClick={closeModal}
+            disabled={isLoading}
+          >
+            닫기
+          </Button>
+          <Button
+            className="bg-mainBlue rounded-full px-5 py-1.5 hover:bg-blue-500"
+            onClick={handleEdit}
+            disabled={isLoading}
+          >
             {isLoading ? '수정 중...' : '대회 수정하기'}
           </Button>
         </div>
-        <Button className="bg-mainBlue w-[100px]" onClick={closeModal} disabled={isLoading}>
-          닫기
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
### 📝 개요
 관리자 Edit 모달 디자인 일치하게 수정
### 🎯 목적
관리자 페이지에서 삭제 모달과 디자인 통일시키기 위해 수정
### ✨ 변경 사항
EditModal css 삭제 모달과 비슷해지게끔 수정했습니다.

### 🔬 리뷰 요구 사항 
디자인 괜찮을까요??
버튼이 너무 위아래로 좁은 느낌이 있는데 넓히는 건 어떨까요?
현재 코드는 위아래 패딩 넓히기 전입니다.

### 📸 참고 이미지/영상
넓히기 전
<img width="1066" height="633" alt="스크린샷 2025-07-12 오후 4 36 46" src="https://github.com/user-attachments/assets/57970601-4f35-446b-84ab-fade0f20403c" />

넓힌 후
<img width="1066" height="633" alt="스크린샷 2025-07-12 오후 4 38 16" src="https://github.com/user-attachments/assets/e96cf4a5-ed1a-4095-8d69-42df2f92369c" />
