### PR TITLE
feat: 어드민 팀·참여자 설정 페이지 추가 및 대회 생성 UX 개선

### DIFF
--- a/src/constants/adminContestLayoutSidebarData.ts
+++ b/src/constants/adminContestLayoutSidebarData.ts
@@ -12,6 +12,7 @@ const adminContestSidebarData = [
     title: '대회',
     links: [
       { to: 'manage', label: '대회 관리' },
+      { to: 'team-setting', label: '팀·참여자 설정' },
       { to: 'tracks', label: '분과 관리' },
       { to: 'votes', label: '투표 관리' },
       { to: 'notices', label: '공지 관리' },

--- a/src/constants/contest.ts
+++ b/src/constants/contest.ts
@@ -1,3 +1,3 @@
-export const contestCreateSteps = ['대회 생성', '대회 팀·참여자 설정', '필수 항목 설정'];
+export const contestCreateSteps = ['대회 생성', '팀·참여자 설정', '필수 항목 설정'];
 
 export const XLSX_MIME_TYPE = `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`;

--- a/src/hooks/useRequiredFields.ts
+++ b/src/hooks/useRequiredFields.ts
@@ -19,11 +19,12 @@ export const useRequiredFields = (contestId: number) => {
     setFieldsSetting((prev) => ({ ...prev, [key]: value }));
   };
 
-  const handleSave = async () => {
+  const handleSave = async (successCb?: () => void) => {
     updateRequiredFields.mutate(fieldsSetting, {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['requiredFields', contestId] });
         toast('필수 항목 설정이 저장되었습니다.', 'success');
+        successCb?.();
       },
       onError: () => {
         toast('필수 항목 설정 저장에 실패했습니다.', 'error');

--- a/src/pages/admin/create/ContestCreatePage.tsx
+++ b/src/pages/admin/create/ContestCreatePage.tsx
@@ -5,14 +5,14 @@ import CreateRequiredFields from './CreateRequiredFields';
 import ContestTeamInsert from './ContestTeamInsert';
 
 const ContestCreateContent = () => {
-  const { currentStep } = useContestCreate();
+  const { contestId, currentStep, setCurrentStep } = useContestCreate();
 
   return (
     <div className="flex flex-col gap-8">
       <ContestCreateProgress />
       <div className="border-t pt-8">
         {currentStep === 1 && <ContestCreateForm />}
-        {currentStep === 2 && <ContestTeamInsert />}
+        {currentStep === 2 && <ContestTeamInsert contestId={contestId} handleSkip={() => setCurrentStep(3)} />}
         {currentStep === 3 && <CreateRequiredFields />}
       </div>
     </div>

--- a/src/pages/admin/create/ContestCreatePage.tsx
+++ b/src/pages/admin/create/ContestCreatePage.tsx
@@ -2,7 +2,7 @@ import { ContestCreateProvider, useContestCreate } from './ContestCreateContext'
 import ContestCreateProgress from './ContestCreateProgress';
 import ContestCreateForm from './ContestCreateForm';
 import CreateRequiredFields from './CreateRequiredFields';
-import ContestTeamInsert from './ContestTeamInsert';
+import ContestTeamSetting from '../team-setting/ContestTeamSetting';
 
 const ContestCreateContent = () => {
   const { contestId, currentStep, setCurrentStep } = useContestCreate();
@@ -12,7 +12,7 @@ const ContestCreateContent = () => {
       <ContestCreateProgress />
       <div className="border-t pt-8">
         {currentStep === 1 && <ContestCreateForm />}
-        {currentStep === 2 && <ContestTeamInsert contestId={contestId} handleSkip={() => setCurrentStep(3)} />}
+        {currentStep === 2 && <ContestTeamSetting contestId={contestId} handleSkip={() => setCurrentStep(3)} />}
         {currentStep === 3 && <CreateRequiredFields />}
       </div>
     </div>

--- a/src/pages/admin/create/ContestTeamInsert.tsx
+++ b/src/pages/admin/create/ContestTeamInsert.tsx
@@ -6,17 +6,20 @@ import { XLSX_MIME_TYPE } from '@constants/contest';
 import { AdminActionButton, AdminHeader } from '@components/admin';
 import { Dialog } from '@components/ui/dialog';
 import { cn } from 'utils/classname';
-import { useToast } from 'hooks/useToast';
 import { postBulkAddTeams } from 'apis/contest';
+import { useToast } from 'hooks/useToast';
 import { ContestBulkAddTeamsErrorDto } from 'types/DTO';
-import { useContestCreate } from './ContestCreateContext';
 import { TemplateErrorModal } from './TemplateErrorModal';
 
-const ContestTeamInsert = () => {
+interface ContestTeamInsertProps {
+  contestId: number;
+  handleSkip?: () => void;
+}
+
+const ContestTeamInsert = ({ contestId, handleSkip }: ContestTeamInsertProps) => {
   const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [templateErrors, setTemplateErrors] = useState<string[]>([]);
-  const { currentStepName, contestId, setCurrentStep } = useContestCreate();
   const inputRef = useRef<HTMLInputElement>(null);
   const toast = useToast();
 
@@ -75,8 +78,8 @@ const ContestTeamInsert = () => {
     if (inputRef.current) inputRef.current.value = '';
   };
 
-  const handleUpload = () => {
-    if (!file || !contestId) return;
+  const handleSetting = () => {
+    if (!file) return;
 
     const formData = new FormData();
     formData.append('file', file);
@@ -89,17 +92,16 @@ const ContestTeamInsert = () => {
       {
         onSuccess: (data) => {
           toast(`${data.teamCount}개의 팀 생성이 완료되었습니다.`, 'success');
-          setCurrentStep(3);
+          handleSkip?.();
         },
         onError: (error: any) => {
           if (error.response?.data?.message) toast(error.response.data.message, 'error');
           else if (error.response?.data?.errors) {
-            setTemplateErrors(
-              error.response.data.errors.map((e: ContestBulkAddTeamsErrorDto) => `${e.rowNumber}행 - ${e.message}`),
-            );
+            const errors = error.response.data.errors;
+            setTemplateErrors(errors.map((e: ContestBulkAddTeamsErrorDto) => `${e.rowNumber}행 - ${e.message}`));
             setFile(null);
             if (inputRef.current) inputRef.current.value = '';
-          } else toast(`${currentStepName}에 실패했습니다.`, 'error');
+          } else toast(`대회 팀·참여자 설정에 실패했습니다.`, 'error');
         },
       },
     );
@@ -107,7 +109,10 @@ const ContestTeamInsert = () => {
 
   return (
     <div className="flex flex-col gap-7">
-      <AdminHeader title={currentStepName} description="하단 엑셀 파일 양식에 참여 팀들을 기입 후 업로드 해주세요." />
+      <AdminHeader
+        title="대회 팀·참여자 설정"
+        description="하단 엑셀 파일 양식에 참여 팀들을 기입 후 업로드 해주세요."
+      />
       <a href="/팀등록_템플릿파일.xlsx" className="group flex items-center gap-1">
         <PiMicrosoftExcelLogo size={24} className="fill-mainGreen mt-0.75" />
         <span className="group-hover:text-mainGreen text-lg group-hover:underline">팀등록_템플릿파일.xlsx</span>
@@ -157,7 +162,12 @@ const ContestTeamInsert = () => {
       <Dialog open={templateErrors.length > 0} onOpenChange={(open) => !open && setTemplateErrors([])}>
         <TemplateErrorModal errors={templateErrors} />
       </Dialog>
-      <AdminActionButton size="lg" className="mx-auto rounded-full" disabled={!file} onClick={handleUpload}>
+      <AdminActionButton
+        size="lg"
+        className="mx-auto rounded-full"
+        disabled={!file || bulkAddTeams.isPending}
+        onClick={handleSetting}
+      >
         설정하기
       </AdminActionButton>
     </div>

--- a/src/pages/admin/create/ContestTeamInsert.tsx
+++ b/src/pages/admin/create/ContestTeamInsert.tsx
@@ -162,14 +162,21 @@ const ContestTeamInsert = ({ contestId, handleSkip }: ContestTeamInsertProps) =>
       <Dialog open={templateErrors.length > 0} onOpenChange={(open) => !open && setTemplateErrors([])}>
         <TemplateErrorModal errors={templateErrors} />
       </Dialog>
-      <AdminActionButton
-        size="lg"
-        className="mx-auto rounded-full"
-        disabled={!file || bulkAddTeams.isPending}
-        onClick={handleSetting}
-      >
-        설정하기
-      </AdminActionButton>
+      <div className="flex items-center justify-center gap-6">
+        {handleSkip && (
+          <AdminActionButton size="lg" className="rounded-full" variant="outline" onClick={handleSkip}>
+            나중에 설정하기
+          </AdminActionButton>
+        )}
+        <AdminActionButton
+          size="lg"
+          className="rounded-full"
+          disabled={!file || bulkAddTeams.isPending}
+          onClick={handleSetting}
+        >
+          설정하기
+        </AdminActionButton>
+      </div>
     </div>
   );
 };

--- a/src/pages/admin/create/CreateRequiredFields.tsx
+++ b/src/pages/admin/create/CreateRequiredFields.tsx
@@ -29,9 +29,14 @@ const CreateRequiredFields = () => {
           onToggle={handleToggleField}
         />
       </QueryWrapper>
-      <AdminActionButton size="lg" className="mx-auto rounded-full" disabled={isPending} onClick={handleButtonClick}>
-        설정하기
-      </AdminActionButton>
+      <div className="flex items-center justify-center gap-6">
+        <AdminActionButton size="lg" className="rounded-full" variant="outline" onClick={() => navigate('/admin')}>
+          나중에 설정하기
+        </AdminActionButton>
+        <AdminActionButton size="lg" className="rounded-full" disabled={isPending} onClick={handleButtonClick}>
+          설정하기
+        </AdminActionButton>
+      </div>
     </div>
   );
 };

--- a/src/pages/admin/create/CreateRequiredFields.tsx
+++ b/src/pages/admin/create/CreateRequiredFields.tsx
@@ -11,8 +11,7 @@ const CreateRequiredFields = () => {
   const navigate = useNavigate();
 
   const handleButtonClick = () => {
-    handleSave();
-    navigate('/admin');
+    handleSave(() => navigate('/admin'));
   };
 
   return (

--- a/src/pages/admin/required-field/RequiredFieldsPage.tsx
+++ b/src/pages/admin/required-field/RequiredFieldsPage.tsx
@@ -12,7 +12,7 @@ const RequiredFieldsPage: React.FC = () => {
   return (
     <div className="flex flex-col gap-8">
       <AdminHeader title="필수 항목 설정" description="프로젝트 생성/수정 폼의 필수 항목을 설정합니다.">
-        <AdminActionButton className="" disabled={isPending} onClick={handleSave}>
+        <AdminActionButton className="" disabled={isPending} onClick={() => handleSave()}>
           {isPending ? '저장 중...' : '저장'}
         </AdminActionButton>
       </AdminHeader>

--- a/src/pages/admin/team-setting/ContestTeamSetting.tsx
+++ b/src/pages/admin/team-setting/ContestTeamSetting.tsx
@@ -9,7 +9,7 @@ import { cn } from 'utils/classname';
 import { postBulkAddTeams } from 'apis/contest';
 import { useToast } from 'hooks/useToast';
 import { ContestBulkAddTeamsErrorDto } from 'types/DTO';
-import { TemplateErrorModal } from './TemplateErrorModal';
+import { TemplateErrorModal } from '../create/TemplateErrorModal';
 
 interface ContestTeamInsertProps {
   contestId: number;

--- a/src/pages/admin/team-setting/ContestTeamSetting.tsx
+++ b/src/pages/admin/team-setting/ContestTeamSetting.tsx
@@ -16,7 +16,7 @@ interface ContestTeamInsertProps {
   handleSkip?: () => void;
 }
 
-const ContestTeamInsert = ({ contestId, handleSkip }: ContestTeamInsertProps) => {
+const ContestTeamSetting = ({ contestId, handleSkip }: ContestTeamInsertProps) => {
   const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [templateErrors, setTemplateErrors] = useState<string[]>([]);
@@ -181,4 +181,4 @@ const ContestTeamInsert = ({ contestId, handleSkip }: ContestTeamInsertProps) =>
   );
 };
 
-export default ContestTeamInsert;
+export default ContestTeamSetting;

--- a/src/pages/admin/team-setting/ContestTeamSetting.tsx
+++ b/src/pages/admin/team-setting/ContestTeamSetting.tsx
@@ -101,7 +101,7 @@ const ContestTeamSetting = ({ contestId, handleSkip }: ContestTeamInsertProps) =
             setTemplateErrors(errors.map((e: ContestBulkAddTeamsErrorDto) => `${e.rowNumber}행 - ${e.message}`));
             setFile(null);
             if (inputRef.current) inputRef.current.value = '';
-          } else toast(`대회 팀·참여자 설정에 실패했습니다.`, 'error');
+          } else toast(`팀·참여자 설정에 실패했습니다.`, 'error');
         },
       },
     );
@@ -109,10 +109,7 @@ const ContestTeamSetting = ({ contestId, handleSkip }: ContestTeamInsertProps) =
 
   return (
     <div className="flex flex-col gap-7">
-      <AdminHeader
-        title="대회 팀·참여자 설정"
-        description="하단 엑셀 파일 양식에 참여 팀들을 기입 후 업로드 해주세요."
-      />
+      <AdminHeader title="팀·참여자 설정" description="하단 엑셀 파일 양식에 참여 팀들을 기입 후 업로드 해주세요." />
       <a href="/팀등록_템플릿파일.xlsx" className="group flex items-center gap-1">
         <PiMicrosoftExcelLogo size={24} className="fill-mainGreen mt-0.75" />
         <span className="group-hover:text-mainGreen text-lg group-hover:underline">팀등록_템플릿파일.xlsx</span>

--- a/src/pages/admin/team-setting/TeamSettingPage.tsx
+++ b/src/pages/admin/team-setting/TeamSettingPage.tsx
@@ -1,0 +1,10 @@
+import { useContestIdOrRedirect } from 'hooks/useId';
+import ContestTeamSetting from './ContestTeamSetting';
+
+const TeamSettingPage = () => {
+  const contestId = useContestIdOrRedirect();
+
+  return <ContestTeamSetting contestId={contestId} />;
+};
+
+export default TeamSettingPage;

--- a/src/route/AppRoutes.tsx
+++ b/src/route/AppRoutes.tsx
@@ -29,6 +29,7 @@ import NotFoundPage from '@pages/common/NotFoundPage';
 import VoteManagePage from '@pages/admin/votes/VoteManagePage';
 import ContestManagePage from '@pages/admin/contest-manage/ContestManagePage';
 import ContestStatisticsPage from '@pages/admin/statistics/ContestStatisticsPage';
+import TeamSettingPage from '@pages/admin/team-setting/TeamSettingPage';
 import MyPageLayout from '@layout/me/MyPageLayout';
 import ActivityPage from '@pages/me/activity/ActivityPage';
 import AccountPage from '@pages/me/account/AccountPage';
@@ -105,6 +106,7 @@ const AppRoutes = () =>
                 { path: 'required-fields', element: <RequiredFieldsPage /> },
                 // 대회
                 { path: 'manage', element: <ContestManagePage /> },
+                { path: 'team-setting', element: <TeamSettingPage /> },
                 { path: 'tracks', element: <TrackManagePage /> },
                 { path: 'votes', element: <VoteManagePage /> },
                 { path: 'notices', element: <NoticeManagePage /> },


### PR DESCRIPTION
### 📝 개요
어드민 대회 페이지 내 팀·참여자 설정 페이지 추가 및 대회 생성 2, 3단계에 나중에 설정하기 버튼 추가 (중도 이탈 처리)

### 🎯 목적
6차 QA 대상 중 UX 향상을 위한 대회 생성 중 중도 이탈 처리를 위함

### 팀·참여자 설정 관련 API 논의 결과
대회에 엑셀 파일로 팀 추가 API (`/contests/{contestId}/teams/bulk`) 담당자인 @pykido 님과 논의 결과,
어떤 팀이 대회에 프로젝트를 등록해서 이미 팀이랑 멤버가 존재하는 상태에서 엑셀 파일로 팀 추가 시 덮어쓰기 처리는 실패
➡️ 해당 행은 오류 처리나고, 오류 반환 타입의 경우 기존과 동일하기 때문에 프론트단 수정 필요 X
하지만 만약 추가하는 정보들(팀 이름, 팀멤버, 팀장, 학번, 이메일)이 완전 일치한다면 스킵 처리
➡️ 프론트단 수정 필요 X 

### ✨ 변경 사항
- 팀·참여자 설정 페이지 추가 (`/admin/contest/{contestId}/team-setting`)
- 대회 생성 2, 3단계에 나중에 설정하기 버튼 추가
- 대회 생성 3단계 - 필수 항목 설정에서 API 실패한 경우도 네비게이션한 버그 수정

### 📸 참고 이미지/영상

#### 어드민 대회 페이지에 추가된 팀·참여자 설정 페이지
<img width="1283" height="803" alt="image" src="https://github.com/user-attachments/assets/2e332cbe-ae29-484d-8160-ea423bc00f98" />

#### 대회 생성 2단계
<img width="1123" height="558" alt="image" src="https://github.com/user-attachments/assets/aa6c6716-5dca-48d5-944d-e0bb2de9a271" />

#### 대회 생성 3단계
<img width="1114" height="413" alt="image" src="https://github.com/user-attachments/assets/b75367b9-f073-4ff7-a01d-faeb765fc734" />
