### PR TITLE
fix: 공지사항 텍스트가 긴 경우(링크 등) 컨테이너에서 넘치는 문제 수정

### DIFF
--- a/src/pages/notice/NoticeDetail.tsx
+++ b/src/pages/notice/NoticeDetail.tsx
@@ -7,58 +7,57 @@ import NoticeDetailSkeleton from './NoticeDetailSkeleton';
 import dayjs from 'dayjs';
 
 const NoticeDetail = () => {
-    useEffect(() => {
-        window.scrollTo({ top: 0, behavior: 'auto' });
-    }, []);
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, []);
 
-    const { noticeId } = useParams();
-    const {
-        data: notice,
-        isLoading,
-        isError,
-    } = useQuery({
-        queryKey: ['noticeDetail', noticeId],
-        queryFn: () => getNoticeDetail(Number(noticeId)),
-        enabled: !!noticeId,
-    });
+  const { noticeId } = useParams();
+  const {
+    data: notice,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['noticeDetail', noticeId],
+    queryFn: () => getNoticeDetail(Number(noticeId)),
+    enabled: !!noticeId,
+  });
 
-    if (isLoading) return <NoticeDetailSkeleton />;
-    if (isError || !notice) {
-        return <div>공지사항을 찾을 수 없습니다.</div>;
-    }
+  if (isLoading) return <NoticeDetailSkeleton />;
+  if (isError || !notice) {
+    return <div>공지사항을 찾을 수 없습니다.</div>;
+  }
 
-    return (
-        <div className="max-w mx-auto">
-            <h1 className="mb-6 text-2xl font-bold">공지사항</h1>
-            <div className="bg-whiteGray mb-2 flex items-center rounded px-4 py-5">
-                <AiOutlineNotification className="mr-4" />
-                <span className="flex-1 text-[clamp(0.85rem,2vw,1.3rem)] font-bold">{notice.title}</span>
-            </div>
+  return (
+    <div className="max-w mx-auto">
+      <h1 className="mb-6 text-2xl font-bold">공지사항</h1>
+      <div className="bg-whiteGray mb-2 flex items-center rounded px-4 py-5">
+        <AiOutlineNotification className="mr-4" />
+        <span className="flex-1 text-[clamp(0.85rem,2vw,1.3rem)] font-bold">{notice.title}</span>
+      </div>
 
-            <div className="flex justify-end">
-                <div className="flex px-2">
-                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">작성일</div>
-                    <div className=" mb-6 text-midGray text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
-                        {dayjs(notice.createdAt).format('YYYY.MM.DD')}
-                    </div>
-                </div>
-
-                <div className="px-1 text-midGray text-[clamp(0.75rem,1.5vw,1rem)] font-bold"> |</div>
-
-                <div className="flex">
-                    <div className="px-2 text-midGray text-[clamp(0.75rem,1.5vw,1rem)]">수정일</div>
-                    <div className=" mb-6 text-midGray text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
-                        {dayjs(notice.updatedAt).format('YYYY.MM.DD')}
-                    </div>
-                </div>
-            </div>
-
-
-            <div className="bg-subGreen rounded p-6 text-[clamp(0.75rem,2vw,1rem)] leading-relaxed whitespace-pre-line">
-                {notice.description}
-            </div>
+      <div className="flex justify-end">
+        <div className="flex px-2">
+          <div className="text-midGray px-2 text-[clamp(0.75rem,1.5vw,1rem)]">작성일</div>
+          <div className="text-midGray mb-6 text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
+            {dayjs(notice.createdAt).format('YYYY.MM.DD')}
+          </div>
         </div>
-    );
+
+        <div className="text-midGray px-1 text-[clamp(0.75rem,1.5vw,1rem)] font-bold"> |</div>
+
+        <div className="flex">
+          <div className="text-midGray px-2 text-[clamp(0.75rem,1.5vw,1rem)]">수정일</div>
+          <div className="text-midGray mb-6 text-right text-[clamp(0.75rem,1.5vw,1rem)] font-semibold">
+            {dayjs(notice.updatedAt).format('YYYY.MM.DD')}
+          </div>
+        </div>
+      </div>
+
+      <p className="bg-subGreen rounded p-6 text-[clamp(0.75rem,2vw,1rem)] leading-relaxed break-words whitespace-pre-line">
+        {notice.description}
+      </p>
+    </div>
+  );
 };
 
 export default NoticeDetail;


### PR DESCRIPTION
### 📝 개요
공지사항 텍스트가 긴 경우(링크 등) 컨테이너에서 넘치는 문제 수정

### 🎯 목적
공지사항 텍스트가 긴 경우(링크 등) 컨테이너에서 넘치는 문제 수정

### ✨ 변경 사항
- NoticeDetail 컴포넌트 break-words 속성 추가
- 시맨틱 태그 활용을 위한 div -> p 태그 변경
- prettier 코드 스타일 적용

### 📸 참고 이미지/영상 (선택)
<img width="757" height="827" alt="image" src="https://github.com/user-attachments/assets/3c316bbe-c79c-4bf3-b8b7-804b21073786" />

