### PR TITLE
design: admin 공지사항 목록 편집일시 크기 늘림

### DIFF
--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -37,11 +37,11 @@ const ManageNoticeListTab = () => {
           columns={[
             {
               label: '편집일시',
-              width: '20%',
+              width: '30%',
               key: 'updatedAt',
               render: (row) => row.updatedAt,
             },
-            { label: '제목', width: '50%', key: 'title' },
+            { label: '제목', width: '30%', key: 'title' },
           ]}
           rows={notices ?? []}
           actions={(row) => (


### PR DESCRIPTION
### 📝 개요
admin 공지사항 목록 편집일시 크기 늘림

### 🎯 목적
admin 공지사항 목록 편집일시 크기 늘림

### ✨ 변경 사항
- ManageNoticeListTab내 Table row의 width 조정
- 공지사항 제목 칸이 작아지는 문제가 있지만 추후 테이블 라이브러리 적용 후 수정 예정

### 📸 참고 이미지/영상 (선택)
<img width="2544" height="1537" alt="image" src="https://github.com/user-attachments/assets/94797c72-d1ac-4991-bb8f-d6a6a31e0f0b" />
