### PR TITLE
Style: 팀원 수정 플로우 재구성 및 UI 개선

### DIFF
--- a/src/pages/project-editor/AdminEditSection/AdminEditSection.tsx
+++ b/src/pages/project-editor/AdminEditSection/AdminEditSection.tsx
@@ -43,7 +43,7 @@ const AdminEditSection = ({
             value={projectName}
             onChange={(e) => setProjectName(e.target.value)}
             placeholder="프로젝트 이름을 입력해주세요."
-            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 px-5 py-3 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>
       </div>
@@ -58,7 +58,7 @@ const AdminEditSection = ({
             value={teamName}
             onChange={(e) => setTeamName(e.target.value)}
             placeholder="팀 이름을 입력해주세요."
-            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 px-5 py-3 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border px-5 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>
       </div>
@@ -73,7 +73,7 @@ const AdminEditSection = ({
             value={leaderName}
             onChange={(e) => setLeaderName(e.target.value)}
             placeholder="팀장 이름을 입력해주세요."
-            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 px-5 py-3 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>
       </div>

--- a/src/pages/project-editor/AdminEditSection/ContestMenu.tsx
+++ b/src/pages/project-editor/AdminEditSection/ContestMenu.tsx
@@ -47,7 +47,7 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
   return (
     <div className="relative w-full max-w-sm text-sm">
       <button
-        className="border-lightGray focus:ring-subGreen focus:border-subGreen flex w-full items-center justify-between rounded-md border-2 px-5 py-3 text-left duration-150 hover:cursor-pointer focus:outline-none"
+        className="border-lightGray focus:ring-subGreen focus:border-mainGreen flex w-full items-center justify-between rounded border px-5 py-3 text-left duration-150 hover:cursor-pointer focus:outline-none"
         onClick={() => {
           if (selectedContest?.contestId == 1) {
             toast('현재 진행 중인 대회의 프로젝트의 소속을 변경할 수 없습니다.', 'info');
@@ -60,7 +60,7 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
         <span className={selectedContest ? '' : 'text-midGray'}>
           {selectedContest?.contestName || '대회를 선택해주세요.'}
         </span>
-        <FaChevronDown className={`${isOpen ? 'text-subGreen' : 'text-lightGray'}`} />
+        <FaChevronDown className={`${isOpen ? 'text-mainGreen' : 'text-lightGray'}`} />
       </button>
 
       {isOpen && contests && (

--- a/src/pages/project-editor/AdminEditSection/MembersInput.tsx
+++ b/src/pages/project-editor/AdminEditSection/MembersInput.tsx
@@ -32,10 +32,10 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
           {teamMembers.map((member) => (
             <div
               key={member.teamMemberId}
-              className="border:lightGray relative w-full rounded border py-3 pr-5 pl-15 text-sm text-black"
+              className="border:lightGray relative w-full rounded border px-15 py-3 text-sm text-black"
             >
               <IoPerson className="text-mainGreen/50 absolute top-1/2 left-5 -translate-y-1/2" size={20} />
-              <div className="truncate pr-12">{member.teamMemberName}</div>
+              <div className="truncate">{member.teamMemberName}</div>
               <button
                 type="button"
                 onClick={() => onMemberRemove(member.teamMemberId)}
@@ -51,7 +51,7 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
               <input
                 type="text"
                 placeholder="팀원명을 입력해주세요."
-                className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
+                className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-15 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
                 value={newMemberInput}
                 onChange={(e) => setNewMemberInput(e.target.value)}
                 onKeyDown={(e) => {

--- a/src/pages/project-editor/AdminEditSection/MembersInput.tsx
+++ b/src/pages/project-editor/AdminEditSection/MembersInput.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { TeamMember } from 'types/DTO/projectViewerDto';
-import { IoIosAdd, IoIosRemove } from 'react-icons/io';
-import { IoPersonOutline } from 'react-icons/io5';
+import { IoPerson } from 'react-icons/io5';
 
 interface MembersInputProps {
   teamMembers: TeamMember[];
@@ -12,118 +11,69 @@ interface MembersInputProps {
 const MAX_MEMBERS = 6;
 
 const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInputProps) => {
-  const [inputs, setInputs] = useState<Record<string, string>>({});
+  const [newMemberInput, setNewMemberInput] = useState('');
 
-  const emptySlotsCount = MAX_MEMBERS - teamMembers.length;
-
-  const [newInputs, setnewInputs] = useState<string[]>([]);
-
-  useEffect(() => {
-    const newInputsMap: Record<string, string> = {};
-    teamMembers.forEach((member) => {
-      newInputsMap[member.teamMemberId.toString()] = member.teamMemberName ?? '';
-    });
-    setInputs(newInputsMap);
-  }, [teamMembers]);
-
-  useEffect(() => {
-    setnewInputs((prev) => {
-      const newLength = emptySlotsCount;
-      const currentLength = prev.length;
-
-      if (newLength === currentLength) {
-        return prev;
-      }
-
-      const updatedNames = Array(newLength).fill('');
-
-      for (let i = 0; i < Math.min(currentLength, newLength); i++) {
-        updatedNames[i] = prev[i] ?? '';
-      }
-      return updatedNames;
-    });
-  }, [emptySlotsCount]);
-
-  const handleNewInputChange = (idx: number, value: string) => {
-    setnewInputs((prev) => {
-      const copy = [...prev];
-      copy[idx] = value;
-      return copy;
-    });
-  };
-
-  const handleAddNewMember = (idx: number) => {
-    const trimmed = (newInputs[idx] ?? '').trim();
-    if (!trimmed) return;
+  const handleAddMember = () => {
+    const trimmed = newMemberInput.trim();
+    if (!trimmed || teamMembers.length >= MAX_MEMBERS) return;
     onMemberAdd(trimmed);
-    setnewInputs((prev) => {
-      const copy = [...prev];
-      copy[idx] = '';
-      return copy;
-    });
+    setNewMemberInput('');
   };
 
   return (
     <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-start sm:gap-10">
-      <div className="text-midGray flex w-25 gap-1">
+      <div className="text-midGray flex w-25 sm:py-3">
         <span className="mr-1 text-red-500">*</span>
-        <span className="w-full">팀원</span>
+        <span>팀원</span>
       </div>
-      <div className="flex flex-1 flex-col">
-        <div className="grid w-full grid-cols-1 gap-3 text-sm lg:grid-cols-2">
+
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="grid w-full grid-cols-1 gap-3 lg:grid-cols-2">
           {teamMembers.map((member) => (
             <div
               key={member.teamMemberId}
-              className="border-mainGreen relative flex items-center gap-1 rounded border px-4 py-2 text-sm"
+              className="border:lightGray relative w-full rounded border py-3 pr-5 pl-15 text-sm text-black"
             >
-              <IoPersonOutline className="text-mainGreen" size={20} />
-              <input
-                type="text"
-                className="placeholder:text-lightGray flex-1 truncate bg-transparent px-2 focus:outline-none"
-                value={inputs[member.teamMemberId.toString()] || ''}
-                disabled
-                readOnly
-              />
+              <IoPerson className="text-mainGreen/50 absolute top-1/2 left-5 -translate-y-1/2" size={20} />
+              <div className="truncate pr-12">{member.teamMemberName}</div>
               <button
                 type="button"
                 onClick={() => onMemberRemove(member.teamMemberId)}
-                className="text-mainGreen"
-                aria-label={`Remove member ${member.teamMemberName ?? 'unknown'}`}
+                className="absolute top-1/2 right-5 -translate-y-1/2 text-xs text-red-500 hover:cursor-pointer hover:text-red-700"
               >
-                <IoIosRemove size={24} />
+                삭제
               </button>
             </div>
           ))}
-          {Array.from({ length: emptySlotsCount }).map((_, idx) => (
-            <div
-              key={`new-${idx}`}
-              className="border-lightGray relative flex items-center gap-1 rounded border px-4 py-2 text-sm"
-            >
-              <IoPersonOutline className="text-lightGray mr-2" size={20} />
+          {teamMembers.length < MAX_MEMBERS && (
+            <div className="relative w-full">
+              <IoPerson className="text-lightGray absolute top-1/2 left-5 -translate-y-1/2" size={20} />
               <input
                 type="text"
                 placeholder="팀원명을 입력해주세요."
-                className="placeholder:text-lightGray flex-1 truncate bg-transparent focus:outline-none"
-                value={newInputs[idx] ?? ''}
-                onChange={(e) => handleNewInputChange(idx, e.target.value)}
+                className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
+                value={newMemberInput}
+                onChange={(e) => setNewMemberInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && (newInputs[idx] ?? '').trim()) {
-                    handleAddNewMember(idx);
-                  }
+                  if (e.key === 'Enter') handleAddMember();
                 }}
               />
               <button
                 type="button"
-                onClick={() => handleAddNewMember(idx)}
-                className={`${(newInputs[idx] ?? '').trim() ? 'text-mainGreen' : 'text-lightGray'}`}
-                disabled={!(newInputs[idx] ?? '').trim()}
-                aria-label="Add member"
+                onClick={handleAddMember}
+                disabled={!newMemberInput.trim()}
+                className={`absolute top-1/2 right-5 -translate-y-1/2 text-xs font-medium hover:cursor-pointer ${
+                  newMemberInput.trim() ? 'text-mainGreen hover:text-green-700' : 'cursor-not-allowed text-gray-300'
+                }`}
               >
-                <IoIosAdd size={24} />
+                추가
               </button>
             </div>
-          ))}
+          )}
         </div>
+        <p className="text-lightGray text-xs">
+          최대 {MAX_MEMBERS}명까지 등록할 수 있어요 ({MAX_MEMBERS - teamMembers.length}명 남음)
+        </p>
       </div>
     </div>
   );

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -171,7 +171,7 @@ const ImageUploaderSection = ({
   while (paddedImages.length < MAX_IMAGES) paddedImages.push(undefined);
 
   return (
-    <div className="flex gap-10 text-sm">
+    <div className="flex flex-col gap-10 text-sm sm:flex-row">
       <div className="flex flex-col items-start gap-3">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
@@ -200,13 +200,13 @@ const ImageUploaderSection = ({
         >
           <p className="text-xs sm:inline sm:text-sm">파일을 이곳에 끌어놓아주세요.</p>
           <p className="text-midGray my-2 text-xs sm:inline sm:text-sm">OR</p>
-          <label className="text-mainGreen flex cursor-pointer rounded-full bg-[#D1F3E1] p-4 text-sm font-bold">
+          <label className="text-mainGreen bg-subGreen flex cursor-pointer rounded-full p-4 text-sm font-bold hover:bg-emerald-200">
             <MdOutlineFileUpload className="sm:hidden" />
             <span className="hidden px-4 sm:inline">파일 업로드</span>
             <input type="file" accept="image/*" multiple className="hidden" onChange={handleImageUpload} />
           </label>
         </div>
-        <div className="grid flex-1 grid-cols-1 gap-3 text-center sm:grid-cols-2">
+        <div className="grid flex-1 grid-cols-2 gap-3 text-center">
           {paddedImages.map((img, index) => {
             if (!img) {
               return (

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -171,8 +171,8 @@ const ImageUploaderSection = ({
   while (paddedImages.length < MAX_IMAGES) paddedImages.push(undefined);
 
   return (
-    <div className="flex flex-col gap-10 text-sm sm:flex-row">
-      <div className="flex flex-col items-start gap-3">
+    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
+      <div className="flex items-start gap-3 sm:flex-col sm:pt-3">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
           <span>이미지</span>
@@ -200,7 +200,7 @@ const ImageUploaderSection = ({
         >
           <p className="text-xs sm:inline sm:text-sm">파일을 이곳에 끌어놓아주세요.</p>
           <p className="text-midGray my-2 text-xs sm:inline sm:text-sm">OR</p>
-          <label className="text-mainGreen bg-subGreen flex cursor-pointer rounded-full p-4 text-sm font-bold hover:bg-emerald-200">
+          <label className="text-mainGreen bg-subGreen hover:bg-emerald-00 flex cursor-pointer rounded-full p-4 text-sm font-bold">
             <MdOutlineFileUpload className="sm:hidden" />
             <span className="hidden px-4 sm:inline">파일 업로드</span>
             <input type="file" accept="image/*" multiple className="hidden" onChange={handleImageUpload} />

--- a/src/pages/project-editor/OverviewInput.tsx
+++ b/src/pages/project-editor/OverviewInput.tsx
@@ -28,7 +28,7 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
 
   return (
     <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
-      <div className="text-midGray flex w-25 gap-1">
+      <div className="text-midGray flex w-25 gap-1 sm:py-3">
         <span className="mr-1 text-red-500">*</span>
         <span className="w-full">Overview</span>
       </div>

--- a/src/pages/project-editor/OverviewInput.tsx
+++ b/src/pages/project-editor/OverviewInput.tsx
@@ -36,7 +36,7 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
         <textarea
           ref={textareaRef}
           placeholder={`Overview를 입력해주세요. (최대 ${MAX_OVERVIEW}자)`}
-          className="placeholder-lightGray ring-lightGray h-40 max-h-40 min-h-40 w-full resize-none overflow-auto rounded bg-gray-100 px-4 py-3 text-sm transition-all duration-300 ease-in-out focus-within:ring-1 focus:outline-none"
+          className="placeholder-lightGray border-lightGray focus:border-mainGreen h-40 max-h-40 min-h-40 w-full resize-none overflow-auto rounded border px-4 py-3 text-sm transition-all duration-300 ease-in-out focus:outline-none"
           value={overview ?? ''}
           onChange={handleOverviewChange}
           onBlur={handleOverviewBlur}

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -344,7 +344,9 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
     }
 
     const isDuplicate = teamMembersRef.current.some(
-      (member) => member.teamMemberName.toLowerCase() === trimmedName.toLowerCase(),
+      (member) =>
+        member.teamMemberName.toLowerCase() === trimmedName.toLowerCase() ||
+        leaderName.trim().toLowerCase() === trimmedName.toLowerCase(),
     );
 
     if (isDuplicate) {

--- a/src/pages/project-editor/UrlInput.tsx
+++ b/src/pages/project-editor/UrlInput.tsx
@@ -32,7 +32,7 @@ const UrlInput = ({
           <input
             type="url"
             placeholder="https://github.com/ (필수)"
-            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
             value={githubUrl}
             onChange={(e) => setGithubUrl(e.target.value)}
           />
@@ -42,7 +42,7 @@ const UrlInput = ({
           <input
             type="url"
             placeholder="https://youtube.com/ (필수)"
-            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
             value={youtubeUrl}
             onChange={(e) => setYoutubeUrl(e.target.value)}
           />
@@ -52,7 +52,7 @@ const UrlInput = ({
           <input
             type="url"
             placeholder="https://your-project.vercel.app (선택)"
-            className="placeholder-lightGray focus:ring-lightGray w-full truncate rounded bg-gray-100 py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:ring-1 focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
             value={productionUrl ?? ''}
             onChange={(e) => setProductionUrl(e.target.value)}
           />

--- a/src/pages/project-editor/UrlInput.tsx
+++ b/src/pages/project-editor/UrlInput.tsx
@@ -22,7 +22,7 @@ const UrlInput = ({
 }: UrlInputProps) => {
   return (
     <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
-      <div className="text-midGray flex w-25">
+      <div className="text-midGray flex w-25 sm:py-3">
         <span className="mr-1 text-red-500">*</span>
         <span>URL</span>
       </div>

--- a/src/pages/project-viewer/CommentSection/Comment.tsx
+++ b/src/pages/project-viewer/CommentSection/Comment.tsx
@@ -95,7 +95,7 @@ const Comment = ({ comment }: CommentProps) => {
 
       {isEditing ? (
         <div className="animate-fade-in flex flex-col gap-5">
-          <div className="bg-whiteGray focus:ring-lightGray flex h-36 flex-col gap-2 rounded p-3 text-sm transition-all duration-300 ease-in-out focus:outline-none">
+          <div className="bg-whiteGray focus-within:ring-lightGray flex h-36 flex-col gap-2 rounded p-3 text-sm transition-all duration-300 ease-in-out focus-within:ring-1 focus:outline-none">
             <textarea
               className="placeholder:text-lightGray w-full flex-1 resize-none p-2 focus:outline-none"
               placeholder="댓글을 입력하세요 (최대 255자)"

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -65,7 +65,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
 
   return (
     <>
-      <div className="ring-lightGray focus-within:ring-midGray flex h-36 flex-col gap-2 rounded p-3 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1">
+      <div className="ring-lightGray focus-within:ring-mainGreen flex h-36 flex-col gap-2 rounded p-3 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1">
         <textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}


### PR DESCRIPTION
### 📝 개요
- 팀원 수정 플로우를 재구성 하고 UI를 개선함
- 중복 검사 대상에 팀장 이름도 포함

### 🎯 목적
- 사용자 입장에게 혼란스럽지 않은 수정 기능을 제공하기 위함

### ✨ 변경 사항
- 6개의 고정 칸을 두고 입력필드/추가/제거를 함께하여 사용 방식이 다소 복잡하다는 피드백을 수렴
- 입력 필드를 하나만 두는 것으로 하여 팀원이 추가될 때마다 아래 또는 우측에 배치되도록 함
  - 명시적인 입력 필드를 제공함으로써 혼란이 없도록 함
- 아이콘이었던 삭제/추가 버튼을 `삭제`, `추가` 텍스트 버튼으로 변경 

### 📸 참고 이미지/영상 (선택)
- 참고: column 2개, sm: column 1개로 구현하였습니다.
<img width="2131" height="178" alt="membersinput-3" src="https://github.com/user-attachments/assets/aeb4a873-e8c6-4812-96fa-d1163b1a701b" />
