### PR TITLE
feat: 대회 등록시 이름 앞뒤 공백 제거해서 보내는 걸로 수정

### DIFF
--- a/src/hooks/useContestAdmin.ts
+++ b/src/hooks/useContestAdmin.ts
@@ -77,13 +77,14 @@ const useContestAdmin = () => {
   }, [currentTeams]);
 
   const handleAddContest = async () => {
-    if (!state.contestName.trim()) {
+    const trimmedName = state.contestName.trim();
+    if (!trimmedName) {
       toast('대회명이 비어있습니다.', 'error');
       return;
     }
 
     try {
-      await postAllContests(state.contestName);
+      await postAllContests(trimmedName);
       console.log('대회 추가 후 캐시 무효화');
       await queryClient.invalidateQueries({ queryKey: ['contests'] });
       setState((prev) => ({ ...prev, contestName: '' }));


### PR DESCRIPTION
### 📝 개요
5차 QA 내용으로 대회 앞뒤 공백이 있을 시 중복이 된다고하여 앞뒤 공백 제거해서 보내는 걸로 수정하였습니다.
### 🎯 목적
공백 제거로 중복 허용하지 않게 하기 위해
### ✨ 변경 사항
useContestAdmin.ts 의 handleAddContest 안에 대회명을 trim() 하여 보냈습니다.