### PR TITLE
add: 작성일, 수정일 공지사항 상세페이지 적용 

### DIFF
--- a/src/pages/main/NoticeList.tsx
+++ b/src/pages/main/NoticeList.tsx
@@ -31,7 +31,7 @@ const NoticeList = ({ notices }: Props) => {
               </div>
 
               <span className="text-midGray ml-2 truncate text-right text-xs">
-                {dayjs(notice.createdAt).format('YYYY년 M월 D일 HH:mm')}
+                {dayjs(notice.createdAt).format('YYYY년 MM월 DD일 HH:mm')}
               </span>
             </Link>
           );

--- a/src/pages/notice/NoticeDetail.tsx
+++ b/src/pages/notice/NoticeDetail.tsx
@@ -37,7 +37,7 @@ const NoticeDetail = () => {
 
             <div className="flex justify-end">
                 <div className="flex px-2">
-                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">수정일</div>
+                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">작성일</div>
                     <div className=" mb-6 text-midGray text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
                         {dayjs(notice.createdAt).format('YYYY.MM.DD')}
                     </div>
@@ -46,7 +46,7 @@ const NoticeDetail = () => {
                 <div className="px-1 text-midGray text-[clamp(0.75rem,1.5vw,1rem)] font-bold"> |</div>
 
                 <div className="flex">
-                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">작성일</div>
+                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">수정일</div>
                     <div className=" mb-6 text-midGray text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
                         {dayjs(notice.updatedAt).format('YYYY.MM.DD')}
                     </div>

--- a/src/pages/notice/NoticeDetail.tsx
+++ b/src/pages/notice/NoticeDetail.tsx
@@ -7,41 +7,58 @@ import NoticeDetailSkeleton from './NoticeDetailSkeleton';
 import dayjs from 'dayjs';
 
 const NoticeDetail = () => {
-  useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'auto' });
-  }, []);
+    useEffect(() => {
+        window.scrollTo({ top: 0, behavior: 'auto' });
+    }, []);
 
-  const { noticeId } = useParams();
-  const {
-    data: notice,
-    isLoading,
-    isError,
-  } = useQuery({
-    queryKey: ['noticeDetail', noticeId],
-    queryFn: () => getNoticeDetail(Number(noticeId)),
-    enabled: !!noticeId,
-  });
+    const { noticeId } = useParams();
+    const {
+        data: notice,
+        isLoading,
+        isError,
+    } = useQuery({
+        queryKey: ['noticeDetail', noticeId],
+        queryFn: () => getNoticeDetail(Number(noticeId)),
+        enabled: !!noticeId,
+    });
 
-  if (isLoading) return <NoticeDetailSkeleton />;
-  if (isError || !notice) {
-    return <div>공지사항을 찾을 수 없습니다.</div>;
-  }
+    if (isLoading) return <NoticeDetailSkeleton />;
+    if (isError || !notice) {
+        return <div>공지사항을 찾을 수 없습니다.</div>;
+    }
 
-  return (
-    <div className="max-w mx-auto">
-      <h1 className="mb-6 text-2xl font-bold">공지사항</h1>
-      <div className="bg-whiteGray mb-2 flex items-center rounded px-4 py-5">
-        <AiOutlineNotification className="mr-4" />
-        <span className="flex-1 text-[clamp(0.85rem,2vw,1.3rem)] font-bold">{notice.title}</span>
-      </div>
-      <div className="text-midGray mb-6 text-right text-[clamp(0.7rem,1.5vw,0.9rem)]">
-        {dayjs(notice.updatedAt).format('YYYY년 M월 D일 HH:mm')}
-      </div>
-      <div className="bg-subGreen rounded p-6 text-[clamp(0.75rem,2vw,1rem)] leading-relaxed whitespace-pre-line">
-        {notice.description}
-      </div>
-    </div>
-  );
+    return (
+        <div className="max-w mx-auto">
+            <h1 className="mb-6 text-2xl font-bold">공지사항</h1>
+            <div className="bg-whiteGray mb-2 flex items-center rounded px-4 py-5">
+                <AiOutlineNotification className="mr-4" />
+                <span className="flex-1 text-[clamp(0.85rem,2vw,1.3rem)] font-bold">{notice.title}</span>
+            </div>
+
+            <div className="flex justify-end">
+                <div className="flex px-2">
+                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">수정일</div>
+                    <div className=" mb-6 text-midGray text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
+                        {dayjs(notice.createdAt).format('YYYY.MM.DD')}
+                    </div>
+                </div>
+
+                <div className="px-1 text-midGray text-[clamp(0.75rem,1.5vw,1rem)] font-bold"> |</div>
+
+                <div className="flex">
+                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">작성일</div>
+                    <div className=" mb-6 text-midGray text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
+                        {dayjs(notice.updatedAt).format('YYYY.MM.DD')}
+                    </div>
+                </div>
+            </div>
+
+
+            <div className="bg-subGreen rounded p-6 text-[clamp(0.75rem,2vw,1rem)] leading-relaxed whitespace-pre-line">
+                {notice.description}
+            </div>
+        </div>
+    );
 };
 
 export default NoticeDetail;


### PR DESCRIPTION
### 📝 개요
변경된 공지사항 api 상세페이지에 적용 

### 🎯 목적
작성일(createdAt)과 수정일(updatedAt)을 공지사항 상세페이지에 따로 띄우기 

### ✨ 변경 사항
- NoticeDetail 에서 updatedAt과 createdAt을 'YYYY.MM.DD' 형식으로 출력
- 메인페이지 공지사항 리스트 날짜 출력 형식 변경 

### 📸 참고 이미지/영상 (선택)
<img width="593" height="347" alt="{F6C815F2-8B65-4CBA-A250-F3CDA2860511}" src="https://github.com/user-attachments/assets/60ea2a45-17cc-4fe7-847a-956902edc0dd" />

