### PR TITLE
feat: 남은 좋아요 개수 표현 툴팁 구현

### DIFF
--- a/src/apis/projectViewer.ts
+++ b/src/apis/projectViewer.ts
@@ -8,6 +8,7 @@ import {
   CommentEditRequestDto,
   CommentDto,
   PreviewResult,
+  LikeUpdateResponseDto,
 } from 'types/DTO/projectViewerDto';
 
 export const getProjectDetails = async (teamId: number): Promise<ProjectDetailsResponseDto> => {
@@ -43,7 +44,7 @@ export const getPreviewImages = async (teamId: number, imageIds: number[]): Prom
   return { imageResults };
 };
 
-export const patchLikeToggle = async (request: LikeUpdateRequestDto) => {
+export const patchLikeToggle = async (request: LikeUpdateRequestDto): Promise<LikeUpdateResponseDto> => {
   const { teamId, isLiked } = request;
   const response = await apiClient.patch(`/teams/${teamId}/like`, { isLiked });
   return response.data;

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -66,6 +66,13 @@ export interface LikeUpdateRequestDto {
   teamId: number;
   isLiked: boolean;
 }
+export interface LikeUpdateResponseDto {
+  teamId: number;
+  isLiked: boolean;
+  message: string;
+  remainingLikeCount: number;
+  maxLikeCount: number;
+}
 
 export interface PreviewImage {
   id?: number;


### PR DESCRIPTION
### 📝 개요
남은 좋아요 개수 표현 툴팁 구현

### 🎯 목적
대회 당 제한된 좋아요(투표) 수, 유저에게 남은 좋아요 개수를 알려주기 위한 툴팁 구현

### ✨ 변경 사항
- '좋아요 토글' api 응답 DTO 정의
- 좋아요 버튼 클릭 시(mutate onSuccess시) 남은 좋아요 수를 표현하는 토글 open
- 좋아요 추가/삭제 시, 최대 좋아요 수를 넘은 요청 시에 대한 처리여부 확인 완료

### 📸 참고 이미지/영상 (선택)
<img width="461" height="360" alt="2025-09-30_06-38-29" src="https://github.com/user-attachments/assets/4445e885-b7f2-4154-af82-14ea2a8e48e9" />
