### PR TITLE
fix: 현재 진행중이지 않은 대회 프로젝트에서 좋아요 클릭 시 히스토리에 반영되지 않는 문제 해결

### DIFF
--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -6,11 +6,12 @@ import { useToast } from 'hooks/useToast';
 import { FaHeart } from 'react-icons/fa';
 
 interface LikeSectionProps {
+  contestId: number;
   teamId: number;
   isLiked: boolean;
 }
 
-const LikeSection = ({ teamId, isLiked }: LikeSectionProps) => {
+const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
   const { isSignedIn } = useAuth();
   const navigate = useNavigate();
   const toast = useToast();
@@ -22,6 +23,7 @@ const LikeSection = ({ teamId, isLiked }: LikeSectionProps) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
       queryClient.invalidateQueries({ queryKey: ['teams', 'current', user?.id ?? 'guest'] });
+      queryClient.invalidateQueries({ queryKey: ['teams', contestId, user?.id ?? 'guest'] });
       toast(!isLiked ? '좋아요를 눌렀어요.' : '좋아요를 취소했어요.');
     },
   });

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -78,7 +78,7 @@ const ProjectViewerPage = () => {
         isEditor={isLeaderOfThisTeam || isAdmin}
       />
       <div className="h-10" />
-      <LikeSection teamId={data.teamId} isLiked={data.isLiked} />
+      <LikeSection contestId={data.contestId} teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />
       <DetailSection overview={data.overview} leaderName={data.leaderName} teamMembers={data.teamMembers} />
       {/* WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의*/}


### PR DESCRIPTION
### 📝 개요
현재 진행중이지 않은 대회 프로젝트에서 좋아요 클릭 시 히스토리에 반영되지 않는 문제 해결

### 🎯 목적
현재 진행중이지 않은 대회 프로젝트에서 좋아요 클릭 시 히스토리에 반영되지 않는 문제 해결

### ✨ 변경 사항
- LikeSection 컴포넌트에서 invalidateQuery 로직 추가
- 현재 contestId가 무엇인지 확인할 방법이 없어, 이전 대회의 프로젝트에 좋아요를 눌러도 메인 페이지에서 사용되는 현재 진행중 api에 대해 invalidate query하도록 함
