### PR TITLE
fix: 썸네일 api 변경 

### DIFF
--- a/src/apis/teams.ts
+++ b/src/apis/teams.ts
@@ -1,9 +1,7 @@
 import { TeamListItemResponseDto } from '../types/DTO/teams/teamListDto';
 import { SubmissionStatusResponseDto } from '../types/DTO/teams/submissionStatusDto';
 import apiClient from './apiClient';
-import { mockTeamsResponse } from 'mocks/data/teams';
 import { SortOption } from '@pages/admin/TeamSortToggle';
-import {ThumbnailResponseDto} from "../types/DTO/teams/thumbnailResponseDto";
 
 export const getAllTeams = async (contestId: number): Promise<TeamListItemResponseDto[]> => {
   const res = await apiClient.get(`/contests/${contestId}/teams`);

--- a/src/apis/teams.ts
+++ b/src/apis/teams.ts
@@ -3,6 +3,7 @@ import { SubmissionStatusResponseDto } from '../types/DTO/teams/submissionStatus
 import apiClient from './apiClient';
 import { mockTeamsResponse } from 'mocks/data/teams';
 import { SortOption } from '@pages/admin/TeamSortToggle';
+import {ThumbnailResponseDto} from "../types/DTO/teams/thumbnailResponseDto";
 
 export const getAllTeams = async (contestId: number): Promise<TeamListItemResponseDto[]> => {
   const res = await apiClient.get(`/contests/${contestId}/teams`);
@@ -12,6 +13,23 @@ export const getAllTeams = async (contestId: number): Promise<TeamListItemRespon
 export const getSubmissionStatus = async (): Promise<SubmissionStatusResponseDto> => {
   const res = await apiClient.get('/teams/submission-status');
   return res.data;
+};
+
+export const getThumbnailTeams = async (teamId: number) => {
+    const baseUrl = import.meta.env.VITE_API_BASE_URL || 'https://swpms.pnu.app';
+    try {
+        const response = await apiClient.get(`/teams/${teamId}/image/thumbnail`);
+
+        if (response.status === 200) {
+            return `${baseUrl}/api/teams/${teamId}/image/thumbnail`;
+        } else if (response.status === 202) {
+            return null;
+        }
+    } catch (error: any) {
+        if (error.response?.status === 404) {
+            return null;
+        }
+    }
 };
 
 export const deleteTeams = async (teamId_: number) => {

--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -1,7 +1,8 @@
 import { FaHeart } from 'react-icons/fa';
-import { useState } from 'react';
+import {useEffect, useState} from 'react';
 import { Link } from 'react-router-dom';
 import basicThumbnail from '@assets/basicThumbnail.jpg'
+import {getThumbnailTeams} from "../../apis/teams";
 
 interface TeamCardProps {
   teamId: number;
@@ -11,9 +12,17 @@ interface TeamCardProps {
 }
 
 const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => {
-  const [imageError, setImageError] = useState(false);
+  const [thumbnailUrl, setThumbnailUrl] = useState<string>(basicThumbnail);
 
-  const thumbnailUrl = `${import.meta.env.VITE_API_BASE_URL}/api/teams/${teamId}/image/thumbnail`;
+  useEffect(() => {
+    const fetchThumbnail = async () => {
+      const url = await getThumbnailTeams(teamId);
+      if (url) {
+        setThumbnailUrl(url);
+      }
+    };
+    fetchThumbnail();
+  }, [teamId]);
 
   return (
     <Link
@@ -22,19 +31,10 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked }: TeamCardProps) => 
 
     >
       <div className="aspect-[3/2] flex-shrink-0 object-cover overflow-hidden relative rounded-md border border-lightGray cursor-pointer transition-transform duration-200 hover:scale-[1.02] hover:shadow-md">
-        {!imageError ? (
-          <img
-            src={thumbnailUrl}
+          <img src={thumbnailUrl ?? basicThumbnail}
             alt="썸네일"
             className="w-full h-full object-cover"
-            onError={() => setImageError(true)}
           />
-          ) : (
-          <img
-            src={basicThumbnail}
-            alt="기본 썸네일"
-            />
-          )}
 
         <div className="absolute top-3 right-3 z-10">
           {isLiked && (

--- a/src/types/DTO/teams/thumbnailResponseDto.ts
+++ b/src/types/DTO/teams/thumbnailResponseDto.ts
@@ -1,3 +1,0 @@
-export interface ThumbnailResponseDto{
-  url: string,
-}

--- a/src/types/DTO/teams/thumbnailResponseDto.ts
+++ b/src/types/DTO/teams/thumbnailResponseDto.ts
@@ -1,0 +1,3 @@
+export interface ThumbnailResponseDto{
+  url: string,
+}


### PR DESCRIPTION
### 📝 개요
이미지 변환 202 상태 반영 코드 추가 및 URL 문자열 구성 방식 변경 

### 🎯 목적
- 추가된 202 상태 -> 기본 이미지 반영
- 배포된 서버에서 가는 썸네일 api 주소가 로컬의 경우와 다름 (URL 문자열 방식 수정해봄)

### ✨ 변경 사항
- teams api 파일에 썸네일 api 추가 및 기존 직접 문자열 구성 방식 변경 
