### PR TITLE
style: 이미지 요소 object-cover -> object-contain 속성으로 변경

### DIFF
--- a/src/pages/main/TeamCard.tsx
+++ b/src/pages/main/TeamCard.tsx
@@ -27,8 +27,8 @@ const TeamCard = ({ teamId, teamName, projectName, isLiked, isVoteTerm }: TeamCa
 
   return (
     <Link to={`/teams/view/${teamId}`} className="flex aspect-[7/8] w-full flex-col">
-      <div className="border-lightGray relative aspect-[3/2] flex-shrink-0 cursor-pointer overflow-hidden rounded-md border object-cover transition-transform duration-200 hover:scale-[1.02] hover:shadow-md">
-        <img src={thumbnailUrl ?? basicThumbnail} alt="썸네일" className="h-full w-full object-cover" />
+      <div className="border-lightGray relative aspect-[3/2] flex-shrink-0 cursor-pointer overflow-hidden rounded-md border transition-transform duration-200 hover:scale-[1.02] hover:shadow-md">
+        <img src={thumbnailUrl ?? basicThumbnail} alt="썸네일" className="h-full w-full object-contain" />
 
         <div className="absolute top-3 right-3 z-10">
           {isVoteTerm && isLiked && <FaHeart color="red" size="clamp(1.5rem, 2vw, 1.8rem)" />}

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -215,7 +215,8 @@ const ImageUploaderSection = ({
             <br />
             허용 확장자: .jpg, .png, .gif, .bmp, .webp
             <br />
-            <br />※권장 비율이 아닌 이미지에는 빈 여백이 생길 수 있어요.※
+            <br />
+            ※권장 비율이 아닌 이미지에는 빈 여백이 생길 수 있어요.※
           </div>
         </div>
       </div>
@@ -258,7 +259,7 @@ const ImageUploaderSection = ({
                 <img
                   src={getImageSrc(img)}
                   alt={`image-${index}`}
-                  className="absolute inset-0 h-full w-full object-cover"
+                  className="absolute inset-0 h-full w-full object-contain"
                 />
               );
             } else if ('status' in img) {
@@ -279,7 +280,7 @@ const ImageUploaderSection = ({
                     <img
                       src={getImageSrc(img)}
                       alt={`image-${index}`}
-                      className="absolute inset-0 h-full w-full object-cover"
+                      className="absolute inset-0 h-full w-full object-contain"
                     />
                   );
                 } else {

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -209,9 +209,13 @@ const ImageUploaderSection = ({
           <div className="absolute top-1/2 right-full z-10 mr-3 w-64 -translate-y-1/2 rounded bg-green-50 p-3 text-xs text-green-600 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-80 group-active:opacity-100 sm:left-full sm:ml-3">
             권장 비율: <strong>3:2</strong> (예: 1500×1000)
             <br />
-            최대 용량: <strong>2MB</strong>
+            최대 이미지 개수: <strong>6개</strong>
             <br />
-            허용 확장자: <strong>.jpg, .png, .gif, .bmp, .webp</strong>
+            최대 용량: <strong>5MB</strong>
+            <br />
+            허용 확장자: .jpg, .png, .gif, .bmp, .webp
+            <br />
+            <br />※권장 비율이 아닌 이미지에는 빈 여백이 생길 수 있어요.※
           </div>
         </div>
       </div>

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -121,7 +121,7 @@ const MediaRenderer = ({
       <img
         src={currentMedia.url}
         alt="기본 이미지"
-        className="border-lightGray absolute inset-0 h-full w-full border object-cover"
+        className="border-lightGray absolute inset-0 h-full w-full border object-contain"
       />
     );
   }
@@ -183,7 +183,7 @@ const MediaRenderer = ({
             alt="Project image"
             onLoad={() => setImageLoaded(true)}
             onError={() => setLoadFailed(true)}
-            className={`border-lightGray absolute inset-0 h-full w-full border object-cover transition-opacity duration-200 ${
+            className={`border-lightGray absolute inset-0 h-full w-full border object-contain transition-opacity duration-200 ${
               imageLoaded ? 'opacity-100' : 'opacity-0'
             }`}
           />


### PR DESCRIPTION
### 📝 개요
- 기존에는 여백이 생기지 않도록 이미지를 관리했지만, 여백이 생기되 모든 이미지의 내용이 보이도록 수정하였습니다.

### 🎯 목적
- 이미지의 모든 정보를 보여주기 위함입니다. (요구사항)

### ✨ 변경 사항
- 이미지를 보여주는 속성을 `object-cover` -> `object-contain`으로 변경하였습니다.
- 이미지 가이드 내용을 수정하였습니다.
  - 오표기 수정: 2MB -> 5MB
  - 여백이 생길 수 있음을 안내
  - 최대 6개 등록 가능함을 안

### 📸 참고 이미지/영상 (선택)
- 이미지 업로더
<img width="920" height="315" alt="image" src="https://github.com/user-attachments/assets/0e05b863-9956-4da9-9347-3ee307a4b707" />

- 캐러셀
<img width="940" height="989" alt="image" src="https://github.com/user-attachments/assets/0f93eb7f-f160-4f16-bc8c-cf4017bd0003" />

- 썸네일
<img width="468" height="442" alt="image" src="https://github.com/user-attachments/assets/f0980c1f-965e-45cd-944d-5677812ad486" />

- 이미지 가이드
<img width="690" height="276" alt="image" src="https://github.com/user-attachments/assets/96ff6142-d23a-48f4-8f34-11de35505af9" />
