### PR TITLE
feat: 팀원 편집 권한 추가 및 포스터 이미지 규격 지원

### DIFF
--- a/src/components/AwardTag.tsx
+++ b/src/components/AwardTag.tsx
@@ -12,7 +12,7 @@ const AwardTag = ({ awardName, awardColor }: AwardTagProps) => {
       style={{
         backgroundColor: awardColor,
         borderColor: awardColor,
-        boxShadow: `0 0 8px 2px ${awardColor}88, 0 0 4px 4px ${awardColor}44`,
+        boxShadow: `0 0 6px 2px ${awardColor}50, 0 0 4px 4px ${awardColor}20`,
       }}
     >
       <span className="award-shimmer" />

--- a/src/components/AwardTag.tsx
+++ b/src/components/AwardTag.tsx
@@ -12,7 +12,7 @@ const AwardTag = ({ awardName, awardColor }: AwardTagProps) => {
       style={{
         backgroundColor: awardColor,
         borderColor: awardColor,
-        boxShadow: `0 0 8px 2px ${awardColor}88, 0 0 24px 4px ${awardColor}44`,
+        boxShadow: `0 0 8px 2px ${awardColor}88, 0 0 4px 4px ${awardColor}44`,
       }}
     >
       <span className="award-shimmer" />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,21 +1,21 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@components/lib/utils"
+import { cn } from '@components/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] duration-300 outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus:border-mainGreen focus:ring-0 focus:outline-none',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,6 +9,7 @@ const useAuth = () => {
 
   const isSignedIn = !!user && !!token;
   const isLeader = isSignedIn && user?.roles?.includes('ROLE_팀장');
+  const isMember = isSignedIn && user?.roles?.includes('ROLE_팀원');
   const isAdmin = isSignedIn && user?.roles?.includes('ROLE_관리자');
 
   const signOut = useCallback(() => {
@@ -32,6 +33,7 @@ const useAuth = () => {
   return {
     isSignedIn,
     isLeader,
+    isMember,
     isAdmin,
     user,
     signIn,

--- a/src/pages/admin/ContestsTab/AwardSet/AwardColorSelect.tsx
+++ b/src/pages/admin/ContestsTab/AwardSet/AwardColorSelect.tsx
@@ -25,7 +25,7 @@ const AwardColorSelect = ({ value, onChange }: AwardColorSelectProps) => {
     <div className="flex flex-1 items-center gap-4">
       <h4 className="w-30 text-sm leading-none">{title}</h4>
       <Select value={selectedValue} onValueChange={handleValueChange}>
-        <SelectTrigger className="w-full overflow-hidden text-sm">
+        <SelectTrigger className="focus:border-mainGreen w-full overflow-hidden text-sm focus:ring-0 focus:outline-none">
           <SelectValue placeholder="뱃지 색상을 선택해주세요." className="truncate" />
         </SelectTrigger>
         <SelectContent className="text-sm">

--- a/src/pages/admin/ContestsTab/AwardSet/AwardSetSection.tsx
+++ b/src/pages/admin/ContestsTab/AwardSet/AwardSetSection.tsx
@@ -30,7 +30,7 @@ const AwardSetSection = ({ contestId, editable, onSuccess }: AwardSetSectionProp
           <AwardColorSelect value={patchAdmin.awardState.awardColor ?? ''} onChange={patchAdmin.onChangeAwardColor} />
           <div className="flex justify-end gap-3">
             <Button
-              variant="default"
+              className="bg-mainGreen hover:bg-emerald-600"
               disabled={!patchAdmin.awardPatchSubmitAvailable}
               onClick={() => patchAdmin.saveAward(onSuccess)}
             >

--- a/src/pages/admin/ContestsTab/AwardSet/SortableTable.tsx
+++ b/src/pages/admin/ContestsTab/AwardSet/SortableTable.tsx
@@ -61,6 +61,22 @@ const SortableTable = ({ data, contestId, onDeleteTeam, editable, onOrderSaved }
 
   return (
     <div>
+      {editable && rows.length > 1 && (
+        <div className="mb-3 flex justify-start gap-4">
+          <Button
+            className="bg-lightGray hover:bg-mainGreen p-2 px-6 text-black hover:text-white"
+            onClick={handleBeforeSaveOrder}
+          >
+            정렬 저장
+          </Button>
+          <Button
+            className="border-lightGray hover:bg-whiteGray border p-2 px-4 text-black"
+            onClick={() => setRows(prevRowsRef.current)}
+          >
+            정렬 새로고침
+          </Button>
+        </div>
+      )}
       <table className="w-full table-fixed border-collapse truncate text-sm text-nowrap">
         <TableHeader fields={FIELDS} />
         <tbody>
@@ -119,13 +135,6 @@ const SortableTable = ({ data, contestId, onDeleteTeam, editable, onOrderSaved }
             ))}
         </tbody>
       </table>
-      {editable && rows.length > 1 && (
-        <div className="mt-3 flex justify-end">
-          <Button className="text-mainBlue border-mainBlue border p-2 px-4" onClick={handleBeforeSaveOrder}>
-            정렬 저장
-          </Button>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/pages/admin/ContestsTab/AwardSet/TeamSelect.tsx
+++ b/src/pages/admin/ContestsTab/AwardSet/TeamSelect.tsx
@@ -21,7 +21,7 @@ const TeamSelect = ({ teamList, onChange }: TeamSelectProps) => {
     <div className="flex flex-1 items-center gap-4">
       <h4 className="w-30 text-sm leading-none">{title}</h4>
       <Select value={selectedValue} onValueChange={handleValueChange}>
-        <SelectTrigger className="w-full overflow-hidden text-sm">
+        <SelectTrigger className="focus:outline:none focus:border-mainGreen w-full overflow-hidden border text-sm focus:ring-0">
           <SelectValue placeholder="수상팀을 선택해주세요." className="truncate" />
         </SelectTrigger>
         <SelectContent className="text-sm">

--- a/src/pages/project-editor/AdminEditSection/AdminEditSection.tsx
+++ b/src/pages/project-editor/AdminEditSection/AdminEditSection.tsx
@@ -7,6 +7,8 @@ interface AdminEditSectionProps {
   setProjectName: (projectName: string) => void;
   teamName: string;
   setTeamName: (teamName: string) => void;
+  professorName: string;
+  setProfessorName: (professorName: string) => void;
   leaderName: string;
   setLeaderName: (teamName: string) => void;
 }
@@ -18,6 +20,8 @@ const AdminEditSection = ({
   setProjectName,
   teamName,
   setTeamName,
+  professorName,
+  setProfessorName,
   leaderName,
   setLeaderName,
 }: AdminEditSectionProps) => {
@@ -73,6 +77,21 @@ const AdminEditSection = ({
             value={leaderName}
             onChange={(e) => setLeaderName(e.target.value)}
             placeholder="팀장 이름을 입력해주세요."
+            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-10">
+        <div className="text-midGray flex w-25 gap-1">
+          <span className="mr-1 text-red-500">*</span>
+          <span className="w-full">지도교수명</span>
+        </div>
+        <div className="flex flex-1 flex-col">
+          <input
+            type="text"
+            value={professorName}
+            onChange={(e) => setProfessorName(e.target.value)}
+            placeholder="지도교수 이름을 입력해주세요."
             className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>

--- a/src/pages/project-editor/ImageUploaderSection.tsx
+++ b/src/pages/project-editor/ImageUploaderSection.tsx
@@ -10,6 +10,8 @@ import { AiFillPicture } from 'react-icons/ai';
 import { MdOutlineFileUpload, MdBrokenImage } from 'react-icons/md';
 import { CgSandClock } from 'react-icons/cg';
 
+const PREVIEW_BOX_TAGS = ['썸네일', '졸업과제 포스터'];
+
 interface ImageUploaderSectionProps {
   thumbnail: ThumbnailResult | File | undefined;
   setThumbnail: (thumb: ThumbnailResult | File | undefined) => void;
@@ -206,8 +208,12 @@ const ImageUploaderSection = ({
           <span className="ml-1 inline-flex animate-bounce cursor-help items-center gap-1 rounded-full bg-green-50 px-2 py-1 text-xs text-green-500">
             <HiInformationCircle /> 가이드
           </span>
-          <div className="absolute top-1/2 right-full z-10 mr-3 w-64 -translate-y-1/2 rounded bg-green-50 p-3 text-xs text-green-600 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-80 group-active:opacity-100 sm:left-full sm:ml-3">
+          <div className="absolute top-1/2 right-full z-10 mr-3 w-64 -translate-y-1/2 rounded bg-green-50 p-3 text-xs leading-5 text-green-600 opacity-0 transition-opacity duration-300 ease-in-out group-hover:opacity-80 group-active:opacity-100 sm:left-full sm:ml-3">
             권장 비율: <strong>3:2</strong> (예: 1500×1000)
+            <br />
+            <span className="bg-mainGreen rounded-lg p-0.5 px-1 text-white">
+              단, 포스터의 경우 약 2:3으로 표시돼요.
+            </span>
             <br />
             최대 이미지 개수: <strong>6개</strong>
             <br />
@@ -244,11 +250,11 @@ const ImageUploaderSection = ({
                   className="border-lightGray text-title text-lightGray relative flex aspect-[3/2] w-full items-center justify-center rounded border border-dashed"
                 >
                   <AiFillPicture />
-                  {index === 0 && (
+                  {index === 0 || index === 1 ? (
                     <span className="absolute bottom-1 left-1 rounded bg-green-100 px-2 py-0.5 text-xs text-green-600">
-                      썸네일
+                      {PREVIEW_BOX_TAGS[index]}
                     </span>
-                  )}
+                  ) : null}
                 </div>
               );
             }

--- a/src/pages/project-editor/IntroSection.tsx
+++ b/src/pages/project-editor/IntroSection.tsx
@@ -7,6 +7,7 @@ interface IntroSectionProps {
   setProjectName: (projectName: string) => void;
   teamName: string;
   professorName: string;
+  setProfessorName: (professorName: string) => void;
   leaderName: string;
   teamMembers: TeamMember[];
 }
@@ -14,6 +15,7 @@ interface IntroSectionProps {
 const IntroSection = ({
   teamName,
   professorName,
+  setProfessorName,
   leaderName,
   teamMembers,
   projectName,
@@ -24,13 +26,11 @@ const IntroSection = ({
       <div className="text-exsm flex gap-10 truncate sm:text-sm">
         <div className="text-midGray flex w-25 flex-col gap-3 pl-3">
           <span>팀명</span>
-          <span>지도교수</span>
           <span>팀장</span>
           <span>팀원</span>
         </div>
         <div className="flex flex-col gap-3">
           <span>{teamName}</span>
-          <span>{professorName}</span>
           <span>{leaderName}</span>
           <div className="flex flex-wrap gap-x-3">
             {teamMembers.map((member, index) => (
@@ -39,6 +39,7 @@ const IntroSection = ({
           </div>
         </div>
       </div>
+
       <div className="h-10" />
       <div className="flex items-center gap-10">
         <div className="text-midGray flex w-25 gap-1">
@@ -51,6 +52,22 @@ const IntroSection = ({
             value={projectName}
             onChange={(e) => setProjectName(e.target.value)}
             placeholder="프로젝트 이름을 입력해주세요."
+            className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
+          />
+        </div>
+      </div>
+      <div className="h-10" />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-10">
+        <div className="text-midGray flex w-25 gap-1">
+          <span className="mr-1 text-red-500">*</span>
+          <span className="w-full">지도교수명</span>
+        </div>
+        <div className="flex flex-1 flex-col">
+          <input
+            type="text"
+            value={professorName}
+            onChange={(e) => setProfessorName(e.target.value)}
+            placeholder="지도교수 이름을 입력해주세요."
             className="placeholder-lightGray border-lightGray focus:border-mainGreen w-full truncate rounded border px-5 py-3 text-black duration-300 ease-in-out focus:outline-none"
           />
         </div>

--- a/src/pages/project-editor/IntroSection.tsx
+++ b/src/pages/project-editor/IntroSection.tsx
@@ -6,22 +6,32 @@ interface IntroSectionProps {
   projectName: string;
   setProjectName: (projectName: string) => void;
   teamName: string;
+  professorName: string;
   leaderName: string;
   teamMembers: TeamMember[];
 }
 
-const IntroSection = ({ teamName, leaderName, teamMembers, projectName, setProjectName }: IntroSectionProps) => {
+const IntroSection = ({
+  teamName,
+  professorName,
+  leaderName,
+  teamMembers,
+  projectName,
+  setProjectName,
+}: IntroSectionProps) => {
   return (
     <>
       <div className="text-exsm flex gap-10 truncate sm:text-sm">
         <div className="text-midGray flex w-25 flex-col gap-3 pl-3">
-          <span>팀명</span>
-          <span>팀장</span>
-          <span>팀원</span>
+          {teamName && <span>팀명</span>}
+          {professorName && <span>지도교수</span>}
+          {leaderName && <span>팀장</span>}
+          {teamMembers.length > 0 && <span>팀원</span>}
         </div>
         <div className="flex flex-col gap-3">
-          <span>{teamName}</span>
-          <span>{leaderName}</span>
+          {teamName && <span>{teamName}</span>}
+          {professorName && <span>{professorName}</span>}
+          {leaderName && <span>{leaderName}</span>}
           <div className="flex flex-wrap gap-x-3">
             {teamMembers.map((member, index) => (
               <span key={index}>{member.teamMemberName}</span>

--- a/src/pages/project-editor/IntroSection.tsx
+++ b/src/pages/project-editor/IntroSection.tsx
@@ -23,15 +23,15 @@ const IntroSection = ({
     <>
       <div className="text-exsm flex gap-10 truncate sm:text-sm">
         <div className="text-midGray flex w-25 flex-col gap-3 pl-3">
-          {teamName && <span>팀명</span>}
-          {professorName && <span>지도교수</span>}
-          {leaderName && <span>팀장</span>}
-          {teamMembers.length > 0 && <span>팀원</span>}
+          <span>팀명</span>
+          <span>지도교수</span>
+          <span>팀장</span>
+          <span>팀원</span>
         </div>
         <div className="flex flex-col gap-3">
-          {teamName && <span>{teamName}</span>}
-          {professorName && <span>{professorName}</span>}
-          {leaderName && <span>{leaderName}</span>}
+          <span>{teamName}</span>
+          <span>{professorName}</span>
+          <span>{leaderName}</span>
           <div className="flex flex-wrap gap-x-3">
             {teamMembers.map((member, index) => (
               <span key={index}>{member.teamMemberName}</span>

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -114,6 +114,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
     if (projectData) {
       setContestId(projectData.contestId);
       setTeamName(projectData.teamName);
+      setProfessorName(projectData.professorName);
       setProjectName(projectData.projectName);
       setLeaderName(projectData.leaderName);
       setTeamMembers(projectData.teamMembers);
@@ -231,7 +232,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
         contestId: isAdmin ? (contestId !== null ? contestId : projectData!.contestId) : projectData!.contestId,
         teamName: isAdmin ? teamName : projectData!.teamName,
         projectName: projectName,
-        professorName: isAdmin ? professorName : projectData!.professorName,
+        professorName: professorName,
         leaderName: isAdmin ? leaderName : projectData!.leaderName,
         overview,
         productionPath: productionUrl,
@@ -498,6 +499,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
           setProjectName={setProjectName}
           teamName={teamName}
           professorName={professorName}
+          setProfessorName={setProfessorName}
           leaderName={leaderName}
           teamMembers={teamMembers} // WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의
         />

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -54,6 +54,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
   const [contestId, setContestId] = useState<number | null>(initialContestId ?? null);
   const [teamName, setTeamName] = useState('');
   const [projectName, setProjectName] = useState('');
+  const [professorName, setProfessorName] = useState('');
   const [leaderName, setLeaderName] = useState('');
   const [thumbnail, setThumbnail] = useState<ThumbnailResult | File | undefined>();
   const [thumbnailToDelete, setThumbnailToDelete] = useState<boolean>(false);
@@ -225,6 +226,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
         contestId: isAdmin ? (contestId !== null ? contestId : projectData!.contestId) : projectData!.contestId,
         teamName: isAdmin ? teamName : projectData!.teamName,
         projectName: projectName,
+        professorName: isAdmin ? professorName : projectData!.professorName,
         leaderName: isAdmin ? leaderName : projectData!.leaderName,
         overview,
         productionPath: productionUrl,
@@ -301,6 +303,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
         contestId: contestId!,
         projectName,
         teamName,
+        professorName,
         leaderName,
         githubPath: githubUrl,
         youTubePath: youtubeUrl,
@@ -398,6 +401,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
       !!contestId &&
       !isEmpty(projectName) &&
       !isEmpty(teamName) &&
+      !isEmpty(professorName) &&
       !isEmpty(leaderName) &&
       teamMembers.length > 0 &&
       !isEmpty(githubUrl) &&
@@ -412,6 +416,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
     const basicInfoChanged =
       projectData.projectName !== projectName ||
       projectData.teamName !== teamName ||
+      projectData.professorName !== professorName ||
       projectData.leaderName !== leaderName ||
       projectData.overview !== overview ||
       projectData.productionPath !== productionUrl ||
@@ -472,6 +477,8 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
             setProjectName={setProjectName}
             teamName={teamName}
             setTeamName={setTeamName}
+            professorName={professorName}
+            setProfessorName={setProfessorName}
             leaderName={leaderName}
             setLeaderName={setLeaderName}
           />
@@ -485,6 +492,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
           projectName={projectName}
           setProjectName={setProjectName}
           teamName={teamName}
+          professorName={professorName}
           leaderName={leaderName}
           teamMembers={teamMembers} // WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의
         />

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -42,7 +42,7 @@ interface ProjectEditorPageProps {
 }
 
 const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
-  const { user, isAdmin, isLeader } = useAuth();
+  const { user, isAdmin, isLeader, isMember } = useAuth();
   const memberId = user?.id;
   const teamId = useTeamId();
   const initialContestId = useContestId();
@@ -166,8 +166,13 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
   if (isProjectLoading) return <EditorDetailSkeleton />;
   if ((isProjectError || !projectData) && isEditMode) return <div>데이터를 가져오지 못했습니다.</div>;
 
-  const isLeaderOfThisTeam = isLeader && isEditMode && projectData && memberId === projectData.leaderId;
-  if (!isLeaderOfThisTeam && !isAdmin) {
+  // const isLeaderOfThisTeam = isLeader && isEditMode && projectData && memberId === projectData.leaderId;
+  const isContributorOfThisTeam =
+    isEditMode &&
+    projectData &&
+    memberId &&
+    (memberId === projectData.leaderId || projectData.memberIds?.includes(memberId));
+  if (!isAdmin && !isContributorOfThisTeam) {
     return <div>접근 권한이 없습니다.</div>;
   }
 
@@ -201,7 +206,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
   };
 
   const validateEditInputs = () => {
-    if (isLeaderOfThisTeam) {
+    if (isContributorOfThisTeam) {
       if (!thumbnail || previews.length === 0) return '썸네일을 포함한 두 개 이상의 이미지를 올려주세요';
     }
 
@@ -487,7 +492,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
         </>
       )}
 
-      {(isLeaderOfThisTeam || (isAdmin && contestId === 1)) && (
+      {(isContributorOfThisTeam || (isAdmin && contestId === 1)) && (
         <IntroSection
           projectName={projectName}
           setProjectName={setProjectName}

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -171,7 +171,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
     isEditMode &&
     projectData &&
     memberId &&
-    (memberId === projectData.leaderId || projectData.memberIds?.includes(memberId));
+    (memberId === projectData.leaderId || projectData.teamMembers.some((member) => member.teamMemberId === memberId));
   if (!isAdmin && !isContributorOfThisTeam) {
     return <div>접근 권한이 없습니다.</div>;
   }

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -56,11 +56,11 @@ const ArrowButton = ({
 }) => {
   const Icon = direction === 'left' ? FaChevronLeft : FaChevronRight;
   return (
-    <button onClick={onClick} className={`focus:outline-none ${className}`}>
-      <Icon
-        size={size}
-        className="text-lightGray/50 hover:text-mainGreen animate-pulse rounded-full p-2 transition-colors duration-200 ease-in-out hover:cursor-pointer hover:bg-[#D1F3E1]/25"
-      />
+    <button
+      onClick={onClick}
+      className={`focus:outline-none ${className} text-lightGray/50 hover:text-mainGreen hover:cursor-pointer hover:bg-[#D1F3E1]/20`}
+    >
+      <Icon size={size} className="animate-pulse p-2 transition-colors duration-200 ease-in-out" />
     </button>
   );
 };
@@ -117,13 +117,7 @@ const MediaRenderer = ({
   }
 
   if (typeof currentMedia === 'object' && currentMedia?.status === 'default') {
-    return (
-      <img
-        src={currentMedia.url}
-        alt="기본 이미지"
-        className="border-lightGray absolute inset-0 h-full w-full border object-contain"
-      />
-    );
+    return <img src={currentMedia.url} alt="기본 이미지" className="absolute inset-0 h-full w-full object-contain" />;
   }
 
   const statusMessageMap: Record<string, { icon: React.ElementType; message: React.ReactNode; isError?: boolean }> = {
@@ -183,7 +177,7 @@ const MediaRenderer = ({
             alt="Project image"
             onLoad={() => setImageLoaded(true)}
             onError={() => setLoadFailed(true)}
-            className={`border-lightGray absolute inset-0 h-full w-full border object-contain transition-opacity duration-200 ${
+            className={`absolute inset-0 h-full w-full bg-gray-50 object-contain transition-opacity duration-200 ${
               imageLoaded ? 'opacity-100' : 'opacity-0'
             }`}
           />
@@ -299,17 +293,13 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
   });
 
   return (
-    <div className="flex flex-col items-center gap-4">
-      <div {...handlers} className="flex w-full items-center justify-center md:gap-10">
-        {!isMobile && (
-          <ArrowButton
-            direction="left"
-            onClick={goToPrev}
-            className={visibleImages.length > 1 ? 'visible' : 'invisible'}
-          />
+    <div {...handlers} className="flex h-full w-full flex-col items-center gap-4">
+      <div className="h-xl relative flex aspect-[3/2] w-full max-w-xl items-center justify-center">
+        {!isMobile && visibleImages.length > 1 && (
+          <ArrowButton direction="left" onClick={goToPrev} className="absolute left-0 z-10 h-full" />
         )}
 
-        <div className="border-lightGray relative aspect-[3/2] w-full max-w-2xl overflow-hidden rounded">
+        <div className="flex flex-1 justify-center">
           <MediaRenderer
             currentMedia={currentMedia}
             embedUrl={embedUrl}
@@ -320,12 +310,8 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
           />
         </div>
 
-        {!isMobile && (
-          <ArrowButton
-            direction="right"
-            onClick={goToNext}
-            className={visibleImages.length > 1 ? 'visible' : 'invisible'}
-          />
+        {!isMobile && visibleImages.length > 1 && (
+          <ArrowButton direction="right" onClick={goToNext} className="absolute right-0 z-10 h-full" />
         )}
       </div>
 
@@ -333,13 +319,13 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
         <div
           className={`mt-4 flex items-center ${!isMobile ? 'justify-center' : 'justify-between'} w-full max-w-2xl px-3`}
         >
-          {isMobile && <ArrowButton direction="left" onClick={goToPrev} size={40} />}
+          {isMobile && <ArrowButton direction="left" onClick={goToPrev} size={40} className="rounded-full" />}
 
           <div className="flex gap-5">
             <IndicatorDots count={visibleImages.length} currentIndex={currentIndex} onClick={goToSlide} />
           </div>
 
-          {isMobile && <ArrowButton direction="right" onClick={goToNext} size={40} />}
+          {isMobile && <ArrowButton direction="right" onClick={goToNext} size={40} className="rounded-full" />}
         </div>
       )}
     </div>

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -200,6 +200,9 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
   const [loadFailed, setLoadFailed] = useState(false);
   const isMobile = useMediaQuery('(max-width:640px)');
 
+  // TECHWEEK: 포스터 처리를 위한 state
+  const [isFirstPosterTall, setIsFirstPosterTall] = useState(false);
+
   const toast = useToast();
   const thumbnailNotFoundToast = useRef(false);
 
@@ -221,30 +224,66 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
     },
   });
 
+  // useEffect(() => {
+  //   if (thumbnailResult?.status === 'error' && thumbnailResult.code === 'THUMBNAIL_NOTFOUND') {
+  //     if (!thumbnailNotFoundToast.current) {
+  //       if (isEditor) {
+  //         toast('썸네일 이미지를 올려주세요', 'info');
+  //       }
+  //       thumbnailNotFoundToast.current = true;
+  //     }
+  //   } else {
+  //     thumbnailNotFoundToast.current = false;
+  //   }
+  // }, [thumbnailResult, isEditor, toast]);
+
+  // TECHWEEK: 포스터 없을 때 토스트
   useEffect(() => {
-    if (thumbnailResult?.status === 'error' && thumbnailResult.code === 'THUMBNAIL_NOTFOUND') {
+    if (previewIds.length === 0) {
       if (!thumbnailNotFoundToast.current) {
         if (isEditor) {
-          toast('썸네일 이미지를 올려주세요', 'info');
+          toast('졸업과제 포스터를 올려주세요', 'info');
         }
         thumbnailNotFoundToast.current = true;
+      } else {
+        thumbnailNotFoundToast.current = false;
       }
-    } else {
-      thumbnailNotFoundToast.current = false;
     }
-  }, [thumbnailResult, isEditor, toast]);
+  }, [previewIds, isEditor, toast]);
 
   const embedUrl = useMemo(() => getEmbedUrl(youtubeUrl), [youtubeUrl]);
   const rawImages = useMemo(() => {
     const images: MediaType[] = [];
+    // if (previewData?.imageResults) {
+    //   images.push(...(previewData.imageResults[0] ? [previewData.imageResults[0]] : []));
+    // }
+    // if (embedUrl) {
+    //   images.push('youtube');
+    // }
+    // if (thumbnailResult) {
+    //   images.push(thumbnailResult);
+    // }
+    // if (previewData?.imageResults) {
+    //   images.push(...(previewData.imageResults[1] ? previewData.imageResults.slice(1) : []));
+    // }
+
+    // TECHWEEK: 포스터 처리를 위한 로직
+    const imageResults = previewData?.imageResults ?? [];
+
+    if (imageResults.length > 0 && imageResults[0]) {
+      images.push(imageResults[0]); // 포스터 역할을 할 previewData.imageResults[0]을 맨 앞에 push 하기
+    }
+
     if (embedUrl) {
       images.push('youtube');
     }
+
     if (thumbnailResult) {
       images.push(thumbnailResult);
     }
-    if (previewData?.imageResults) {
-      images.push(...previewData.imageResults);
+
+    if (imageResults.length > 1) {
+      images.push(...imageResults.slice(1));
     }
 
     const hasValidMedia = images.some(
@@ -272,6 +311,18 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
 
   const currentMedia = useMemo(() => visibleImages[currentIndex] || null, [visibleImages, currentIndex]);
 
+  const isFirstPreviewActive = useMemo(() => {
+    const first = previewData?.imageResults?.[0];
+    if (!first) return false;
+    const media = visibleImages[currentIndex];
+    if (!media || typeof media !== 'object') return false;
+    // Only compare URLs when both items are successful preview results (they expose `url`)
+    if ('status' in media && media.status === 'success' && first.status === 'success') {
+      return media.url === first.url;
+    }
+    return false;
+  }, [previewData, visibleImages, currentIndex]);
+
   useEffect(() => {
     setImageLoaded(false);
     setLoadFailed(false);
@@ -294,38 +345,77 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
 
   return (
     <div {...handlers} className="flex h-full w-full flex-col items-center gap-4">
-      <div className="h-xl relative flex aspect-[3/2] w-full max-w-xl items-center justify-center">
-        {!isMobile && visibleImages.length > 1 && (
-          <ArrowButton direction="left" onClick={goToPrev} className="absolute left-0 z-10 h-full" />
-        )}
+      <div className="relative flex w-full items-center justify-center">
+        <div className={`relative w-full max-w-2xl ${isFirstPreviewActive ? 'max-h-[80vh] sm:max-h-[70vh]' : ''}`}>
+          <div
+            className={`border-lightGray relative w-full overflow-hidden rounded ${
+              isFirstPreviewActive ? 'aspect-[2/3]' : 'aspect-[3/2]'
+            }`}
+          >
+            {isFirstPreviewActive && typeof currentMedia === 'object' && currentMedia?.status === 'success' ? (
+              <img
+                src={(currentMedia as any).url}
+                alt="포스터"
+                onLoad={() => setImageLoaded(true)}
+                onError={() => setLoadFailed(true)}
+                className="absolute inset-0 h-full w-full bg-gray-50 object-cover"
+              />
+            ) : (
+              <div className="absolute inset-0 h-full w-full">
+                <MediaRenderer
+                  currentMedia={currentMedia}
+                  embedUrl={embedUrl}
+                  imageLoaded={imageLoaded}
+                  setImageLoaded={setImageLoaded}
+                  setLoadFailed={setLoadFailed}
+                  isEditor={isEditor}
+                />
+              </div>
+            )}
+          </div>
 
-        <div className="flex flex-1 justify-center">
-          <MediaRenderer
-            currentMedia={currentMedia}
-            embedUrl={embedUrl}
-            imageLoaded={imageLoaded}
-            setImageLoaded={setImageLoaded}
-            setLoadFailed={setLoadFailed}
-            isEditor={isEditor}
-          />
+          {/* {!isMobile && visibleImages.length > 1 && (
+            <>
+              <button
+                onClick={goToPrev}
+                aria-label="이전"
+                className="absolute top-0 bottom-0 left-0 flex items-center px-2"
+                style={{ zIndex: 20 }}
+              >
+                <span className="rounded-full p-2 transition-colors group-hover:bg-[#D1F3E1]/25">
+                  <FaChevronLeft size={50} className="text-lightGray/50 hover:text-mainGreen" />
+                </span>
+              </button>
+
+              <button
+                onClick={goToNext}
+                aria-label="다음"
+                className="absolute top-0 right-0 bottom-0 flex items-center px-2"
+                style={{ zIndex: 20 }}
+              >
+                <span className="rounded-full p-2 transition-colors group-hover:bg-[#D1F3E1]/25">
+                  <FaChevronRight size={50} className="text-lightGray/50 hover:text-mainGreen" />
+                </span>
+              </button>
+            </>
+          )} */}
         </div>
-
-        {!isMobile && visibleImages.length > 1 && (
-          <ArrowButton direction="right" onClick={goToNext} className="absolute right-0 z-10 h-full" />
-        )}
       </div>
 
       {visibleImages.length > 1 && (
-        <div
-          className={`mt-4 flex items-center ${!isMobile ? 'justify-center' : 'justify-between'} w-full max-w-2xl px-3`}
-        >
-          {isMobile && <ArrowButton direction="left" onClick={goToPrev} size={40} className="rounded-full" />}
+        // TECHWEEK: PC와 모바일 indicator 위치 같도록
+        // <div
+        //   className={`mt-4 flex items-center ${!isMobile ? 'justify-center' : 'justify-between'} w-full max-w-2xl px-3`}
+        // >
+        <div className="mt-4 flex w-full max-w-2xl items-center justify-between px-3">
+          {/* TECHWEEK: PC와 모바일 indicator 위치 같도록 */}
+          <ArrowButton direction="left" onClick={goToPrev} size={40} className="rounded-full" />
 
           <div className="flex gap-5">
             <IndicatorDots count={visibleImages.length} currentIndex={currentIndex} onClick={goToSlide} />
           </div>
 
-          {isMobile && <ArrowButton direction="right" onClick={goToNext} size={40} className="rounded-full" />}
+          <ArrowButton direction="right" onClick={goToNext} size={40} className="rounded-full" />
         </div>
       )}
     </div>

--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -346,7 +346,7 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
   return (
     <div {...handlers} className="flex h-full w-full flex-col items-center gap-4">
       <div className="relative flex w-full items-center justify-center">
-        <div className={`relative w-full max-w-2xl ${isFirstPreviewActive ? 'max-h-[80vh] sm:max-h-[70vh]' : ''}`}>
+        <div className={`relative w-full max-w-2xl ${isFirstPreviewActive ? 'max-h-[800vh] sm:max-h-[700vh]' : ''}`}>
           <div
             className={`border-lightGray relative w-full overflow-hidden rounded ${
               isFirstPreviewActive ? 'aspect-[2/3]' : 'aspect-[3/2]'

--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 
-import { TeamMember } from 'types/DTO/projectViewerDto';
+import { ProjectDetailsResponseDto, TeamMember } from 'types/DTO/projectViewerDto';
 import { FaCrown } from 'react-icons/fa6';
+import { FaChalkboardTeacher } from 'react-icons/fa';
 import { IoEllipsisHorizontal, IoPerson } from 'react-icons/io5';
 
 interface DetailSectionProps {
-  overview?: string;
-  leaderName: string;
-  teamMembers: TeamMember[];
+  data: ProjectDetailsResponseDto;
 }
 
-const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps) => {
+const DetailSection = ({ data }: DetailSectionProps) => {
+  const { overview, professorName = '교수님', leaderName, teamMembers } = data; // TODO: professorName mock data
   const hasOverview = overview?.trim();
   const safeOverview = overview ?? '';
   const INIT_LENGTH = 500;
@@ -22,7 +22,13 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
   return (
     <>
       <div className="flex flex-col gap-3">
-        <div className="sm:text-title text-xl font-bold">Participants</div>
+        <div className="sm:text-title text-xl font-bold">Contributors</div>
+        <span className="flex items-center gap-3">
+          <FaChalkboardTeacher className="text-teal-500" size={20} />
+          <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
+            {professorName}
+          </span>
+        </span>
         <span className="flex items-center gap-3">
           <FaCrown className="text-amber-300" size={20} />
           <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
@@ -30,11 +36,14 @@ const DetailSection = ({ overview, leaderName, teamMembers }: DetailSectionProps
           </span>
         </span>
         <div className="flex items-start gap-3">
-          <IoPerson className="h-7 shrink-0 text-blue-400" size={20} />
+          <IoPerson className="h-8 shrink-0 text-blue-400" size={20} />
           <div className="flex flex-wrap gap-2 sm:gap-3">
             {teamMembers.map((member, index) => (
-              <div key={index} className="h-7">
-                <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
+              <div key={index} className="flex h-8 items-center">
+                <span
+                  key={index}
+                  className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm"
+                >
                   {member.teamMemberName}
                 </span>
               </div>

--- a/src/pages/project-viewer/IntroSection.tsx
+++ b/src/pages/project-viewer/IntroSection.tsx
@@ -7,16 +7,11 @@ import { FaGithub, FaYoutube } from 'react-icons/fa';
 import { FaEdit } from 'react-icons/fa';
 import { RiLink } from 'react-icons/ri';
 import { FiExternalLink } from 'react-icons/fi';
+import { ProjectDetailsResponseDto } from 'types/DTO/projectViewerDto';
 
 interface IntroSectionProps {
-  contestId: number;
-  teamId: number;
+  data: ProjectDetailsResponseDto;
   isEditor: boolean;
-  projectName: string;
-  teamName: string;
-  productionUrl: string | null;
-  githubUrl: string;
-  youtubeUrl: string;
 }
 
 const UrlButton = ({ url }: { url: string }) => {
@@ -50,17 +45,9 @@ const UrlButton = ({ url }: { url: string }) => {
   );
 };
 
-const IntroSection = ({
-  contestId,
-  teamId,
-  isEditor,
-  projectName,
-  teamName,
-  productionUrl,
-  githubUrl,
-  youtubeUrl,
-}: IntroSectionProps) => {
+const IntroSection = ({ data, isEditor }: IntroSectionProps) => {
   const navigate = useNavigate();
+  const { teamId, teamName, projectName, productionPath } = data;
 
   return (
     <div className="flex flex-col items-center gap-8 md:flex-row md:items-start md:justify-between">
@@ -80,7 +67,7 @@ const IntroSection = ({
             </button>
           </div>
         )}
-        {productionUrl && <UrlButton url={productionUrl} />}
+        {productionPath && <UrlButton url={productionPath} />}
       </div>
     </div>
   );

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -61,17 +61,21 @@ const ProjectViewerPage = () => {
   if (error) return <div>에러 발생: {String(error)}</div>;
   if (!data) return <div>데이터를 불러올 수 없습니다.</div>;
 
-  const isLeaderOfThisTeam = isLeader && memberId == data.leaderId;
+  // const isLeaderOfThisTeam = isLeader && memberId == data.leaderId;
+  const isContributorOfThisTeam =
+    data &&
+    memberId &&
+    (memberId === data.leaderId || data.teamMembers.some((member) => member.teamMemberId === memberId));
 
   return (
     <div className="min-w-xs px-2 sm:px-5">
-      <IntroSection data={data} isEditor={isLeaderOfThisTeam || isAdmin} />
+      <IntroSection data={data} isEditor={isContributorOfThisTeam || isAdmin} />
       <div className="h-10" />
       <CarouselSection
         teamId={data.teamId}
         previewIds={data.previewIds}
         youtubeUrl={data.youTubePath}
-        isEditor={isLeaderOfThisTeam || isAdmin}
+        isEditor={isContributorOfThisTeam || isAdmin}
       />
       <div className="h-10" />
       {isVoteTerm ? <LikeSection contestId={data.contestId} teamId={data.teamId} isLiked={data.isLiked} /> : null}

--- a/src/pages/project-viewer/ProjectViewerPage.tsx
+++ b/src/pages/project-viewer/ProjectViewerPage.tsx
@@ -65,16 +65,7 @@ const ProjectViewerPage = () => {
 
   return (
     <div className="min-w-xs px-2 sm:px-5">
-      <IntroSection
-        contestId={data.contestId}
-        teamId={data.teamId}
-        isEditor={isLeaderOfThisTeam || isAdmin}
-        projectName={data.projectName}
-        teamName={data.teamName}
-        productionUrl={data.productionPath}
-        githubUrl={data.githubPath}
-        youtubeUrl={data.youTubePath}
-      />
+      <IntroSection data={data} isEditor={isLeaderOfThisTeam || isAdmin} />
       <div className="h-10" />
       <CarouselSection
         teamId={data.teamId}
@@ -85,7 +76,7 @@ const ProjectViewerPage = () => {
       <div className="h-10" />
       {isVoteTerm ? <LikeSection contestId={data.contestId} teamId={data.teamId} isLiked={data.isLiked} /> : null}
       <div className="h-10" />
-      <DetailSection overview={data.overview} leaderName={data.leaderName} teamMembers={data.teamMembers} />
+      <DetailSection data={data} />
       <div className="h-10" />
       <GithubCard githubUrl={data.githubPath} />
       <div className="h-28" />

--- a/src/types/DTO/projectEditorDto.ts
+++ b/src/types/DTO/projectEditorDto.ts
@@ -2,6 +2,7 @@ export interface ProjectDetailsEditDto {
   contestId: number;
   teamName: string;
   projectName: string;
+  professorName: string;
   leaderName: string;
   overview: string;
   productionPath: string | null;

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -11,6 +11,7 @@ export interface ProjectDetailsResponseDto {
   teamName: string;
   projectName: string;
   overview: string;
+  professorName: string;
   leaderName: string;
   teamMembers: TeamMember[]; // WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의
   previewIds: number[];

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -8,6 +8,7 @@ export interface ProjectDetailsResponseDto {
   contestName: string;
   teamId: number;
   leaderId: number;
+  memberIds: number[];
   teamName: string;
   projectName: string;
   overview: string;

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -8,7 +8,6 @@ export interface ProjectDetailsResponseDto {
   contestName: string;
   teamId: number;
   leaderId: number;
-  memberIds: number[];
   teamName: string;
   projectName: string;
   overview: string;

--- a/src/types/MemberType.ts
+++ b/src/types/MemberType.ts
@@ -1,1 +1,1 @@
-export type MemberType = 'ROLE_회원' | 'ROLE_팀장' | 'ROLE_관리자';
+export type MemberType = 'ROLE_회원' | 'ROLE_팀장' | 'ROLE_팀원' | 'ROLE_관리자';


### PR DESCRIPTION
### 📝 개요
- 팀장에게만 있던 프로젝트 편집 권한을 팀원에게도 부여합니다.
- 졸업과제 포스터 규격(2:3)에 맞는 이미지를 보여줍니다.

### 🎯 목적
- 효율적인 졸업과제 프로젝트 관리를 위해서입니다.

### 📸 참고 이미지/영상 (선택)
<img width="833" height="1201" alt="image" src="https://github.com/user-attachments/assets/05515562-0f9e-4f87-a156-f0e7ed3ee8c8" />

