### PR TITLE
fix: 현재 진행중인 대회 id를 1로 하드코딩하던 코드 공통 상수로 변경

### DIFF
--- a/src/constants/contest.ts
+++ b/src/constants/contest.ts
@@ -1,1 +1,1 @@
-export const CURRENT_CONTEST_ID = 3;
+export const CURRENT_CONTEST_ID = 3; // TODO: API에서 받아올 수 있도록 변경 필요(하드코딩 피해야함)

--- a/src/pages/project-editor/AdminEditSection/ContestMenu.tsx
+++ b/src/pages/project-editor/AdminEditSection/ContestMenu.tsx
@@ -50,10 +50,10 @@ const ContestMenu = ({ value, onChange }: ContestMenuProps) => {
       <button
         className="border-lightGray focus:ring-subGreen focus:border-mainGreen flex w-full items-center justify-between rounded border px-5 py-3 text-left duration-150 hover:cursor-pointer focus:outline-none"
         onClick={() => {
-          if (selectedContest?.contestId == 1) {
+          if (selectedContest?.contestId == CURRENT_CONTEST_ID) {
             toast('현재 진행 중인 대회의 프로젝트의 소속을 변경할 수 없습니다.', 'info');
           }
-          if (selectedContest?.contestId !== 1) {
+          if (selectedContest?.contestId !== CURRENT_CONTEST_ID) {
             setIsOpen((prev) => !prev);
           }
         }}

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -115,7 +115,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
     if (projectData) {
       setContestId(projectData.contestId);
       setTeamName(projectData.teamName);
-      setProfessorName(projectData.professorName);
+      setProfessorName(projectData.professorName ?? '');
       setProjectName(projectData.projectName);
       setLeaderName(projectData.leaderName);
       setTeamMembers(projectData.teamMembers);

--- a/src/pages/project-editor/ProjectEditorPage.tsx
+++ b/src/pages/project-editor/ProjectEditorPage.tsx
@@ -475,7 +475,7 @@ const ProjectEditorPage = ({ mode }: ProjectEditorPageProps) => {
       </div>
 
       <div className="h-10" />
-      {isAdmin && contestId !== 1 && (
+      {isAdmin && contestId !== CURRENT_CONTEST_ID && (
         <>
           <AdminEditSection
             contestId={contestId}


### PR DESCRIPTION
### 📝 개요
현재 진행중인 대회 id를 1로 하드코딩하던 코드 공통 상수로 변경

### 🎯 목적
이전 변경에서 미흡한 코드 변경 문제를 해결

### ✨ 변경 사항
- contestId를 1로 하드코딩중인 코드 재확인 및 수정

### 🔬 리뷰 요구 사항
- @redzzzi 지연님 담당 부분이라 크로스체크 필요할 것 같습니다. 제가 변경한 부분 적용해도 되는지 검토 부탁드립니다.