### PR TITLE
feat: 관리자 페이지 정렬 설정 토글 '수상 설정순' 버튼 추가

### DIFF
--- a/src/pages/admin/ProjectSortToggle.tsx
+++ b/src/pages/admin/ProjectSortToggle.tsx
@@ -46,7 +46,7 @@ const ProjectSortToggle = () => {
   return (
     <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:gap-15">
       <span className="text-sm font-medium whitespace-nowrap">- 프로젝트 정렬 설정</span>
-      <div className="border-lightGray flex flex-1 items-center justify-center rounded-md border p-1">
+      <div className="border-lightGray flex flex-1 items-center justify-center gap-1 rounded-md border p-1">
         {sortOptions.map((option) => (
           <button
             key={option.value}
@@ -54,7 +54,7 @@ const ProjectSortToggle = () => {
             onClick={() => handleToggle(option.value)}
             disabled={option.value == selected || isLoading || mutation.isPending}
             className={`h-10 flex-1 cursor-pointer rounded-sm text-sm transition-colors ${
-              selected === option.value ? 'bg-mainGreen text-white' : 'text-black hover:text-gray-500'
+              selected === option.value ? 'bg-mainGreen text-white' : 'hover:bg-lightGray/70 text-black'
             }`}
           >
             {option.label}

--- a/src/pages/admin/ProjectSortToggle.tsx
+++ b/src/pages/admin/ProjectSortToggle.tsx
@@ -2,11 +2,12 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useToast } from 'hooks/useToast';
 import { getSortStatus, patchSortTeam } from 'apis/teams';
 
-export type SortOption = 'RANDOM' | 'ASC';
+export type SortOption = 'RANDOM' | 'ASC' | 'CUSTOM';
 
 const sortOptions: { label: string; value: SortOption }[] = [
   { label: '랜덤', value: 'RANDOM' },
   { label: '오름차순', value: 'ASC' },
+  { label: '수상 설정순', value: 'CUSTOM' },
 ];
 
 const ProjectSortToggle = () => {

--- a/src/pages/admin/ProjectSortToggle.tsx
+++ b/src/pages/admin/ProjectSortToggle.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useToast } from 'hooks/useToast';
 import { getSortStatus, patchSortTeam } from 'apis/teams';
 
@@ -13,31 +12,35 @@ const sortOptions: { label: string; value: SortOption }[] = [
 const ProjectSortToggle = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
-  const [selected, setSelected] = useState<SortOption | null>(null);
 
-  useEffect(() => {
-    const fetchSortMode = async () => {
-      try {
-        const mode = await getSortStatus();
-        setSelected(mode);
-      } catch (error) {
-        console.error('Error fetching sort mode:', error);
-      }
-    };
-    fetchSortMode();
-  }, []);
+  const { data: selected, isLoading, error } = useQuery({ queryKey: ['sortStatus'], queryFn: getSortStatus });
 
-  const handleToggle = async (mode: SortOption) => {
-    try {
-      await patchSortTeam(mode);
-      setSelected(mode);
+  const mutation = useMutation({
+    mutationFn: patchSortTeam,
+    onSuccess: (_, mode) => {
+      queryClient.invalidateQueries({ queryKey: ['sortStatus'] });
       queryClient.invalidateQueries({ queryKey: ['teams'] });
       toast(`프로젝트가 ${mode === 'RANDOM' ? '랜덤' : '오름차순'} 정렬로 변경되었어요`, 'success');
-    } catch (error) {
-      console.error('Error sorting teams:', error);
+    },
+    onError: () => {
       toast('프로젝트 정렬 설정에 실패했어요', 'error');
-    }
+    },
+  });
+
+  const handleToggle = (mode: SortOption) => {
+    mutation.mutate(mode);
   };
+
+  if (error) {
+    return (
+      <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:gap-15">
+        <span className="text-sm font-medium whitespace-nowrap">- 프로젝트 정렬 설정</span>
+        <div className="border-lightGray flex flex-1 items-center justify-center rounded-md border p-4">
+          <span className="text-sm">정렬 설정을 불러오지 못했습니다. 다시 시도해 주세요</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:gap-15">
@@ -48,6 +51,7 @@ const ProjectSortToggle = () => {
             key={option.value}
             type="button"
             onClick={() => handleToggle(option.value)}
+            disabled={option.value == selected || isLoading || mutation.isPending}
             className={`h-10 flex-1 cursor-pointer rounded-sm text-sm transition-colors ${
               selected === option.value ? 'bg-mainGreen text-white' : 'text-black hover:text-gray-500'
             }`}


### PR DESCRIPTION
### 📝 개요
관리자 페이지 정렬 설정 토글 '수상 설정순' 버튼 추가

### 🎯 목적
센터의 요구사항에 따라, 순서를 직접 지정하는 CUSTOM 타입의 정렬 기준 도입을 위한 토글 버튼 추가

### ✨ 변경 사항
- ProjectSortToggle 컴포넌트
 - '수상 설정순' 버튼 추가
 - patchSortTeam 함수로 CUSTOM request를 전달할 수 있도록 구현
 - hover시 버튼 스타일 일부 수정

### 📸 참고 이미지/영상 (선택)
- API 미구현으로 인해 정상 작동 여부 확인하지 않은 상태입니다. api 구현 완료 후 테스트 하고 머지 필요할 것 같습니다.
<img width="5088" height="3742" alt="image" src="https://github.com/user-attachments/assets/aab3bb0f-ba24-485f-a6af-27661093aa97" />
