### PR TITLE
fix: 캐러셀에서 일부 이미지가 잘려 보이는 문제 수정

### DIFF
--- a/src/pages/project-viewer/CarouselSection.tsx
+++ b/src/pages/project-viewer/CarouselSection.tsx
@@ -113,11 +113,11 @@ const MediaRenderer = ({
   isEditor: boolean;
 }) => {
   if (currentMedia === 'youtube' && embedUrl) {
-    return <iframe src={embedUrl} title="Youtube Iframe" allowFullScreen className="absolute inset-0 h-full w-full" />;
+    return <iframe src={embedUrl} title="Youtube Iframe" allowFullScreen className="aspect-video w-full" />;
   }
 
   if (typeof currentMedia === 'object' && currentMedia?.status === 'default') {
-    return <img src={currentMedia.url} alt="기본 이미지" className="absolute inset-0 h-full w-full object-contain" />;
+    return <img src={currentMedia.url} alt="기본 이미지" className="w-full object-contain" />;
   }
 
   const statusMessageMap: Record<string, { icon: React.ElementType; message: React.ReactNode; isError?: boolean }> = {
@@ -177,7 +177,7 @@ const MediaRenderer = ({
             alt="Project image"
             onLoad={() => setImageLoaded(true)}
             onError={() => setLoadFailed(true)}
-            className={`absolute inset-0 h-full w-full bg-gray-50 object-contain transition-opacity duration-200 ${
+            className={`w-full bg-gray-50 object-contain transition-opacity duration-200 ${
               imageLoaded ? 'opacity-100' : 'opacity-0'
             }`}
           />
@@ -347,21 +347,17 @@ const CarouselSection = ({ teamId, previewIds, youtubeUrl, isEditor }: CarouselS
     <div {...handlers} className="flex h-full w-full flex-col items-center gap-4">
       <div className="relative flex w-full items-center justify-center">
         <div className={`relative w-full max-w-2xl ${isFirstPreviewActive ? 'max-h-[800vh] sm:max-h-[700vh]' : ''}`}>
-          <div
-            className={`border-lightGray relative w-full overflow-hidden rounded ${
-              isFirstPreviewActive ? 'aspect-[2/3]' : 'aspect-[3/2]'
-            }`}
-          >
+          <div className="border-lightGray relative w-full overflow-hidden rounded">
             {isFirstPreviewActive && typeof currentMedia === 'object' && currentMedia?.status === 'success' ? (
               <img
                 src={(currentMedia as any).url}
                 alt="포스터"
                 onLoad={() => setImageLoaded(true)}
                 onError={() => setLoadFailed(true)}
-                className="absolute inset-0 h-full w-full bg-gray-50 object-cover"
+                className="w-full bg-gray-50 object-contain"
               />
             ) : (
-              <div className="absolute inset-0 h-full w-full">
+              <div className="w-full">
                 <MediaRenderer
                   currentMedia={currentMedia}
                   embedUrl={embedUrl}


### PR DESCRIPTION
### 📝 개요
캐러셀에서 일부 이미지가 잘려 보이는 문제 수정

### 🎯 목적
테크위크 프로젝트 포스터 이미지 표현을 위한 캐러셀 수정 이후 이전 대회들의 이미지가 잘려 보이는 문제를 수정하기 위함

### ✨ 변경 사항
- CarouselSection 컴포넌트의 css 속성을 조절하여 너비는 모든 이미지가 동일하고, 고정된 너비에 따라 높이가 결정되도록 수정

### 🔬 리뷰 요구 사항 (선택)
- 컴포넌트 구조가 복잡해 최소한의 수정으로 문제가 해결될 수 있도록 진행했습니다. 중첩된 태그들 간의 CSS 속성을 깊이 고려하지 못한 수정이 있을 수 있습니다..!

### 📸 참고 이미지/영상 (선택)
|변경 전|변경 후|
|---|---|
|<img width="1440" height="998" alt="image" src="https://github.com/user-attachments/assets/eaa2574c-a3f1-4bb7-9cde-40e620a17ea5" />|<img width="1440" height="969" alt="image" src="https://github.com/user-attachments/assets/5bacdb59-fb2b-4191-8a9c-0927d132a1c9" />|


