### PR TITLE
fix: 프로젝트 카드 hover 처리 및 공지사항 상세 페이지 반응형 구현 등등

### DIFF
--- a/src/pages/main/NoticeList.tsx
+++ b/src/pages/main/NoticeList.tsx
@@ -37,22 +37,21 @@ const NoticeList = ({ notices }: Props) => {
           const showNewIcon = isNew(notice.updatedAt);
 
           return (
-            <li
+            <Link to={`/notices/${notice.noticeId}`}
               key={notice.noticeId}
               className="hover:bg-lightGray flex items-center justify-between rounded px-2 py-1 transition"
             >
               <AiOutlineNotification className="mr-2" />
               <div className="flex flex-1 items-center gap-1 truncate ">
-                <Link to={`/notices/${notice.noticeId}`} className="text-[clamp(0.75rem,2vw,1rem)] truncate">
-                  {notice.title}
-                </Link>
+                <div className="text-[clamp(0.75rem,2vw,1rem)] truncate">
+                  {notice.title} </div>
                 {showNewIcon && (
                   <MdFiberNew className="text-mainRed shrink-0 text-[clamp(1rem,2vw,1.5rem)] " />
                 )}
               </div>
 
               <span className="ml-2 text-midGray truncate text-right text-xs">{notice.updatedAt}</span>
-            </li>
+            </Link>
           );
         })}
       </ul>

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -17,10 +17,10 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => 
   return (
     <Link
       to={`/teams/view/${teamId}`}
-      className="border-none flex aspect-[7/8] w-full flex-col overflow-hidden"
+      className="border-none flex aspect-[7/8] w-full flex-col"
 
     >
-      <div className="aspect-[3/2] flex-shrink-0 object-cover relative overflow-hidden rounded-sm cursor-pointer transition-transform duration-200 hover:scale-[1.02] hover:shadow-md">
+      <div className="aspect-[3/2] flex-shrink-0 object-cover overflow-hidden relative rounded-md cursor-pointer transition-transform duration-200 hover:scale-[1.02] hover:shadow-md">
         {!imageError ? (
           <img
             src={thumbnailUrl}

--- a/src/pages/notice/NoticeDetail.tsx
+++ b/src/pages/notice/NoticeDetail.tsx
@@ -28,10 +28,10 @@ const NoticeDetail = () => {
       <h1 className="text-2xl font-bold mb-6">공지사항</h1>
       <div className="flex items-center bg-whiteGray rounded px-4 py-5 mb-2">
         <AiOutlineNotification className="mr-4" />
-        <span className="font-semibold text-base flex-1">{notice.title}</span>
+        <span className="font-bold text-[clamp(0.85rem,2vw,1.3rem)] flex-1">{notice.title}</span>
       </div>
-      <div className="text-right text-midGray mb-6">{notice.updatedAt}</div>
-      <div className="bg-subGreen rounded p-6 leading-relaxed whitespace-pre-line">
+      <div className="text-[clamp(0.7rem,1.5vw,0.9rem)] text-right text-midGray mb-6">{notice.updatedAt}</div>
+      <div className="text-[clamp(0.75rem,2vw,1rem)] bg-subGreen rounded p-6 leading-relaxed whitespace-pre-line">
         {notice.description}
       </div>
     </div>


### PR DESCRIPTION
### 📝 개요
전체회의 전 QA 중 발견한 버그 수정 

### 🎯 목적
- 메인페이지 프로젝트 카드 hover 일치 처리
- 공지사항 상세 페이지 반응형 텍스트 크기 변경 구현
- 메인페이지 공지사항 리스트에서 제목부분만 link 됨 문제 -> 링크 영역 확장 

### ✨ 변경 사항
- 프로젝트 카드 컴포넌트에서 overflow-hidden 중복 처리되어 있어 해당 버그 발생 -> 중복 없앰
- 공지사항 상세 페이지의 텍스트 세 부분 clamp 처리
- 공지사항 메인페이지 hover 영역과 link 영역 일치시킴 