### PR TITLE
fix: 모달 닫기 시 입력 값 초기화

### DIFF
--- a/src/pages/admin/CategoryModal.tsx
+++ b/src/pages/admin/CategoryModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FaRegEdit } from 'react-icons/fa';
 import Input from '@components/Input';
 import { useToast } from 'hooks/useToast';
-import { DialogClose, DialogContent, DialogTitle } from '@components/ui/dialog';
+import { DialogContent, DialogTitle } from '@components/ui/dialog';
 import { AdminActionButton, AdminDeleteConfirmModal } from '@components/admin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteCategory, patchCategory, postCategory } from 'apis/category';
@@ -28,6 +28,11 @@ export const CategoryModal = ({ type, prevData, closeModal }: CategoryModalProps
     mutationFn: ({ categoryId, categoryName }: Omit<CategoryDto, 'updatedAt'>) =>
       patchCategory(categoryId, categoryName),
   });
+
+  const handleClose = () => {
+    setCategoryName(prevData?.categoryName ?? '');
+    closeModal();
+  };
 
   const handleSubmit = async () => {
     if (!categoryName) {
@@ -77,11 +82,9 @@ export const CategoryModal = ({ type, prevData, closeModal }: CategoryModalProps
         className="bg-whiteGray h-12 rounded-lg"
       />
       <div className="flex justify-center gap-4">
-        <DialogClose asChild>
-          <AdminActionButton variant={'outline'} size={'lg'} className="rounded-full">
-            {'닫기'}
-          </AdminActionButton>
-        </DialogClose>
+        <AdminActionButton variant={'outline'} size={'lg'} className="rounded-full" onClick={handleClose}>
+          {'닫기'}
+        </AdminActionButton>
         <AdminActionButton size={'lg'} className="rounded-full" onClick={handleSubmit}>
           {`${type === 'create' ? '추가' : '수정'}하기`}
         </AdminActionButton>

--- a/src/pages/admin/NoticeModal.tsx
+++ b/src/pages/admin/NoticeModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { DialogClose, DialogContent, DialogTitle } from '@components/ui/dialog';
+import { DialogContent, DialogTitle } from '@components/ui/dialog';
 import Input from '@components/Input';
 import TextArea from '@components/TextArea';
 import { deleteNotice, patchNotice, postCreateNotice } from 'apis/notice';
@@ -39,6 +39,12 @@ export const NoticeModal = ({ type, noticeId, isOpen, closeModal }: NoticeModalP
       setDescription(notice.description || '');
     }
   }, [type, isOpen, notice]);
+
+  const handleClose = () => {
+    setTitle(notice?.title || '');
+    setDescription(notice?.description || '');
+    closeModal();
+  };
 
   const handleSave = async () => {
     await upsertMutation.mutateAsync(
@@ -81,11 +87,9 @@ export const NoticeModal = ({ type, noticeId, isOpen, closeModal }: NoticeModalP
         />
       </div>
       <div className="flex justify-end gap-4">
-        <DialogClose asChild>
-          <AdminActionButton variant={'outline'} size={'lg'} className="rounded-full">
-            닫기
-          </AdminActionButton>
-        </DialogClose>
+        <AdminActionButton variant={'outline'} size={'lg'} className="rounded-full" onClick={handleClose}>
+          닫기
+        </AdminActionButton>
         <AdminActionButton size={'lg'} className="rounded-full" onClick={handleSave}>
           {`${type === 'create' ? '추가' : '저장'}하기`}
         </AdminActionButton>

--- a/src/pages/admin/notice-manage/ContestNoticeModal.tsx
+++ b/src/pages/admin/notice-manage/ContestNoticeModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { DialogClose, DialogContent, DialogTitle } from '@components/ui/dialog';
+import { DialogContent, DialogTitle } from '@components/ui/dialog';
 import Input from '@components/Input';
 import RoundedButton from '@components/RoundedButton';
 import TextArea from '@components/TextArea';
@@ -41,6 +41,12 @@ export const ContestNoticeModal = ({ type, contestId, noticeId, isOpen, closeMod
       setDescription(notice.description || '');
     }
   }, [type, isOpen, notice]);
+
+  const handleClose = () => {
+    setTitle(notice?.title || '');
+    setDescription(notice?.description || '');
+    closeModal();
+  };
 
   const handleSave = async () => {
     await upsertMutation.mutateAsync(
@@ -83,9 +89,9 @@ export const ContestNoticeModal = ({ type, contestId, noticeId, isOpen, closeMod
         />
       </div>
       <div className="flex justify-end gap-4">
-        <DialogClose asChild>
-          <RoundedButton className="min-w-28">취소</RoundedButton>
-        </DialogClose>
+        <RoundedButton className="min-w-28" onClick={handleClose}>
+          취소
+        </RoundedButton>
         <RoundedButton className="min-w-28" onClick={handleSave}>
           {type === 'create' ? '추가' : '저장'}
         </RoundedButton>

--- a/src/pages/admin/notice-manage/ContestNoticeModal.tsx
+++ b/src/pages/admin/notice-manage/ContestNoticeModal.tsx
@@ -2,12 +2,11 @@ import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DialogContent, DialogTitle } from '@components/ui/dialog';
 import Input from '@components/Input';
-import RoundedButton from '@components/RoundedButton';
 import TextArea from '@components/TextArea';
 import { createContestNotice, deleteContestNotice, updateContestNotice } from 'apis/notice';
 import { useToast } from 'hooks/useToast';
 import { NoticeRequestDto } from 'types/DTO/noticeDto';
-import { AdminDeleteConfirmModal } from '@components/admin';
+import { AdminActionButton, AdminDeleteConfirmModal } from '@components/admin';
 import { contestNoticeDetailOption } from 'queries/notices';
 
 interface ContestNoticeModalProps {
@@ -89,12 +88,12 @@ export const ContestNoticeModal = ({ type, contestId, noticeId, isOpen, closeMod
         />
       </div>
       <div className="flex justify-end gap-4">
-        <RoundedButton className="min-w-28" onClick={handleClose}>
+        <AdminActionButton variant={'outline'} size={'lg'} className="rounded-full" onClick={handleClose}>
           취소
-        </RoundedButton>
-        <RoundedButton className="min-w-28" onClick={handleSave}>
+        </AdminActionButton>
+        <AdminActionButton size={'lg'} className="rounded-full" onClick={handleSave}>
           {type === 'create' ? '추가' : '저장'}
-        </RoundedButton>
+        </AdminActionButton>
       </div>
     </DialogContent>
   );

--- a/src/pages/admin/track-manage/TrackManagePage.tsx
+++ b/src/pages/admin/track-manage/TrackManagePage.tsx
@@ -76,7 +76,7 @@ const TrackManagePage = () => {
         <DialogTrigger asChild>
           <AdminHeader title="분과 관리" onButtonClick={() => setCreateOpen(true)} buttonLabel="+ 새 분과" />
         </DialogTrigger>
-        <TrackModal type="create" onSubmit={handleCreateTrack} />
+        <TrackModal type="create" onSubmit={handleCreateTrack} onClose={() => setCreateOpen(false)} />
       </Dialog>
       <div className="h-[35px]" />
       <div className="flex flex-col gap-2">
@@ -121,6 +121,7 @@ const TrackManagePage = () => {
               handleEditTrack(editTarget.id, trackName);
               setEditTarget(null);
             }}
+            onClose={() => setEditTarget(null)}
           />
         )}
       </Dialog>

--- a/src/pages/admin/track-manage/TrackModal.tsx
+++ b/src/pages/admin/track-manage/TrackModal.tsx
@@ -4,6 +4,7 @@ import Button from '@components/Button';
 import Input from '@components/Input';
 import { useToast } from 'hooks/useToast';
 import { DialogClose, DialogContent, DialogTitle } from '@components/ui/dialog';
+import { AdminActionButton } from '@components/admin';
 
 interface TrackModalProps {
   type: 'create' | 'edit';
@@ -43,16 +44,13 @@ export const TrackModal = ({ type, prevName, onSubmit, onClose }: TrackModalProp
         className="bg-whiteGray h-12 rounded-lg"
       />
       <div className="flex justify-center gap-4">
-        <Button
-          className="border-lightGray text-midGray rounded-full border px-5 py-3 hover:bg-gray-100"
-          onClick={handleClose}
-        >
+        <AdminActionButton variant={'outline'} size={'lg'} className="rounded-full" onClick={handleClose}>
           {'닫기'}
-        </Button>
+        </AdminActionButton>
         <DialogClose asChild>
-          <Button className="bg-mainBlue rounded-full px-5 py-3 hover:bg-blue-500" onClick={handleSubmit}>
+          <AdminActionButton size={'lg'} className="rounded-full" onClick={handleSubmit}>
             {`${type === 'create' ? '추가' : '수정'}하기`}
-          </Button>
+          </AdminActionButton>
         </DialogClose>
       </div>
     </DialogContent>

--- a/src/pages/admin/track-manage/TrackModal.tsx
+++ b/src/pages/admin/track-manage/TrackModal.tsx
@@ -3,17 +3,23 @@ import { FaRegEdit } from 'react-icons/fa';
 import Button from '@components/Button';
 import Input from '@components/Input';
 import { useToast } from 'hooks/useToast';
-import { DialogClose, DialogContent } from '@components/ui/dialog';
+import { DialogClose, DialogContent, DialogTitle } from '@components/ui/dialog';
 
 interface TrackModalProps {
   type: 'create' | 'edit';
   prevName?: string;
   onSubmit: (trackName: string) => void;
+  onClose: () => void;
 }
 
-export const TrackModal = ({ type, prevName, onSubmit }: TrackModalProps) => {
+export const TrackModal = ({ type, prevName, onSubmit, onClose }: TrackModalProps) => {
   const [trackName, setTrackName] = useState<string>(prevName ?? '');
   const toast = useToast();
+
+  const handleClose = () => {
+    setTrackName(prevName ?? '');
+    onClose();
+  };
 
   const handleSubmit = () => {
     if (!trackName) {
@@ -28,7 +34,7 @@ export const TrackModal = ({ type, prevName, onSubmit }: TrackModalProps) => {
       <div className="text-mainBlue mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
         <FaRegEdit size={20} />
       </div>
-      <h3 className="text-center text-lg font-semibold text-gray-800">{`${type === 'create' ? '추가' : '수정'}할 분과 이름을 입력하세요.`}</h3>
+      <DialogTitle className="text-center text-lg font-semibold text-gray-800">{`${type === 'create' ? '추가' : '수정'}할 분과 이름을 입력하세요.`}</DialogTitle>
       <Input
         type="text"
         value={trackName}
@@ -37,11 +43,12 @@ export const TrackModal = ({ type, prevName, onSubmit }: TrackModalProps) => {
         className="bg-whiteGray h-12 rounded-lg"
       />
       <div className="flex justify-center gap-4">
-        <DialogClose asChild>
-          <Button className="border-lightGray text-midGray rounded-full border px-5 py-3 hover:bg-gray-100">
-            {'닫기'}
-          </Button>
-        </DialogClose>
+        <Button
+          className="border-lightGray text-midGray rounded-full border px-5 py-3 hover:bg-gray-100"
+          onClick={handleClose}
+        >
+          {'닫기'}
+        </Button>
         <DialogClose asChild>
           <Button className="bg-mainBlue rounded-full px-5 py-3 hover:bg-blue-500" onClick={handleSubmit}>
             {`${type === 'create' ? '추가' : '수정'}하기`}


### PR DESCRIPTION
### 📝 개요
모달을 닫을 때 입력 값이 초기화 되지 않는 문제 수정

### ✨ 변경 사항
- 대상 모달 - 카테고리, 전체 공지사항, 대회별 공지사항, 분과
- DialogClose로 닫는 부분을 버튼 onClick 핸들러에 State 초기화 후 닫는 함수로 변경
- 전체 공지사항 및 카테고리 모델 Admin 공통 버튼으로 변경