### PR TITLE
Feat: GitHub embed card 구현

### DIFF
--- a/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
+++ b/src/pages/admin/NoticeManageTab/ManageNoticeListTab.tsx
@@ -67,7 +67,7 @@ const ManageNoticeListTab = () => {
         />
         <button
           type="submit"
-          className="bg-mainBlue mx-auto w-fit rounded-lg px-6 py-3 text-lg text-white"
+          className="bg-mainBlue mx-auto w-fit rounded-lg px-6 py-3 text-lg text-white hover:cursor-pointer"
           onClick={() => navigate('/admin/notice/create')}
         >
           공지사항 추가하기

--- a/src/pages/project-editor/AdminEditSection/AdminEditSection.tsx
+++ b/src/pages/project-editor/AdminEditSection/AdminEditSection.tsx
@@ -22,8 +22,8 @@ const AdminEditSection = ({
   setLeaderName,
 }: AdminEditSectionProps) => {
   return (
-    <div className="flex flex-col gap-8 sm:gap-5">
-      <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-center sm:gap-10">
+    <div className="text-exsm flex flex-col gap-8 sm:gap-5 sm:text-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-10">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
           <span className="w-full">대회명</span>
@@ -32,7 +32,7 @@ const AdminEditSection = ({
           <ContestMenu value={contestId} onChange={setContestId} />
         </div>
       </div>
-      <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-center sm:gap-10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-10">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
           <span className="w-full text-nowrap">프로젝트명</span>
@@ -43,11 +43,11 @@ const AdminEditSection = ({
             value={projectName}
             onChange={(e) => setProjectName(e.target.value)}
             placeholder="프로젝트 이름을 입력해주세요."
-            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
+            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>
       </div>
-      <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-center sm:gap-10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-10">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
           <span className="w-full">팀명</span>
@@ -58,11 +58,11 @@ const AdminEditSection = ({
             value={teamName}
             onChange={(e) => setTeamName(e.target.value)}
             placeholder="팀 이름을 입력해주세요."
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border px-5 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>
       </div>
-      <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-center sm:gap-10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-10">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
           <span className="w-full">팀장명</span>
@@ -73,7 +73,7 @@ const AdminEditSection = ({
             value={leaderName}
             onChange={(e) => setLeaderName(e.target.value)}
             placeholder="팀장 이름을 입력해주세요."
-            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
+            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>
       </div>

--- a/src/pages/project-editor/AdminEditSection/ContestMenu.tsx
+++ b/src/pages/project-editor/AdminEditSection/ContestMenu.tsx
@@ -45,7 +45,7 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
     );
 
   return (
-    <div className="relative w-full max-w-sm text-sm">
+    <div className="text-exsm relative w-full max-w-sm sm:text-sm">
       <button
         className="border-lightGray focus:ring-subGreen focus:border-mainGreen flex w-full items-center justify-between rounded border px-5 py-3 text-left duration-150 hover:cursor-pointer focus:outline-none"
         onClick={() => {

--- a/src/pages/project-editor/AdminEditSection/MembersInput.tsx
+++ b/src/pages/project-editor/AdminEditSection/MembersInput.tsx
@@ -53,7 +53,9 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
                 placeholder="팀원명을 입력해주세요."
                 className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-15 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
                 value={newMemberInput}
-                onChange={(e) => setNewMemberInput(e.target.value)}
+                onChange={(e) => {
+                  if (e.target.value.length <= 20) setNewMemberInput(e.target.value);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') handleAddMember();
                 }}

--- a/src/pages/project-editor/AdminEditSection/MembersInput.tsx
+++ b/src/pages/project-editor/AdminEditSection/MembersInput.tsx
@@ -21,7 +21,7 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
   };
 
   return (
-    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:items-start sm:gap-10">
+    <div className="text-exsm flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-10 sm:text-sm">
       <div className="text-midGray flex w-25 sm:py-3">
         <span className="mr-1 text-red-500">*</span>
         <span>팀원</span>
@@ -32,7 +32,7 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
           {teamMembers.map((member) => (
             <div
               key={member.teamMemberId}
-              className="border:lightGray relative w-full rounded border px-15 py-3 text-sm text-black"
+              className="border:lightGray relative w-full rounded border px-15 py-3 text-black"
             >
               <IoPerson className="text-mainGreen/50 absolute top-1/2 left-5 -translate-y-1/2" size={20} />
               <div className="truncate">{member.teamMemberName}</div>
@@ -51,7 +51,7 @@ const MembersInput = ({ teamMembers, onMemberAdd, onMemberRemove }: MembersInput
               <input
                 type="text"
                 placeholder="팀원명을 입력해주세요."
-                className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-15 py-3 text-sm text-black duration-300 ease-in-out focus:outline-none"
+                className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-15 py-3 text-black duration-300 ease-in-out focus:outline-none"
                 value={newMemberInput}
                 onChange={(e) => {
                   if (e.target.value.length <= 20) setNewMemberInput(e.target.value);

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -194,15 +194,15 @@ const ImageUploaderSection = ({
 
       <div className="flex w-full flex-1 flex-col gap-3 xl:flex-row">
         <div
-          className="border-lightGray text-midGray sm:items-around flex flex-1 flex-col items-center justify-center gap-2 rounded border p-6 text-center sm:gap-5"
+          className="border-lightGray text-midGray sm:items-around flex flex-1 flex-col items-center justify-center gap-2 rounded border p-6 text-center sm:gap-3 md:gap-5"
           onDrop={handleDrop}
           onDragOver={handleDragOver}
         >
-          <p className="text-xs sm:inline sm:text-sm">파일을 이곳에 끌어놓아주세요.</p>
-          <p className="text-midGray my-2 text-xs sm:inline sm:text-sm">OR</p>
-          <label className="text-mainGreen bg-subGreen hover:bg-emerald-00 flex cursor-pointer rounded-full p-4 text-sm font-bold">
+          <p className="sm:text-exsm text-xs sm:inline">파일을 이곳에 끌어놓아주세요.</p>
+          <p className="text-midGray sm:text-exsm my-2 text-xs sm:inline">OR</p>
+          <label className="text-mainGreen bg-subGreen hover:bg-emerald-00 flex cursor-pointer rounded-full p-4 font-bold">
             <MdOutlineFileUpload className="sm:hidden" />
-            <span className="hidden px-4 sm:inline">파일 업로드</span>
+            <span className="sm:text-exsm hidden px-4 text-sm sm:inline">파일 업로드</span>
             <input type="file" accept="image/*" multiple className="hidden" onChange={handleImageUpload} />
           </label>
         </div>

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -171,8 +171,8 @@ const ImageUploaderSection = ({
   while (paddedImages.length < MAX_IMAGES) paddedImages.push(undefined);
 
   return (
-    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
-      <div className="flex items-start gap-3 sm:flex-col sm:pt-3">
+    <div className="flex flex-col gap-3 text-sm sm:flex-row sm:gap-10">
+      <div className="text-exsm flex items-start gap-3 sm:flex-col sm:pt-3 sm:text-sm">
         <div className="text-midGray flex w-25 gap-1">
           <span className="mr-1 text-red-500">*</span>
           <span>이미지</span>
@@ -182,7 +182,7 @@ const ImageUploaderSection = ({
             <HiInformationCircle /> 가이드
           </span>
 
-          <div className="absolute top-1/2 left-full z-10 ml-3 w-64 -translate-y-1/2 rounded bg-green-50 p-3 text-xs text-green-600 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-80">
+          <div className="absolute top-1/2 left-full z-10 ml-3 w-64 -translate-y-1/2 rounded bg-green-50 p-3 text-xs text-green-600 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-80 group-active:opacity-100">
             권장 비율: <strong>3:2</strong> (예: 1500×1000)
             <br />
             최대 용량: <strong>2MB</strong>

--- a/src/pages/project-editor/IntroSection.tsx
+++ b/src/pages/project-editor/IntroSection.tsx
@@ -11,7 +11,7 @@ interface IntroSectionProps {
 
 const IntroSection = ({ projectName, teamName, leaderName, teamMembers }: IntroSectionProps) => {
   return (
-    <div className="flex gap-10 truncate text-sm">
+    <div className="text-exsm flex gap-10 truncate sm:text-sm">
       <div className="text-midGray flex w-25 flex-col gap-3 pl-3">
         <span>프로젝트</span>
         <span>팀명</span>

--- a/src/pages/project-editor/OverviewInput.tsx
+++ b/src/pages/project-editor/OverviewInput.tsx
@@ -27,7 +27,7 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
   };
 
   return (
-    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
+    <div className="text-exsm flex flex-col gap-3 sm:flex-row sm:gap-10 sm:text-sm">
       <div className="text-midGray flex w-25 gap-1 sm:py-3">
         <span className="mr-1 text-red-500">*</span>
         <span className="w-full">Overview</span>
@@ -36,7 +36,7 @@ const OverviewInput = ({ overview, setOverview }: OverviewInputProps) => {
         <textarea
           ref={textareaRef}
           placeholder={`Overview를 입력해주세요. (최대 ${MAX_OVERVIEW}자)`}
-          className="placeholder-lightGray border-lightGray focus:border-mainGreen h-40 max-h-40 min-h-40 w-full resize-none overflow-auto rounded border px-4 py-3 text-sm transition-all duration-300 ease-in-out focus:outline-none"
+          className="placeholder-lightGray border-lightGray focus:border-mainGreen h-40 max-h-40 min-h-40 w-full resize-none overflow-auto rounded border px-4 py-3 transition-all duration-300 ease-in-out focus:outline-none"
           value={overview ?? ''}
           onChange={handleOverviewChange}
           onBlur={handleOverviewBlur}

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -396,8 +396,8 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
   };
 
   return (
-    <div className="px-2 sm:px-5">
-      <div className="text-title font-bold">{isEditMode ? '프로젝트 수정' : '프로젝트 생성'}</div>
+    <div className="min-w-xs px-2 sm:px-5">
+      <div className="sm:text-title text-xl font-bold">{isEditMode ? '프로젝트 수정' : '프로젝트 생성'}</div>
       <div className="h-10" />
       {isAdmin && contestId !== 1 && (
         <>
@@ -451,17 +451,17 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
       <div className="h-15" />
       <OverviewInput overview={overview} setOverview={setOverview} />
       <div className="h-20" />
-      <div className="flex justify-end gap-5 sm:gap-10">
+      <div className="flex flex-col-reverse items-end gap-5 sm:flex-row sm:justify-end sm:gap-10">
         <button
           onClick={() => navigate(-1)}
-          className="border-mainGreen hover:bg-whiteGray focus:bg-subGreen text-mainGreen rounded-full border px-4 py-2 font-bold hover:cursor-pointer focus:outline-none sm:px-15 sm:py-4"
+          className="border-mainGreen hover:bg-whiteGray focus:bg-subGreen text-mainGreen rounded-full border px-15 py-4 font-bold hover:cursor-pointer focus:outline-none"
         >
           취소
         </button>
         <button
           onClick={handleSave}
           disabled={isSaved}
-          className="bg-mainGreen rounded-full px-4 py-2 text-sm font-bold text-white hover:cursor-pointer hover:bg-green-700 focus:bg-green-400 focus:outline-none sm:px-15 sm:py-4"
+          className="bg-mainGreen rounded-full px-15 py-4 text-sm font-bold text-white hover:cursor-pointer hover:bg-green-700 focus:bg-green-400 focus:outline-none"
         >
           저장
         </button>

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -396,7 +396,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
   };
 
   return (
-    <div className="px-5">
+    <div className="px-2 sm:px-5">
       <div className="text-title font-bold">{isEditMode ? '프로젝트 수정' : '프로젝트 생성'}</div>
       <div className="h-10" />
       {isAdmin && contestId !== 1 && (

--- a/src/pages/project-editor/UrlInput.tsx
+++ b/src/pages/project-editor/UrlInput.tsx
@@ -31,31 +31,46 @@ const UrlInput = ({
           <FaGithub className="absolute top-1/2 left-5 -translate-y-1/2 text-gray-500" size={20} />
           <input
             type="url"
-            placeholder="https://github.com/ (필수)"
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-black duration-300 ease-in-out focus:outline-none"
+            placeholder="https://github.com"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-13 text-black duration-300 ease-in-out focus:outline-none"
             value={githubUrl}
             onChange={(e) => setGithubUrl(e.target.value)}
           />
+          {!githubUrl && (
+            <span className="text-mainGreen/60 bg-subGreen/50 absolute top-1/2 right-4 -translate-y-1/2 rounded-full px-2 py-1 text-xs">
+              필수
+            </span>
+          )}
         </div>
         <div className="relative w-full">
           <FaYoutube className="absolute top-1/2 left-5 -translate-y-1/2 text-red-400" size={20} />
           <input
             type="url"
-            placeholder="https://youtube.com/ (필수)"
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-black duration-300 ease-in-out focus:outline-none"
+            placeholder="https://youtube.com"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-13 text-black duration-300 ease-in-out focus:outline-none"
             value={youtubeUrl}
             onChange={(e) => setYoutubeUrl(e.target.value)}
           />
+          {!youtubeUrl && (
+            <span className="text-mainGreen/60 bg-subGreen/50 absolute top-1/2 right-4 -translate-y-1/2 rounded-full px-2 py-1 text-xs">
+              필수
+            </span>
+          )}
         </div>
         <div className="relative w-full">
           <RiLink className="text-mainGreen/50 absolute top-1/2 left-5 -translate-y-1/2" size={20} />
           <input
             type="url"
-            placeholder="https://your-project.vercel.app (선택)"
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-black duration-300 ease-in-out focus:outline-none"
+            placeholder="https://your-project.com"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-13 text-black duration-300 ease-in-out focus:outline-none"
             value={productionUrl ?? ''}
             onChange={(e) => setProductionUrl(e.target.value)}
           />
+          {!productionUrl && (
+            <span className="text-midGray/80 bg-whiteGray absolute top-1/2 right-4 -translate-y-1/2 rounded-full px-2 py-1 text-xs">
+              선택
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/project-editor/UrlInput.tsx
+++ b/src/pages/project-editor/UrlInput.tsx
@@ -21,7 +21,7 @@ const UrlInput = ({
   setYoutubeUrl,
 }: UrlInputProps) => {
   return (
-    <div className="flex flex-col gap-5 text-sm sm:flex-row sm:gap-10">
+    <div className="text-exsm flex flex-col gap-3 sm:flex-row sm:gap-10 sm:text-sm">
       <div className="text-midGray flex w-25 sm:py-3">
         <span className="mr-1 text-red-500">*</span>
         <span>URL</span>
@@ -32,7 +32,7 @@ const UrlInput = ({
           <input
             type="url"
             placeholder="https://github.com/ (필수)"
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-black duration-300 ease-in-out focus:outline-none"
             value={githubUrl}
             onChange={(e) => setGithubUrl(e.target.value)}
           />
@@ -42,7 +42,7 @@ const UrlInput = ({
           <input
             type="url"
             placeholder="https://youtube.com/ (필수)"
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-black duration-300 ease-in-out focus:outline-none"
             value={youtubeUrl}
             onChange={(e) => setYoutubeUrl(e.target.value)}
           />
@@ -52,7 +52,7 @@ const UrlInput = ({
           <input
             type="url"
             placeholder="https://your-project.vercel.app (선택)"
-            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-sm text-black duration-300 ease-in-out focus:outline-none"
+            className="placeholder-lightGray focus:border-mainGreen border-lightGray w-full truncate rounded border py-3 pr-5 pl-15 text-black duration-300 ease-in-out focus:outline-none"
             value={productionUrl ?? ''}
             onChange={(e) => setProductionUrl(e.target.value)}
           />

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -293,7 +293,7 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
   const goToSlide = (index: number) => setCurrentIndex(index);
 
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex min-w-xs flex-col items-center gap-4">
       <div className="flex items-center justify-center md:gap-10">
         {visibleImages.length > 1 && !isMobile && <ArrowButton direction="left" onClick={goToPrev} />}
 

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -297,7 +297,7 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
       <div className="flex items-center justify-center md:gap-10">
         {visibleImages.length > 1 && !isMobile && <ArrowButton direction="left" onClick={goToPrev} />}
 
-        <div className="border-lightGray relative aspect-[3/2] w-[50vw] max-w-[900px] min-w-[300px] overflow-hidden rounded">
+        <div className="border-lightGray relative aspect-[3/2] w-[50vw] max-w-[900px] min-w-sm overflow-hidden rounded">
           <MediaRenderer
             currentMedia={currentMedia}
             embedUrl={embedUrl}
@@ -313,7 +313,7 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
 
       {visibleImages.length > 1 && (
         <div
-          className={`mt-4 flex items-center ${!isMobile ? 'justify-center' : 'justify-between'} w-[50vw] max-w-[900px] min-w-[300px] px-3`}
+          className={`mt-4 flex items-center ${!isMobile ? 'justify-center' : 'justify-between'} w-[50vw] max-w-[900px] min-w-sm px-3`}
         >
           {isMobile && <ArrowButton direction="left" onClick={goToPrev} size={40} />}
 

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -293,7 +293,7 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
   const goToSlide = (index: number) => setCurrentIndex(index);
 
   return (
-    <div className="flex min-w-xs flex-col items-center gap-4">
+    <div className="flex flex-col items-center gap-4">
       <div className="flex items-center justify-center md:gap-10">
         {visibleImages.length > 1 && !isMobile && <ArrowButton direction="left" onClick={goToPrev} />}
 

--- a/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentFormSection.tsx
@@ -65,7 +65,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
 
   return (
     <>
-      <div className="ring-lightGray focus-within:ring-midGray flex h-36 flex-col gap-2 rounded p-3 text-sm ring-1 transition-all duration-300 ease-in-out focus-within:ring-1">
+      <div className="ring-lightGray focus-within:ring-midGray text-exsm flex h-36 flex-col gap-2 rounded p-3 ring-1 transition-all duration-300 ease-in-out focus-within:ring-1 sm:text-sm">
         <textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
@@ -81,7 +81,7 @@ const CommentFormSection = ({ teamId }: CommentFormSection) => {
       <div className="mt-2 flex justify-end">
         <button
           onClick={handleClick}
-          className="text-mainGreen rounded-full bg-[#D1F3E1] px-10 py-2 font-medium transition-colors duration-200 hover:cursor-pointer hover:bg-[#b2e8cf] focus:bg-[#b2e8cf] focus:outline-none"
+          className="text-mainGreen text-exsm rounded-full bg-[#D1F3E1] px-10 py-2 font-medium transition-colors duration-200 hover:cursor-pointer hover:bg-[#b2e8cf] focus:bg-[#b2e8cf] focus:outline-none sm:text-sm"
         >
           등록
         </button>

--- a/src/pages/project-viewer/CommentSection/CommentSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentSection.tsx
@@ -16,7 +16,7 @@ const CommentSection = ({ teamId }: CommentSectionProps) => {
     return (
       <button
         onClick={() => navigate('/signin')}
-        className="bg-whiteGray text-midGray flex h-[100px] w-full items-center justify-center rounded hover:cursor-pointer"
+        className="bg-whiteGray text-midGray text-exsm flex h-[100px] w-full items-center justify-center rounded hover:cursor-pointer sm:text-sm"
       >
         댓글 작성 및 열람은 로그인이 필요해요.
       </button>

--- a/src/pages/project-viewer/CommentSection/CommentSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentSection.tsx
@@ -25,7 +25,7 @@ const CommentSection = ({ teamId }: CommentSectionProps) => {
 
   return (
     <>
-      <div className="flex flex-col">
+      <div className="flex min-w-xs flex-col">
         <CommentFormSection teamId={teamId} />
         <div className="h-20" />
         <CommentListSection teamId={teamId} />

--- a/src/pages/project-viewer/CommentSection/CommentSection.tsx
+++ b/src/pages/project-viewer/CommentSection/CommentSection.tsx
@@ -25,7 +25,7 @@ const CommentSection = ({ teamId }: CommentSectionProps) => {
 
   return (
     <>
-      <div className="flex min-w-xs flex-col">
+      <div className="flex flex-col">
         <CommentFormSection teamId={teamId} />
         <div className="h-20" />
         <CommentListSection teamId={teamId} />

--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -20,18 +20,20 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
   const visibleText = isFolded && shouldTruncate ? safeOverview.slice(0, INIT_LENGTH) : safeOverview;
 
   return (
-    <>
+    <div className="min-w-xs">
       <div className="flex flex-col gap-3">
-        <div className="text-title font-bold">Participants</div>
+        <div className="sm:text-title text-xl font-bold">Participants</div>
         <span className="flex items-center gap-3">
           <FaCrown className="text-amber-300" size={20} />
-          <span className="bg-whiteGray rounded-full px-3 py-1 text-sm whitespace-nowrap">{leaderName}</span>
+          <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
+            {leaderName}
+          </span>
         </span>
         <div className="flex items-start gap-3 sm:items-center">
-          <IoPerson className="mt-2 shrink-0 text-blue-400 sm:mt-0" size={20} />
+          <IoPerson className="mt-1 shrink-0 text-blue-400 sm:mt-0" size={20} />
           <div className="flex flex-wrap gap-2 sm:gap-3">
             {teamMembers.map((member, index) => (
-              <span key={index} className="bg-whiteGray rounded-full px-3 py-1 text-sm whitespace-nowrap">
+              <span key={index} className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
                 {member.teamMemberName}
               </span>
             ))}
@@ -43,8 +45,8 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
         <>
           <div className="h-10" />
           <div className="flex flex-col gap-3">
-            <div className="text-title font-bold">Overview</div>
-            <div className="bg-whiteGray rounded-md p-4 text-sm leading-[1.7] whitespace-pre-wrap">
+            <div className="sm:text-title text-xl font-bold">Overview</div>
+            <div className="bg-whiteGray text-exsm rounded p-4 leading-[1.7] whitespace-pre-wrap sm:text-sm">
               {visibleText}
               {shouldTruncate && (
                 <button
@@ -58,7 +60,7 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
           </div>
         </>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -29,8 +29,8 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
             {leaderName}
           </span>
         </span>
-        <div className="flex items-start gap-3 sm:items-center">
-          <IoPerson className="mt-1 shrink-0 text-blue-400 sm:mt-0" size={20} />
+        <div className="flex items-start gap-3">
+          <IoPerson className="mt-1 shrink-0 text-blue-400" size={20} />
           <div className="flex flex-wrap gap-2 sm:gap-3">
             {teamMembers.map((member, index) => (
               <span key={index} className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">

--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -20,7 +20,7 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
   const visibleText = isFolded && shouldTruncate ? safeOverview.slice(0, INIT_LENGTH) : safeOverview;
 
   return (
-    <div className="min-w-xs">
+    <>
       <div className="flex flex-col gap-3">
         <div className="sm:text-title text-xl font-bold">Participants</div>
         <span className="flex items-center gap-3">
@@ -60,7 +60,7 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
           </div>
         </>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -21,26 +21,6 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
 
   return (
     <>
-      {hasOverview && (
-        <>
-          <div className="flex flex-col gap-3">
-            <div className="text-title font-bold">Overview</div>
-            <div className="bg-whiteGray rounded-md p-4 text-sm leading-[1.7] whitespace-pre-wrap">
-              {visibleText}
-              {shouldTruncate && (
-                <button
-                  className="bg-subGreen text-mainGreen mx-3 cursor-pointer rounded-full px-3 py-1 text-xs hover:bg-emerald-100"
-                  onClick={() => setIsFolded(!isFolded)}
-                >
-                  {isFolded ? <IoEllipsisHorizontal /> : '간략히'}
-                </button>
-              )}
-            </div>
-          </div>
-          <div className="h-20" />
-        </>
-      )}
-
       <div className="flex flex-col gap-3">
         <div className="text-title font-bold">Participants</div>
         <span className="flex items-center gap-3">
@@ -58,6 +38,26 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
           </div>
         </div>
       </div>
+
+      {hasOverview && (
+        <>
+          <div className="h-10" />
+          <div className="flex flex-col gap-3">
+            <div className="text-title font-bold">Overview</div>
+            <div className="bg-whiteGray rounded-md p-4 text-sm leading-[1.7] whitespace-pre-wrap">
+              {visibleText}
+              {shouldTruncate && (
+                <button
+                  className="bg-subGreen text-mainGreen mx-3 cursor-pointer rounded-full px-3 py-1 text-xs hover:bg-emerald-100"
+                  onClick={() => setIsFolded(!isFolded)}
+                >
+                  {isFolded ? <IoEllipsisHorizontal /> : '간략히'}
+                </button>
+              )}
+            </div>
+          </div>
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -42,9 +42,9 @@ const UrlButton = ({ url }: { url: string }) => {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="border-mainGreen text-mainGreen hover:border-mainGreen inline-flex h-10 w-10 items-center justify-center gap-2 rounded-full border transition-colors duration-200 hover:bg-[#D1F3E1]/60 focus:outline-none sm:w-auto sm:px-5"
+      className="border-mainGreen text-mainGreen hover:border-mainGreen inline-flex h-10 w-auto items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:bg-[#D1F3E1]/60 focus:outline-none"
     >
-      <span className="text-exsm hidden font-medium whitespace-nowrap sm:inline-block">{text}</span>
+      <span className="text-exsm font-medium whitespace-nowrap">{text}</span>
       <FiExternalLink className="text-subGreen shrink-0" />
     </a>
   );
@@ -63,8 +63,8 @@ const IntroSection = ({
   const navigate = useNavigate();
 
   return (
-    <div className="flex flex-col items-center gap-8 sm:flex-row sm:items-start sm:justify-between">
-      <div className="flex flex-col items-start gap-2 self-start sm:self-auto">
+    <div className="flex flex-col items-center gap-8 md:flex-row md:items-start md:justify-between">
+      <div className="flex flex-col items-start gap-2 self-start md:self-auto">
         <div className="sm:text-title pt-1 text-xl leading-none font-bold">{projectName}</div>
         <div className="text-midGray text-exsm font-bold sm:text-sm">{teamName}</div>
       </div>
@@ -73,9 +73,9 @@ const IntroSection = ({
           <div className="flex">
             <button
               onClick={() => navigate(`/teams/edit/${teamId}`)}
-              className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 w-10 items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60 sm:w-auto"
+              className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 w-auto items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60"
             >
-              <span className="hidden whitespace-nowrap sm:inline">수정하기</span>{' '}
+              <span className="whitespace-nowrap">수정하기</span>
               <FaEdit className="text-lightGray shrink-0" />
             </button>
           </div>

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -63,8 +63,8 @@ const IntroSection = ({
   const navigate = useNavigate();
 
   return (
-    <div className="flex min-w-xs flex-col items-center gap-8 md:flex-row md:items-start md:justify-between">
-      <div className="flex flex-col items-center gap-2 md:items-start">
+    <div className="flex flex-col items-center gap-8 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col items-start gap-2 self-start sm:self-auto">
         <div className="sm:text-title pt-1 text-xl leading-none font-bold">{projectName}</div>
         <div className="text-midGray text-exsm font-bold sm:text-sm">{teamName}</div>
       </div>

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -74,7 +74,8 @@ const IntroSection = ({
                   onClick={() => navigate(`/teams/edit/${teamId}`)}
                   className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 w-10 items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60 sm:w-auto"
                 >
-                  <span className="hidden sm:inline">수정하기</span> <FaEdit className="text-lightGray shrink-0" />
+                  <span className="hidden whitespace-nowrap sm:inline">수정하기</span>{' '}
+                  <FaEdit className="text-lightGray shrink-0" />
                 </button>
               </div>
             )}

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -85,8 +85,6 @@ const IntroSection = ({
 
       <div className="flex w-full flex-1 flex-col items-end gap-2">
         {productionUrl && <UrlButton url={productionUrl} />}
-        {githubUrl && <UrlButton url={githubUrl} />}
-        {youtubeUrl && <UrlButton url={youtubeUrl} />}
       </div>
     </div>
   );

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -4,7 +4,7 @@ import useAuth from 'hooks/useAuth';
 import { useUserStore } from 'stores/useUserStore';
 
 import { FaGithub, FaYoutube } from 'react-icons/fa';
-import { GoPencil } from 'react-icons/go';
+import { FaEdit } from 'react-icons/fa';
 import { RiLink } from 'react-icons/ri';
 import { FiExternalLink } from 'react-icons/fi';
 
@@ -42,11 +42,10 @@ const UrlButton = ({ url }: { url: string }) => {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="border-lightGray hover:border-mainGreen inline-flex w-45 items-center gap-2 rounded-full border px-4 py-1 transition-colors duration-200 hover:bg-[#D1F3E1]/60 focus:outline-none"
+      className="border-mainGreen text-mainGreen hover:border-mainGreen inline-flex h-10 w-10 items-center justify-center gap-2 rounded-full border transition-colors duration-200 hover:bg-[#D1F3E1]/60 focus:outline-none sm:w-auto sm:px-5"
     >
-      <span className="shrink-0">{icon}</span>
-      <span className="text-xs whitespace-nowrap text-gray-700">{text}</span>
-      <FiExternalLink className="text-lightGray ml-auto shrink-0" />
+      <span className="text-exsm hidden font-medium whitespace-nowrap sm:inline-block">{text}</span>
+      <FiExternalLink className="text-subGreen shrink-0" />
     </a>
   );
 };
@@ -64,27 +63,25 @@ const IntroSection = ({
   const navigate = useNavigate();
 
   return (
-    <div className="flex w-full flex-wrap items-start gap-4">
-      <div className="flex justify-start gap-5">
-        <div className="flex min-w-0 flex-col gap-2">
+    <div className="flex min-w-xs flex-wrap items-start gap-4">
+      <div className="w-full flex-col">
+        <div className="flex w-full items-center justify-between gap-5">
           <div className="text-title min-w-0 leading-none font-bold">{projectName}</div>
-          <div className="text-smbold font-bold text-[#4B5563]">{teamName}</div>
-        </div>
-        {isEditor && (
-          <div className="flex pt-3">
-            <button
-              onClick={() => navigate(`/teams/edit/${teamId}`)}
-              className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 items-center gap-2 rounded-full border px-4 py-1 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60"
-            >
-              <GoPencil />
-              <span className="hidden sm:inline">수정하기</span>
-            </button>
+          <div className="flex gap-3">
+            {isEditor && (
+              <div className="flex">
+                <button
+                  onClick={() => navigate(`/teams/edit/${teamId}`)}
+                  className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 w-10 items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60 sm:w-auto"
+                >
+                  <span className="hidden sm:inline">수정하기</span> <FaEdit className="text-lightGray shrink-0" />
+                </button>
+              </div>
+            )}
+            {productionUrl && <UrlButton url={productionUrl} />}
           </div>
-        )}
-      </div>
-
-      <div className="flex w-full flex-1 flex-col items-end gap-2">
-        {productionUrl && <UrlButton url={productionUrl} />}
+        </div>
+        <div className="text-exsm text-midGray font-bold">{teamName}</div>
       </div>
     </div>
   );

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -63,26 +63,24 @@ const IntroSection = ({
   const navigate = useNavigate();
 
   return (
-    <div className="flex min-w-xs flex-wrap items-start gap-4">
-      <div className="w-full flex-col">
-        <div className="flex w-full items-center justify-between gap-5">
-          <div className="text-title min-w-0 leading-none font-bold">{projectName}</div>
-          <div className="flex gap-3">
-            {isEditor && (
-              <div className="flex">
-                <button
-                  onClick={() => navigate(`/teams/edit/${teamId}`)}
-                  className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 w-10 items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60 sm:w-auto"
-                >
-                  <span className="hidden whitespace-nowrap sm:inline">수정하기</span>{' '}
-                  <FaEdit className="text-lightGray shrink-0" />
-                </button>
-              </div>
-            )}
-            {productionUrl && <UrlButton url={productionUrl} />}
+    <div className="flex min-w-xs flex-col items-center gap-8 md:flex-row md:items-start md:justify-between">
+      <div className="flex flex-col items-center gap-2 md:items-start">
+        <div className="sm:text-title pt-1 text-xl leading-none font-bold">{projectName}</div>
+        <div className="text-midGray text-exsm font-bold sm:text-sm">{teamName}</div>
+      </div>
+      <div className="flex items-center gap-3">
+        {isEditor && (
+          <div className="flex">
+            <button
+              onClick={() => navigate(`/teams/edit/${teamId}`)}
+              className="border-midGray text-exsm text-midGray hover:text-mainGreen hover:border-mainGreen flex h-10 w-10 items-center justify-center gap-2 rounded-full border px-5 transition-colors duration-200 hover:cursor-pointer hover:bg-[#D1F3E1]/60 sm:w-auto"
+            >
+              <span className="hidden whitespace-nowrap sm:inline">수정하기</span>{' '}
+              <FaEdit className="text-lightGray shrink-0" />
+            </button>
           </div>
-        </div>
-        <div className="text-exsm text-midGray font-bold">{teamName}</div>
+        )}
+        {productionUrl && <UrlButton url={productionUrl} />}
       </div>
     </div>
   );

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -38,7 +38,7 @@ const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
   };
 
   return (
-    <div className="min-w-xs">
+    <>
       <button
         onClick={handleClick}
         disabled={likeMutation.isPending}
@@ -49,7 +49,7 @@ const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
         <FaHeart className={`${isLiked ? 'text-white' : 'text-whiteGray'}`} size={20} />
         <span className="hidden sm:inline">좋아요</span>
       </button>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -38,7 +38,7 @@ const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
   };
 
   return (
-    <>
+    <div className="min-w-xs">
       <button
         onClick={handleClick}
         disabled={likeMutation.isPending}
@@ -49,7 +49,7 @@ const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
         <FaHeart className={`${isLiked ? 'text-white' : 'text-whiteGray'}`} size={20} />
         <span className="hidden sm:inline">좋아요</span>
       </button>
-    </>
+    </div>
   );
 };
 

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -24,7 +24,7 @@ const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
       queryClient.invalidateQueries({ queryKey: ['projectDetails', teamId] });
       queryClient.invalidateQueries({ queryKey: ['teams', 'current', user?.id ?? 'guest'] });
       queryClient.invalidateQueries({ queryKey: ['teams', contestId, user?.id ?? 'guest'] });
-      toast(!isLiked ? '좋아요를 눌렀어요.' : '좋아요를 취소했어요.');
+      toast(!isLiked ? '좋아요를 눌렀어요' : '좋아요를 취소했어요');
     },
   });
 

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -44,7 +44,7 @@ const LikeSection = ({ contestId, teamId, isLiked }: LikeSectionProps) => {
         disabled={likeMutation.isPending}
         className={`${
           isLiked ? 'bg-mainGreen text-white hover:bg-emerald-600' : 'bg-lightGray text-white hover:bg-gray-300'
-        } relative flex cursor-pointer items-center gap-5 justify-self-center rounded-full px-5 py-3 text-sm sm:px-8`}
+        } relative flex cursor-pointer items-center gap-5 justify-self-center rounded-full p-4 text-sm sm:px-8 sm:py-3`}
       >
         <FaHeart className={`${isLiked ? 'text-white' : 'text-whiteGray'}`} size={20} />
         <span className="hidden sm:inline">좋아요</span>

--- a/src/pages/project-viewer/MediaSection/GithubCard.tsx
+++ b/src/pages/project-viewer/MediaSection/GithubCard.tsx
@@ -1,21 +1,22 @@
 import { useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import { FaGithub } from 'react-icons/fa';
 import { GithubCardSkeleton } from '../ViewerSkeleton';
 import { fetchGithubContent } from 'utils/media';
-import { FaGithub } from 'react-icons/fa';
-
-export type GithubContentType = 'repo' | 'profile';
 
 interface GithubCardProps {
   githubRepoUrl: string;
 }
 
+export type GithubContentType = 'repo' | 'profile';
+
 export interface GithubRepoData {
   name: string;
   description: string;
-  language: string;
+  html_url: string;
   owner: {
     avatar_url: string;
+    login: string;
   };
 }
 
@@ -25,7 +26,7 @@ export interface GithubProfileData {
   html_url: string;
   bio?: string;
   name?: string;
-  type: 'User' | 'Organization';
+  public_repos?: number;
 }
 
 const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
@@ -40,48 +41,45 @@ const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
   if (isPending) return <GithubCardSkeleton />;
   if (isError || !data) return null;
 
+  const cardStyle =
+    'flex w-full items-center justify-between rounded border border-gray-200 bg-white px-6 py-5 transition hover:bg-gray-50';
+
   if (data.type === 'repo') {
     const repo = data.data as GithubRepoData;
     return (
-      <a
-        href={githubRepoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center rounded border border-gray-200 p-3 hover:bg-gray-50"
-      >
-        <img src={repo.owner.avatar_url} alt="owner" className="mx-5 h-10 w-10 rounded-full border border-gray-300" />
-        <div className="ml-3 flex flex-1 flex-col text-sm">
-          <span className="font-semibold">{repo.name}</span>
-          <span className="hidden w-full max-w-[500px] truncate text-xs text-gray-500 sm:block">
-            {repo.description}
-          </span>
-          <span className="text-xs text-gray-400">{repo.language}</span>
+      <a href={repo.html_url} target="_blank" rel="noopener noreferrer" className={cardStyle}>
+        <div className="flex flex-col gap-1 truncate">
+          <p className="truncate text-sm font-semibold text-gray-900">{repo.name}</p>
+          <p className="text-exsm line-clamp-2 truncate text-gray-600">
+            {repo.description || 'No description provided.'}
+          </p>
+          <div className="text-exsm mt-2 flex items-center gap-2 text-gray-700 hover:text-black">
+            <FaGithub size={16} className="shrink-0" />
+            <p className="truncate">{repo.html_url}</p>
+          </div>
         </div>
-        <FaGithub size={30} className="mx-5 shrink-0 text-xl text-black" />
+        <img src={repo.owner.avatar_url} alt={`${repo.owner.login}'s avatar`} className="h-10 w-10 sm:h-30 sm:w-30" />
       </a>
     );
   }
 
   if (data.type === 'profile') {
     const profile = data.data as GithubProfileData;
+
     return (
-      <a
-        href={profile.html_url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center rounded border border-gray-200 p-4 hover:bg-gray-50"
-      >
-        <img
-          src={profile.avatar_url}
-          alt={profile.login}
-          className="mx-5 h-14 w-14 rounded-full border border-gray-300"
-        />
-        <div className="ml-3 flex flex-col text-sm">
-          <span className="text-lg font-semibold">{profile.name || profile.login}</span>
-          <span className="text-xs text-gray-500">{profile.bio}</span>
-          <span className="text-xs text-gray-400">{profile.type}</span>
+      <a href={profile.html_url} target="_blank" rel="noopener noreferrer" className={cardStyle}>
+        <div className="flex flex-col gap-1 truncate">
+          <p className="truncate text-sm font-semibold text-gray-900">{profile.name || profile.login}</p>
+          <p className="text-exsm line-clamp-2 truncate text-gray-600">
+            {profile.name || profile.login} has {profile.public_repos ?? 'several'} repositories available. Follow their
+            code on GitHub.
+          </p>
+          <div className="text-exsm mt-2 flex items-center gap-2 text-gray-700 hover:text-black">
+            <FaGithub size={16} className="shrink-0" />
+            <p className="truncate">{profile.html_url}</p>
+          </div>
         </div>
-        <FaGithub size={30} className="mx-5 shrink-0 text-xl text-black" />
+        <img src={profile.avatar_url} alt={`${profile.login}'s avatar`} className="h-15 w-15 sm:h-20 sm:w-20" />
       </a>
     );
   }

--- a/src/pages/project-viewer/MediaSection/GithubCard.tsx
+++ b/src/pages/project-viewer/MediaSection/GithubCard.tsx
@@ -58,7 +58,7 @@ const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
             <p className="truncate">{repo.html_url}</p>
           </div>
         </div>
-        <img src={repo.owner.avatar_url} alt={`${repo.owner.login}'s avatar`} className="h-10 w-10 sm:h-30 sm:w-30" />
+        <img src={repo.owner.avatar_url} alt={`${repo.owner.login}'s avatar`} className="h-15 w-15 sm:h-20 sm:w-20" />
       </a>
     );
   }

--- a/src/pages/project-viewer/MediaSection/GithubCard.tsx
+++ b/src/pages/project-viewer/MediaSection/GithubCard.tsx
@@ -49,11 +49,11 @@ const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
     return (
       <a href={repo.html_url} target="_blank" rel="noopener noreferrer" className={cardStyle}>
         <div className="flex flex-col gap-1 truncate">
-          <p className="truncate text-sm font-semibold text-gray-900">{repo.name}</p>
-          <p className="text-exsm line-clamp-2 truncate text-gray-600">
+          <p className="text-exsm truncate font-semibold text-gray-900 sm:text-sm">{repo.name}</p>
+          <p className="sm:text-exsm line-clamp-2 truncate text-xs text-gray-600">
             {repo.description || 'No description provided.'}
           </p>
-          <div className="text-exsm mt-2 flex items-center gap-2 text-gray-700 hover:text-black">
+          <div className="sm:text-exsm mt-2 flex items-center gap-2 text-xs text-gray-700 hover:text-black">
             <FaGithub size={16} className="shrink-0" />
             <p className="truncate">{repo.html_url}</p>
           </div>
@@ -69,12 +69,12 @@ const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
     return (
       <a href={profile.html_url} target="_blank" rel="noopener noreferrer" className={cardStyle}>
         <div className="flex flex-col gap-1 truncate">
-          <p className="truncate text-sm font-semibold text-gray-900">{profile.name || profile.login}</p>
-          <p className="text-exsm line-clamp-2 truncate text-gray-600">
+          <p className="text-exsm truncate font-semibold text-gray-900 sm:text-sm">{profile.name || profile.login}</p>
+          <p className="sm:text-exsm line-clamp-2 truncate text-xs text-gray-600">
             {profile.name || profile.login} has {profile.public_repos ?? 'several'} repositories available. Follow their
             code on GitHub.
           </p>
-          <div className="text-exsm mt-2 flex items-center gap-2 text-gray-700 hover:text-black">
+          <div className="sm:text-exsm mt-2 flex items-center gap-2 text-xs text-gray-700 hover:text-black">
             <FaGithub size={16} className="shrink-0" />
             <p className="truncate">{profile.html_url}</p>
           </div>

--- a/src/pages/project-viewer/MediaSection/GithubCard.tsx
+++ b/src/pages/project-viewer/MediaSection/GithubCard.tsx
@@ -42,7 +42,7 @@ const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
   if (isError || !data) return null;
 
   const cardStyle =
-    'flex w-full items-center justify-between rounded border border-gray-200 bg-white px-6 py-5 transition hover:bg-gray-50';
+    'flex w-full items-center justify-between rounded border border-gray-200 bg-white px-6 py-5 transition hover:bg-gray-50 min-w-xs';
 
   if (data.type === 'repo') {
     const repo = data.data as GithubRepoData;

--- a/src/pages/project-viewer/MediaSection/GithubCard.tsx
+++ b/src/pages/project-viewer/MediaSection/GithubCard.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { fetchGithubRepoData } from 'utils/media';
+import { GithubCardSkeleton } from '../ViewerSkeleton';
+import { fetchGithubContent } from 'utils/media';
 import { FaGithub } from 'react-icons/fa';
+
+export type GithubContentType = 'repo' | 'profile';
 
 interface GithubCardProps {
   githubRepoUrl: string;
@@ -16,57 +19,74 @@ export interface GithubRepoData {
   };
 }
 
+export interface GithubProfileData {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  bio?: string;
+  name?: string;
+  type: 'User' | 'Organization';
+}
+
 const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
-  const {
-    mutate,
-    data: repoData,
-    isPending,
-    isError,
-  } = useMutation({
-    mutationFn: fetchGithubRepoData,
+  const { mutate, data, isPending, isError } = useMutation({
+    mutationFn: fetchGithubContent,
   });
 
   useEffect(() => {
     if (githubRepoUrl) mutate(githubRepoUrl);
   }, [githubRepoUrl, mutate]);
 
-  if (isPending)
-    return (
-      <div className="text-midGray flex h-20 flex-col items-center justify-center gap-5 rounded border border-gray-200">
-        레포지토리를 불러오는 중입니다.
-      </div>
-    );
-  if (isError || !repoData)
-    return (
-      <div className="text-midGray flex h-20 flex-col items-center justify-center gap-5 rounded border border-gray-200">
-        유효하지 않은 레포지토리 링크입니다.
-      </div>
-    );
+  if (isPending) return <GithubCardSkeleton />;
+  if (isError || !data) return null;
 
-  return (
-    <div className="flex flex-col gap-5 overflow-hidden">
+  if (data.type === 'repo') {
+    const repo = data.data as GithubRepoData;
+    return (
       <a
         href={githubRepoUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-center rounded border border-gray-200 p-3 hover:bg-gray-50"
       >
-        <img
-          src={repoData.owner.avatar_url}
-          alt="owner"
-          className="mx-5 h-10 w-10 rounded-full border border-gray-300"
-        />
+        <img src={repo.owner.avatar_url} alt="owner" className="mx-5 h-10 w-10 rounded-full border border-gray-300" />
         <div className="ml-3 flex flex-1 flex-col text-sm">
-          <span className="font-semibold">{repoData.name}</span>
+          <span className="font-semibold">{repo.name}</span>
           <span className="hidden w-full max-w-[500px] truncate text-xs text-gray-500 sm:block">
-            {repoData.description}
+            {repo.description}
           </span>
-          <span className="text-xs text-gray-400">{repoData.language}</span>
+          <span className="text-xs text-gray-400">{repo.language}</span>
         </div>
         <FaGithub size={30} className="mx-5 shrink-0 text-xl text-black" />
       </a>
-    </div>
-  );
+    );
+  }
+
+  if (data.type === 'profile') {
+    const profile = data.data as GithubProfileData;
+    return (
+      <a
+        href={profile.html_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center rounded border border-gray-200 p-4 hover:bg-gray-50"
+      >
+        <img
+          src={profile.avatar_url}
+          alt={profile.login}
+          className="mx-5 h-14 w-14 rounded-full border border-gray-300"
+        />
+        <div className="ml-3 flex flex-col text-sm">
+          <span className="text-lg font-semibold">{profile.name || profile.login}</span>
+          <span className="text-xs text-gray-500">{profile.bio}</span>
+          <span className="text-xs text-gray-400">{profile.type}</span>
+        </div>
+        <FaGithub size={30} className="mx-5 shrink-0 text-xl text-black" />
+      </a>
+    );
+  }
+
+  return null;
 };
 
 export default GithubCard;

--- a/src/pages/project-viewer/MediaSection/GithubCard.tsx
+++ b/src/pages/project-viewer/MediaSection/GithubCard.tsx
@@ -42,7 +42,7 @@ const GithubCard = ({ githubRepoUrl }: GithubCardProps) => {
   if (isError || !data) return null;
 
   const cardStyle =
-    'flex w-full items-center justify-between rounded border border-gray-200 bg-white px-6 py-5 transition hover:bg-gray-50 min-w-xs';
+    'flex w-full items-center justify-between rounded border border-gray-200 bg-white px-6 py-5 transition hover:bg-gray-50';
 
   if (data.type === 'repo') {
     const repo = data.data as GithubRepoData;

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -9,6 +9,8 @@ import IntroSection from './IntroSection';
 import CarouselSection from './CarouselSection';
 import LikeSection from './LikeSection';
 import DetailSection from './DetailSection';
+import MediaSection from './MediaSection/MediaSection';
+import GithubCard from './MediaSection/GithubCard';
 import CommentSection from './CommentSection/CommentSection';
 
 import {
@@ -81,6 +83,8 @@ const ProjectViewerPage = () => {
       <LikeSection contestId={data.contestId} teamId={data.teamId} isLiked={data.isLiked} />
       <div className="h-10" />
       <DetailSection overview={data.overview} leaderName={data.leaderName} teamMembers={data.teamMembers} />
+      <div className="h-10" />
+      <GithubCard githubRepoUrl={data.githubPath} />
       {/* WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의*/}
       <div className="h-28" />
       <CommentSection teamId={data.teamId} />

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -61,7 +61,7 @@ const ProjectViewerPage = () => {
   const isLeaderOfThisTeam = isLeader && memberId == data.leaderId;
 
   return (
-    <div className="px-5">
+    <div className="min-w-xs px-2 sm:px-5">
       <IntroSection
         contestId={data.contestId}
         teamId={data.teamId}

--- a/src/pages/project-viewer/ViewerSkeleton.tsx
+++ b/src/pages/project-viewer/ViewerSkeleton.tsx
@@ -39,3 +39,17 @@ export const CommentSectionSkeleton = () => (
     <div className="h-6 w-1/2 rounded bg-gray-300"></div>
   </div>
 );
+
+export const GithubCardSkeleton = () => (
+  <div className="flex animate-pulse flex-col gap-5 overflow-hidden">
+    <div className="flex items-center rounded border border-gray-200 bg-white p-3">
+      <div className="mx-5 h-10 w-10 rounded-full bg-gray-200" />
+      <div className="ml-3 flex flex-1 flex-col gap-1 text-sm">
+        <div className="h-4 w-32 rounded bg-gray-200" />
+        <div className="hidden h-3 w-60 rounded bg-gray-200 sm:block" />
+        <div className="h-3 w-20 rounded bg-gray-200" />
+      </div>
+      <div className="mx-5 h-6 w-6 rounded bg-gray-300" />
+    </div>
+  </div>
+);


### PR DESCRIPTION
### 📝 개요
- `깃헙 카드` -> `url 버튼`으로 대체했었던 깃헙 링크 진입점을 다시 `깃헙 카드`로 구현함
- 화면 너비에 따른 css를 개선함

### 🎯 목적
- 사용자들의 편리한 접속을 위함

### ✨ 변경 사항
- 뷰어 페이지와 에디터 페이지에, 너비에 따라 패딩과 최소 너비 속성을 부여
- 그 외 폰트 사이즈 반응형으로 수정
- 깃헙과 유튜브의 url 버튼을 없애고 `프로젝트 바로가기` 버튼만 남김
- 팀원 한명 당 글자 수를 20자로 제한하였습니다.
- url 입력 필드에 있던 '필수', '선택' placeholder의 css를 개선
- 이미지 업로더 가이드를 모바일에서도 볼 수 있도록 `active` 속성 추가

### 🔬 리뷰 요구 사항 (선택)
- 사파리 브라우저 확인이 필요합니다!

### 📸 참고 이미지/영상 (선택)
- GitHub embed card
<img width="2879" height="1021" alt="image" src="https://github.com/user-attachments/assets/ae3a92f8-7993-4252-a27c-03cc8e7de807" />

- IntroSection responsive UI
  - 프로젝트명 또는 팀명이 길어질 경우를 고려하여 md를 기준으로 `flex-row`, `flex-col`을 적용
<img width="2879" height="245" alt="image" src="https://github.com/user-attachments/assets/f6999151-0975-40eb-9ae2-5d9082698317" />
<img width="672" height="185" alt="image" src="https://github.com/user-attachments/assets/a7b84005-3b3b-4949-b8bc-2fc55bf0297c" />

- Url textfield placeholder css improvement
<img width="1334" height="243" alt="image" src="https://github.com/user-attachments/assets/3d4e34fb-5856-471e-8522-05ba27f00403" />
