### PR TITLE
Feat: Tanstack Table로 수정 / 모바일 UI 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/postcss": "^4.1.7",
         "@tailwindcss/vite": "^4.1.7",
         "@tanstack/react-query": "^5.77.2",
+        "@tanstack/react-table": "^8.21.3",
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2265,6 +2266,39 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tailwindcss/postcss": "^4.1.7",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.77.2",
+    "@tanstack/react-table": "^8.21.3",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,62 +1,104 @@
 import { ReactNode } from 'react';
+import { useReactTable, getCoreRowModel, flexRender, ColumnDef, RowData } from '@tanstack/react-table';
 
 interface Column<T> {
-  label: string;
+  header: string;
   width?: string;
   key: string;
   render?: (row: T) => ReactNode;
 }
 
-interface Props<T> {
+interface Props<T extends RowData> {
   columns: Column<T>[];
   rows: T[];
   actions?: (row: T) => ReactNode;
+  onRowClick?: (row: T) => void;
 }
 
-function Table<T>({ columns, rows, actions }: Props<T>) {
+function Table<T extends RowData>({ columns, rows, actions, onRowClick }: Props<T>) {
+  const tableColumns: ColumnDef<T>[] = columns.map((col) => ({
+    accessorKey: col.key,
+    header: col.header,
+    cell: (info) => (col.render ? col.render(info.row.original) : info.getValue()),
+  }));
+
+  const allColumns = actions
+    ? [
+        ...tableColumns,
+        {
+          id: 'actions',
+          header: '편집',
+          accessorKey: 'actions',
+          cell: (info: any) => <div className="flex w-full justify-center gap-2">{actions(info.row.original)}</div>,
+        } as ColumnDef<T>,
+      ]
+    : tableColumns;
+
+  const table = useReactTable({
+    data: rows,
+    columns: allColumns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
   return (
-    <table className="w-full border-collapse bg-white">
-      <thead className="bg-gray-100">
-        <tr>
-          {columns.map((col) => (
-            <th
-              key={col.key}
-              className={`border-r border-b border-gray-300 p-2 text-left text-sm ${col.width ? `w-[${col.width}]` : ''}`}
-            >
-              {col.label}
-            </th>
-          ))}
-          {actions && <th className="w-[30%] border-b border-gray-300 p-2 text-sm">편집</th>}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.length === 0 ? (
-          <tr>
-            <td
-              colSpan={columns.length + (actions ? 1 : 0)}
-              className="border-b border-gray-300 p-8 text-center text-gray-500"
-            >
-              데이터가 없습니다.
-            </td>
-          </tr>
-        ) : (
-          rows.map((row, index) => (
-            <tr key={index}>
-              {columns.map((col) => (
-                <td key={col.key} className="border-r border-b border-gray-300 p-2 text-sm">
-                  {col.render ? col.render(row) : (row as any)[col.key]}
-                </td>
-              ))}
-              {actions && (
-                <td className="border-b border-gray-300 p-2 text-sm">
-                  <div className="flex justify-center gap-2">{actions(row)}</div>
-                </td>
-              )}
+    <div style={{ overflowX: 'auto' }}>
+      <table className="w-full min-w-[700px] border-collapse bg-white">
+        <thead className="bg-gray-100">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id} className="">
+              {headerGroup.headers.map((header, idx) => {
+                let thClass = ` border-b border-gray-300 p-2 text-sm`;
+                if (idx < columns.length) {
+                  const width = columns[idx]?.width;
+                  if (width) thClass += ` border-r w-[${width}] text-left`;
+                } else if (idx == columns.length) {
+                  thClass += ` w-[30%] text-center`;
+                }
+
+                return (
+                  <th key={header.id} className={thClass}>
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
+                );
+              })}
             </tr>
-          ))
-        )}
-      </tbody>
-    </table>
+          ))}
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length + (actions ? 1 : 0)}
+                className="border-b border-gray-300 p-8 text-center text-gray-500"
+              >
+                데이터가 없습니다.
+              </td>
+            </tr>
+          ) : (
+            table.getRowModel().rows.map((row) => (
+              <tr
+                key={row.id}
+                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                style={onRowClick ? { cursor: 'pointer' } : undefined}
+              >
+                {row.getVisibleCells().map((cell, idx) => (
+                  <td
+                    key={cell.id}
+                    className={
+                      idx < row.getVisibleCells().length - 1
+                        ? 'border-r border-b border-gray-300 p-2 text-sm'
+                        : 'border-b border-gray-300 p-2 text-sm'
+                    }
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -12,10 +12,9 @@ interface Props<T extends RowData> {
   columns: Column<T>[];
   rows: T[];
   actions?: (row: T) => ReactNode;
-  onRowClick?: (row: T) => void;
 }
 
-function Table<T extends RowData>({ columns, rows, actions, onRowClick }: Props<T>) {
+function Table<T extends RowData>({ columns, rows, actions }: Props<T>) {
   const tableColumns: ColumnDef<T>[] = columns.map((col) => ({
     accessorKey: col.key,
     header: col.header,
@@ -76,11 +75,7 @@ function Table<T extends RowData>({ columns, rows, actions, onRowClick }: Props<
             </tr>
           ) : (
             table.getRowModel().rows.map((row) => (
-              <tr
-                key={row.id}
-                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-                style={onRowClick ? { cursor: 'pointer' } : undefined}
-              >
+              <tr key={row.id}>
                 {row.getVisibleCells().map((cell, idx) => (
                   <td
                     key={cell.id}

--- a/src/pages/admin/ContestsTab/ContestAdminTab.tsx
+++ b/src/pages/admin/ContestsTab/ContestAdminTab.tsx
@@ -23,7 +23,7 @@ const HistoryMenu = ({ contestName, onContestChange }: HistoryMenuProps) => {
   const { data: contests } = useQuery({ queryKey: ['contests'], queryFn: getAllContests });
 
   return (
-    <div className="relative inline-block">
+    <div className="relative inline-block w-64">
       <select
         value={contestName}
         onChange={(e) => {
@@ -82,12 +82,12 @@ const ContestAdminTab = () => {
         <Table<ContestResponseDto>
           columns={[
             {
-              label: '편집일시',
+              header: '편집일시',
               width: '20%',
               key: 'updatedAt',
               render: (row) => row.updatedAt.replace('T', ' ').slice(0, 16),
             },
-            { label: '대회명', width: '50%', key: 'contestName' },
+            { header: '대회명', width: '50%', key: 'contestName' },
           ]}
           rows={contests ?? []}
           actions={(row) => (
@@ -120,16 +120,19 @@ const ContestAdminTab = () => {
       </section>
 
       <section className="min-w-[350px]">
-        <div className="mb-8 flex">
-          <h2 className="mr-16 text-2xl font-bold">대회별 프로젝트 목록</h2>
+        <div className="mb-8 flex flex-col md:flex-row">
+          <h2 className="mr-16 text-2xl font-bold text-nowrap sm:mb-4">대회별 프로젝트 목록</h2>
           <HistoryMenu contestName={state.currentContestName} onContestChange={handleContestChange} />
         </div>
-
         <Table<TeamListItemResponseDto>
           columns={[
-            { label: '순번', width: '10%', key: 'teamId' },
-            { label: '팀명', width: '30%', key: 'teamName' },
-            { label: '작품명', width: '30%', key: 'projectName' },
+            { header: '순번', width: '10%', key: 'teamId' },
+            {
+              header: '팀명',
+              width: '30%',
+              key: 'teamName',
+            },
+            { header: '작품명', width: '30%', key: 'projectName' },
           ]}
           rows={state.contestTeams}
           actions={(row) => (

--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -36,12 +36,21 @@ const ManageNoticeListTab = () => {
         <Table<NoticeResponseDto>
           columns={[
             {
-              label: '편집일시',
-              width: '30%',
+              header: '편집일시',
+              width: '20%',
               key: 'updatedAt',
               render: (row) => row.updatedAt,
             },
-            { label: '제목', width: '30%', key: 'title' },
+            {
+              header: '제목',
+              width: '50%',
+              key: 'title',
+              render: (row) => (
+                <span onClick={() => navigate(`/notices/${row.noticeId}`)} className="cursor-pointer">
+                  {row.title}
+                </span>
+              ),
+            },
           ]}
           rows={notices ?? []}
           actions={(row) => (

--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -5,6 +5,7 @@ import { deleteNotice, getNotices } from 'apis/notices';
 import { useToast } from 'hooks/useToast';
 import { useNavigate } from 'react-router-dom';
 import { NoticeResponseDto } from 'types/DTO/notices/NoticeResponseDto';
+import { Link } from 'react-router-dom';
 
 const ManageNoticeListTab = () => {
   const navigate = useNavigate();
@@ -46,9 +47,10 @@ const ManageNoticeListTab = () => {
               width: '50%',
               key: 'title',
               render: (row) => (
-                <span onClick={() => navigate(`/notices/${row.noticeId}`)} className="cursor-pointer">
-                  {row.title}
-                </span>
+                <Link to={`/notices/${row.noticeId}`}>{row.title}</Link>
+                // <span onClick={() => navigate(`/notices/${row.noticeId}`)} className="cursor-pointer">
+                //   {row.title}
+                // </span>
               ),
             },
           ]}

--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -46,12 +46,7 @@ const ManageNoticeListTab = () => {
               header: '제목',
               width: '50%',
               key: 'title',
-              render: (row) => (
-                <Link to={`/notices/${row.noticeId}`}>{row.title}</Link>
-                // <span onClick={() => navigate(`/notices/${row.noticeId}`)} className="cursor-pointer">
-                //   {row.title}
-                // </span>
-              ),
+              render: (row) => <Link to={`/notices/${row.noticeId}`}>{row.title}</Link>,
             },
           ]}
           rows={notices ?? []}

--- a/src/pages/admin/ProjectSubmissionTable.tsx
+++ b/src/pages/admin/ProjectSubmissionTable.tsx
@@ -16,9 +16,11 @@ const TableHead = ({ type }: { type: 'project' | 'vote' }) => {
   return (
     <thead className="bg-gray-100">
       <tr>
-        <th className="w-[5%] border-r border-b border-gray-300 p-2 text-sm">{type === 'project' ? '순번' : '순위'}</th>
-        <th className="w-[20%] border-r border-b border-gray-300 p-2 text-sm">팀명</th>
-        <th className="w-[55%] border-r border-b border-gray-300 p-2 text-sm">작품명</th>
+        <th className="w-[5%] border-r border-b border-gray-300 p-2 text-left text-sm">
+          {type === 'project' ? '순번' : '순위'}
+        </th>
+        <th className="w-[20%] border-r border-b border-gray-300 p-2 text-left text-sm">팀명</th>
+        <th className="w-[55%] border-r border-b border-gray-300 p-2 text-left text-sm">작품명</th>
         <th className="w-[20%] border-b border-gray-300 p-2 text-sm">
           {type === 'project' ? '제출여부' : '좋아요 수'}
         </th>


### PR DESCRIPTION
### 📝 개요
기존 테이블 컴포넌트에서 tanstack react-table을 추가해서 만들었습니다.
### 🎯 목적
* 좌우 스크롤
* 공지사항 클릭 시 이동하기 위해 (Link 태그)
### ✨ 변경 사항
1. npm 으로 react-table 설치
2. react-table로 수정
3. 공지사항 Link 태그로 수정
4. 대회별 프로젝트 목록과 select 버튼이 모바일에서 깨짐 수정

### 📸 참고 이미지/영상
* 좌우 스크롤
<img width="648" height="673" alt="스크린샷 2025-07-16 오후 12 32 23" src="https://github.com/user-attachments/assets/8aeb886e-ddef-4407-bdc2-cd531f42dee1" />

* 모바일에서 UI
<img width="499" height="248" alt="스크린샷 2025-07-16 오후 12 33 13" src="https://github.com/user-attachments/assets/95850a77-54bf-40b6-9436-1c1f79b605ab" />
