### PR TITLE
Feat: 이미지 압축 시 삭제 불가

### DIFF
--- a/src/apis/projectEditor.ts
+++ b/src/apis/projectEditor.ts
@@ -42,7 +42,7 @@ export const postThumbnail = async (teamId: number, formData: FormData) => {
 
 export const deleteThumbnail = async (teamId: number) => {
   const response = await apiClient.delete(`/teams/${teamId}/image/thumbnail`);
-  return response.data;
+  return response;
 };
 
 export const postPreview = async (teamId: number, formData: FormData) => {
@@ -54,7 +54,7 @@ export const postPreview = async (teamId: number, formData: FormData) => {
 
 export const deletePreview = async (teamId: number, body: PreviewDeleteRequestDto) => {
   const response = await apiClient.delete(`/teams/${teamId}/image`, { data: body });
-  return response.data;
+  return response;
 };
 
 export const postMember = async (teamId: number, body: TeamMemberCreateRequestDto) => {

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -103,6 +103,11 @@ const ImageUploaderSection = ({
     const target = images[index];
     if (!target) return;
 
+    if (!(target instanceof File) && 'status' in target && target.status === 'processing') {
+      toast('이미지 압축 중에는 삭제할 수 없어요', 'info');
+      return;
+    }
+
     if (index === 0) {
       if (!(target instanceof File) && 'status' in target && target.status === 'success') {
         setThumbnailToDelete(true);

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -250,7 +250,10 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
       await Promise.all(addMemberPromises);
 
       if (thumbnailToDelete) {
-        await deleteThumbnail(teamId!);
+        const res = await deleteThumbnail(teamId!);
+        if (res.status === 202) {
+          toast('압축 중인 이미지는 삭제할 수 없어요', 'error');
+        }
       }
       if (thumbnail instanceof File) {
         const formData = new FormData();
@@ -259,7 +262,10 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
       }
 
       if (previewsToDelete.length > 0) {
-        await deletePreview(teamId!, { imageIds: previewsToDelete });
+        const res = await deletePreview(teamId!, { imageIds: previewsToDelete });
+        if (res.status === 202) {
+          toast('압축 중인 이미지는 삭제할 수 없어요', 'error');
+        }
         setPreviewsToDelete([]);
       }
       const newFiles = previews.filter((p) => p instanceof File).map((p) => p as File);


### PR DESCRIPTION
### 📝 개요
- 이미지 압축 중인 상태에서 삭제가 불가하다는 토스트 메시지를 띄움

### 🎯 목적
- 기존에는 압축 중인 상태에서도 삭제가 가능했으나, 삭제가 불가능해짐에 따라 구현

### 📸 참고 이미지/영상 (선택)

https://github.com/user-attachments/assets/65873777-19d4-47e3-b2c1-2a2ef5c7d5ef

