### PR TITLE
feat: 404 페이지 추가

### DIFF
--- a/src/pages/common/NotFound.tsx
+++ b/src/pages/common/NotFound.tsx
@@ -1,4 +1,0 @@
-const NotFound = () => {
-  return <div>not found 페이지입니다.</div>;
-};
-export default NotFound;

--- a/src/pages/common/NotFoundPage.tsx
+++ b/src/pages/common/NotFoundPage.tsx
@@ -1,0 +1,21 @@
+import { TbError404 } from 'react-icons/tb';
+import { Link } from 'react-router-dom';
+import FullContainer from '@layout/FullContainer';
+
+const NotFound = () => {
+  return (
+    <FullContainer>
+      <div className="flex h-[500px] flex-col items-center justify-center">
+        <TbError404 className="stroke-mainGreen" size={150} />
+        <div className="flex flex-col items-center gap-7">
+          <p className="text-center text-lg whitespace-pre-wrap">{`페이지를 찾을 수 없습니다.\n주소가 올바른지 다시 한번 확인해주세요.`}</p>
+          <Link to="/" className="bg-mainGreen w-fit rounded-lg px-4 py-2 text-lg text-white">
+            메인으로 이동
+          </Link>
+        </div>
+      </div>
+    </FullContainer>
+  );
+};
+
+export default NotFound;

--- a/src/route/AppRoutes.tsx
+++ b/src/route/AppRoutes.tsx
@@ -19,6 +19,7 @@ import AdminContestLayout from '@layout/admin/contest/AdminContestLayout';
 import FullContainer from '@layout/FullContainer';
 import SidebarLayout from '@layout/SidebarLayout';
 import TeamOrderAdminPage from '@pages/admin/team-order/TeamOrderAdminPage';
+import NotFoundPage from '@pages/common/NotFoundPage';
 
 const AppRoutes = () =>
   createBrowserRouter([
@@ -80,6 +81,7 @@ const AppRoutes = () =>
             },
           ],
         },
+        { path: '*', element: <NotFoundPage /> },
       ],
     },
   ]);


### PR DESCRIPTION
### 📝 개요
404 페이지 추가

### 🎯 목적
기존에는 별도로 404에 대한 핸들링 처리가 되어 있지 않아 라우팅 설정 후 페이지 추가

### ✨ 변경 사항
- 404 페이지 추가
- `AppRoutes`에 wildcard 설정으로 나머지 경로에 대한 라우팅 적용

### 📸 참고 이미지/영상
- 기존
<img width="1146" height="160" alt="image" src="https://github.com/user-attachments/assets/a4adb7be-14b5-4288-96d2-954a9d056488" />

- 수정
<img width="1267" height="734" alt="image" src="https://github.com/user-attachments/assets/da04fa86-ac84-4edb-b036-69525617671e" />
