### PR TITLE
fix: 대회 수정 모달에 현재 대회명 가져오기

### DIFF
--- a/src/hooks/useContestAdmin.ts
+++ b/src/hooks/useContestAdmin.ts
@@ -20,6 +20,7 @@ type ContestAdminState = {
   isEditModalOpen: boolean;
   isDeleteModalOpen: boolean;
   editContestId: number;
+  editContestName: string;
 };
 
 const useContestAdmin = () => {
@@ -31,6 +32,7 @@ const useContestAdmin = () => {
     isEditModalOpen: false,
     isDeleteModalOpen: false,
     editContestId: 0,
+    editContestName: '',
   });
 
   const [deleteModal, setDeleteModal] = useState<DeleteModalState>({
@@ -154,11 +156,12 @@ const useContestAdmin = () => {
     setDeleteModal({ type: null, targetId: null });
   };
 
-  const openEditModal = (contestId: number) =>
+  const openEditModal = (contestId: number, contestName: string) =>
     setState((prev) => ({
       ...prev,
       isEditModalOpen: true,
       editContestId: contestId,
+      editContestName: contestName,
     }));
   const closeEditModal = () => setState((prev) => ({ ...prev, isEditModalOpen: false }));
 

--- a/src/hooks/useEditContest.ts
+++ b/src/hooks/useEditContest.ts
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { patchContest } from 'apis/contests';
 import { useToast } from 'hooks/useToast';
 
-const useEditContest = (editId: number, onClose: () => void) => {
+const useEditContest = (isOpen: boolean, editId: number, onClose: () => void, editContestName: string) => {
   const [contestName, setContestName] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const toast = useToast();
@@ -29,6 +29,9 @@ const useEditContest = (editId: number, onClose: () => void) => {
       setIsLoading(false);
     }
   };
+  useEffect(() => {
+    if (isOpen) setContestName(editContestName);
+  }, [isOpen]);
 
   return {
     contestName,

--- a/src/pages/admin/ContestsTab/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestsTab/ContestAdminTab.tsx
@@ -70,7 +70,12 @@ const ContestAdminTab = () => {
         onCancel={closeDeleteModal}
         message={`삭제한 ${deleteModal.type == 'contest' ? '대회' : '팀'}은 복구할 수 없습니다.`}
       />
-      <EditModal isOpen={state.isEditModalOpen} closeModal={closeEditModal} editId={state.editContestId} />
+      <EditModal
+        isOpen={state.isEditModalOpen}
+        closeModal={closeEditModal}
+        editId={state.editContestId}
+        editContestName={state.editContestName}
+      />
 
       <section className="mb-8 min-w-[350px]">
         <h2 className="mb-8 text-2xl font-bold">대회 목록</h2>
@@ -90,7 +95,10 @@ const ContestAdminTab = () => {
               <Button className="bg-mainRed h-[35px] w-full" onClick={() => openDeleteModal('contest', row.contestId)}>
                 삭제하기
               </Button>
-              <Button className="bg-mainGreen h-[35px] w-full" onClick={() => openEditModal(row.contestId)}>
+              <Button
+                className="bg-mainGreen h-[35px] w-full"
+                onClick={() => openEditModal(row.contestId, row.contestName)}
+              >
                 수정하기
               </Button>
             </>

--- a/src/pages/admin/ContestsTab/EditModal.tsx
+++ b/src/pages/admin/ContestsTab/EditModal.tsx
@@ -8,10 +8,16 @@ type EditModalProps = {
   isOpen: boolean;
   closeModal: () => void;
   editId: number;
+  editContestName: string;
 };
 
-const EditModal = ({ isOpen, closeModal, editId }: EditModalProps) => {
-  const { contestName, setContestName, isLoading, handleEdit } = useEditContest(editId, closeModal);
+const EditModal = ({ isOpen, closeModal, editId, editContestName }: EditModalProps) => {
+  const { contestName, setContestName, isLoading, handleEdit } = useEditContest(
+    isOpen,
+    editId,
+    closeModal,
+    editContestName,
+  );
   if (!isOpen) return null;
 
   return (


### PR DESCRIPTION
### 📝 개요
대회 수정 모달에 현재 대회명 가져오기
### 🎯 목적
대회 수정 모달 인풋에 수정사항 남아있는 버그 수정
### ✨ 변경 사항
edit modal 훅에 클릭한 대회명 가져오기 추가
### 📸 참고 이미지/영상 (선택)
<img width="853" height="745" alt="스크린샷 2025-07-13 오후 1 44 51" src="https://github.com/user-attachments/assets/4ca98e3b-c64d-48bb-9b53-7c11442e940b" />
