### PR TITLE
design: 로그인 툴팁 문구 변경

### DIFF
--- a/src/pages/signin/SignInOptions.tsx
+++ b/src/pages/signin/SignInOptions.tsx
@@ -41,8 +41,12 @@ const OnBoardingToolTip = ({ children }: ToolTipProps) => {
         <TooltipContent className="max-w-3xs duration-400">
           <div className="flex flex-col gap-2 p-2 text-base">
             <p className="break-keep">
-              <strong className="text-mainBlue font-semibold">팀장이신가요? </strong>
-              소셜 로그인 대신 직접 회원가입 해주세요
+              <strong className="text-mainBlue font-semibold">팀장 </strong>
+              <span>또는 </span>
+              <strong className="text-mainBlue font-semibold">팀원</strong>
+              <span>이신가요? 소셜 로그인 대신 직접 </span>
+              <strong className="text-mainBlue font-semibold">회원가입 </strong>
+              <span>해주세요</span>
             </p>
             <button
               onClick={handleConfirm}


### PR DESCRIPTION
### 📝 개요
팀원 권한 추가로 인한 회원가입 툴팁 수정

### 🎯 목적
팀원 권한 추가로 인한 회원가입 툴팁 수정
 - 팀장 뿐만 아니라 팀원도 소셜로그인이 아닌 서비스 회원가입이 필요
- 이를 안내하기 위한 툴팁 구현 및 기존 안내 문구 수정

### ✨ 변경 사항
- 툴팁 문구 변경
 - "팀장 또는 팀원이신가요? 소셜로그인 대신 직접 회원가입 해주세요"

### 📸 참고 이미지/영상
<img width="832" height="978" alt="image" src="https://github.com/user-attachments/assets/12148c17-984b-429e-a0de-c28239a443da" />

