### PR TITLE
design: 프로젝트 상세보기 페이지 Contributor 섹션에서 지도교수가 없는 경우 보이지 않도록 처리

### DIFF
--- a/src/pages/project-viewer/DetailSection.tsx
+++ b/src/pages/project-viewer/DetailSection.tsx
@@ -10,7 +10,7 @@ interface DetailSectionProps {
 }
 
 const DetailSection = ({ data }: DetailSectionProps) => {
-  const { overview, professorName = '교수님', leaderName, teamMembers } = data; // TODO: professorName mock data
+  const { overview, professorName, leaderName, teamMembers } = data; // TODO: professorName mock data
   const hasOverview = overview?.trim();
   const safeOverview = overview ?? '';
   const INIT_LENGTH = 500;
@@ -23,12 +23,14 @@ const DetailSection = ({ data }: DetailSectionProps) => {
     <>
       <div className="flex flex-col gap-3">
         <div className="sm:text-title text-xl font-bold">Contributors</div>
-        <span className="flex items-center gap-3">
-          <FaChalkboardTeacher className="text-teal-500" size={20} />
-          <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
-            {professorName}
+        {professorName && (
+          <span className="flex items-center gap-3">
+            <FaChalkboardTeacher className="text-teal-500" size={20} />
+            <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">
+              {professorName}
+            </span>
           </span>
-        </span>
+        )}
         <span className="flex items-center gap-3">
           <FaCrown className="text-amber-300" size={20} />
           <span className="bg-whiteGray text-exsm rounded-full px-3 py-1 whitespace-nowrap sm:text-sm">

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -11,7 +11,7 @@ export interface ProjectDetailsResponseDto {
   teamName: string;
   projectName: string;
   overview: string;
-  professorName: string;
+  professorName: string | null;
   leaderName: string;
   teamMembers: TeamMember[]; // WARN: 백엔드 측에서 필드명 바꿀 수도 있음 주의
   previewIds: number[];


### PR DESCRIPTION
### 📝 개요
프로젝트 상세보기 페이지 Contributor 섹션에서 지도교수가 없는 경우 보이지 않도록 처리

### 🎯 목적
프로젝트 상세보기 페이지 Contributor 섹션에서 지도교수가 없는 경우에도 해당 필드가 나타나는 문제 해결

### ✨ 변경 사항
- ProjectDetailsResponseDto professorName 필드 nullable
- professorName이 null인 경우 지도교수가 보이지 않도록 수정

### 📸 참고 이미지/영상
|변경 전|변경 후|
|---|---|
|<img width="317" height="207" alt="image" src="https://github.com/user-attachments/assets/009449e0-6a88-4824-872e-316605b9a851" />|<img width="309" height="176" alt="image" src="https://github.com/user-attachments/assets/78e08221-929b-4602-acca-ba1ec225dcb0" />|


