### PR TITLE
[내용 공유를 위한 PR] queryKey 관리를 위한 queryOption 객체 정의

### DIFF
--- a/src/utils/queryOption.ts
+++ b/src/utils/queryOption.ts
@@ -1,0 +1,57 @@
+import { queryOptions } from '@tanstack/react-query';
+
+/**
+ * Usage
+ * ```javascript
+ * // 팀 이미지 조회(썸네일) API 호출 시: /teams/{teamId}/image/thumbnail
+ * useQuery(
+ *  {
+ *    queryKey: queryOption.teams.thumbnail(teamId).queryKey,
+ *    queryFn: ...
+ *  }
+ * );
+ * ```
+ *
+ * queryOption 필드 명명법
+ * 1. queryOption.도메인.마지막정적세그먼트.queryKey로 접근할 수 있도록 한다.
+ * 2. /teams/{teamId} 처럼 마지막 정적 세그먼트가 도메인이라면 api 명으로 별칭을 지정한다.
+ *  ex) 팀 (상세보기) 조회 => detail
+ * 3. /teams 처럼 도메인이 마지막 세그먼트라면 root를 사용한다.
+ * 4. 마지막 세그먼트에 '-'등이 포함되어있다면 camelCase로 변환하여 사용한다.
+ * 5. 기타 예외적인 상황의 경우 다른 개발자가 적절히 활요할 수 있는 필드명으로 명명한다.
+ * 6. queryKey는 동적인 uri를 직접 사용하여 검색이 용이하도록 한다.
+ *  ex) ['comment', teamId] => [`/teams/${teamId}/comments`]
+ */
+
+const queryOption = {
+  teams: {
+    image: (teamId: number, imageId: number) => queryOptions({ queryKey: [`/teams/${teamId}/image/${imageId}`] }),
+    thumbnail: (teamId: number) => queryOptions({ queryKey: [`/teams/${teamId}/image/thumbnail`] }),
+    submissionStatus: () => queryOptions({ queryKey: [`/teams/submission-status`] }),
+    detail: (teamId: number) => queryOptions({ queryKey: [`/teams/${teamId}`] }),
+    comments: (teamId: number) => queryOptions({ queryKey: [`/teams/${teamId}/comments`] }),
+  },
+  contests: {
+    teams: (contestId: number, userId?: number) => queryOptions({ queryKey: [`/contests/${contestId}/teams`, userId] }),
+    current: (userId?: number) => queryOptions({ queryKey: [`/contests/current`, userId] }),
+    root: () => queryOptions({ queryKey: [`/contests`] }),
+  },
+  oauth: {
+    google: () => queryOptions({ queryKey: [`/oauth/google`] }),
+    callback: () => queryOptions({ queryKey: [`/oauth/google/callback`] }),
+  },
+  admin: {
+    dashboard: () => queryOptions({ queryKey: [`/admin/dashboard`] }),
+    ranking: () => queryOptions({ queryKey: [`/admin/ranking`] }),
+    participationRate: () => queryOptions({ queryKey: [`/admin/participation-rate`] }),
+  },
+  notices: {
+    detail: (noticeId: number) => queryOptions({ queryKey: [`/notices/${noticeId}`] }),
+    root: () => queryOptions({ queryKey: [`/notices`] }),
+  },
+  signIn: {
+    emailFind: (studentId: number) => queryOptions({ queryKey: [`/sign-in/${studentId}/email-find`] }),
+  },
+} as const;
+
+export default queryOption;


### PR DESCRIPTION
### 📝 개요
queryKey 관리를 위한 queryOption 객체 정의

### 🎯 목적
queryKey가 관리되지 않아, API 스펙 변경 시 useQuery에는 변경, invalidateQuery에서는 변경하지 않는 실수가 있었습니다.
이를 방지하기 위한 queryOption 객체를 정의해 보았습니다.

### 참고사항
어떤 방식을 도입할지 고민한 내용을 아래에 정리했으니 참고하시면 좋을 것 같습니다!
https://plume-forest-69a.notion.site/QueryKey-23505cf56f5680169a1ae9bae8a2c68b?source=copy_link

### 💬 논의 사항 (선택)
지금 방식은 사용 시 아래와 같은 형태로 사용해야 하는데 너무 복잡한가요?
1, 2번 방법 중 어떤 방법이 나은지 알려주세요~
```javascript
// 1번 방법
useQuery(
  {
    queryKey: queryOption.team.comment(teamId).queryFn,
    ...
  }
)
```
```javascript
// 2번 방법: 코드는 짧아지지만 teamsQuery, noticesQuery ... 등으로 나뉘어서 숙지가 조금 필요함
useQuery(
  {
    queryKey: teamsQuery.comment(teamId).queryFn,
    ...
  }
)
```