### PR TITLE
refactor : 좋아요/투표 토글 API PUT/DELETE 분리 대응

### DIFF
--- a/src/apis/projectViewer.ts
+++ b/src/apis/projectViewer.ts
@@ -3,13 +3,12 @@ import axios from 'axios';
 import apiClient from './apiClient';
 import {
   PreviewImagesResponseDto,
-  LikeUpdateRequestDto,
   CommentCreateRequestDto,
   CommentDeleteRequestDto,
   CommentEditRequestDto,
   CommentDto,
   PreviewResult,
-  LikeUpdateResponseDto,
+  TeamVoteResponseDto,
 } from '@dto/projectViewerDto';
 import { TeamDetailDto } from '@dto/teams/teamsDto';
 
@@ -64,14 +63,21 @@ export const getPreviewImages = async (teamId: number, imageIds: number[]): Prom
   return { imageResults };
 };
 
-export const putLikeToggle = async (request: LikeUpdateRequestDto): Promise<LikeUpdateResponseDto> => {
-  const { teamId, isLiked } = request;
-  const response = await apiClient.put(`/teams/${teamId}/likes`, { isLiked });
+export const addLike = async (teamId: number): Promise<void> => {
+  await apiClient.put(`/teams/${teamId}/likes`);
+};
+
+export const removeLike = async (teamId: number): Promise<void> => {
+  await apiClient.delete(`/teams/${teamId}/likes`);
+};
+
+export const addVote = async (teamId: number): Promise<TeamVoteResponseDto> => {
+  const response = await apiClient.put(`/teams/${teamId}/votes`);
   return response.data;
 };
 
-export const putVoteToggle = async (teamId: number, isVoted: boolean) => {
-  const response = await apiClient.put(`/teams/${teamId}/votes`, { isVoted });
+export const removeVote = async (teamId: number): Promise<TeamVoteResponseDto> => {
+  const response = await apiClient.delete(`/teams/${teamId}/votes`);
   return response.data;
 };
 

--- a/src/mocks/handlers/teams.ts
+++ b/src/mocks/handlers/teams.ts
@@ -2,8 +2,22 @@ import { mockTeamDetail } from '@mocks/data/teams';
 import { API_BASE_URL } from '@constants/env';
 import { http, HttpResponse } from 'msw';
 
+const mockVoteResponse = { remainingVotesCount: 1, maxVotesLimit: 2 };
+
 export const teamsHandlers = [
   http.get(`${API_BASE_URL}/api/teams/:teamId`, () => {
     return HttpResponse.json(mockTeamDetail);
+  }),
+  http.put(`${API_BASE_URL}/api/teams/:teamId/likes`, () => {
+    return new HttpResponse(null, { status: 200 });
+  }),
+  http.delete(`${API_BASE_URL}/api/teams/:teamId/likes`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.put(`${API_BASE_URL}/api/teams/:teamId/votes`, () => {
+    return HttpResponse.json(mockVoteResponse);
+  }),
+  http.delete(`${API_BASE_URL}/api/teams/:teamId/votes`, () => {
+    return HttpResponse.json(mockVoteResponse);
   }),
 ];

--- a/src/pages/project-viewer/LikeSection.tsx
+++ b/src/pages/project-viewer/LikeSection.tsx
@@ -5,7 +5,7 @@ import { FaHeart } from 'react-icons/fa';
 import { MdHowToVote } from 'react-icons/md';
 
 import { getMyContestVoteStatus } from '@apis/vote';
-import { putLikeToggle, putVoteToggle } from '@apis/projectViewer';
+import { addLike, removeLike, addVote, removeVote } from '@apis/projectViewer';
 import Backdrop from '@components/Backdrop';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ToolTip';
 import useAuth from '@hooks/useAuth';
@@ -67,7 +67,7 @@ const LikeSection = ({ contestId, teamId, isLiked, isVoted }: LikeSectionProps) 
   }, [myContestVoteStatus]);
 
   const likeMutation = useMutation({
-    mutationFn: (nextIsLiked: boolean) => putLikeToggle({ teamId, isLiked: nextIsLiked }),
+    mutationFn: (nextIsLiked: boolean) => (nextIsLiked ? addLike(teamId) : removeLike(teamId)),
     onSuccess: (_, nextIsLiked) => {
       invalidateVoteLikeQueries();
       toast(nextIsLiked ? '좋아요를 눌렀어요' : '좋아요를 취소했어요');
@@ -78,14 +78,11 @@ const LikeSection = ({ contestId, teamId, isLiked, isVoted }: LikeSectionProps) 
   });
 
   const voteMutation = useMutation({
-    mutationFn: (nextIsVoted: boolean) => putVoteToggle(teamId, nextIsVoted),
-    onSuccess: (_, nextIsVoted) => {
+    mutationFn: (nextIsVoted: boolean) => (nextIsVoted ? addVote(teamId) : removeVote(teamId)),
+    onSuccess: (data, nextIsVoted) => {
       invalidateVoteLikeQueries();
       toast(nextIsVoted ? '투표를 완료했어요' : '투표를 취소했어요');
-
-      if (remainingVotesCount !== null && maxVotesLimit !== null) {
-        showVoteTooltip(remainingVotesCount + (nextIsVoted ? -1 : 1), maxVotesLimit);
-      }
+      showVoteTooltip(data.remainingVotesCount, data.maxVotesLimit);
     },
     onError: (err: any) => {
       toast(err.response?.data?.message ?? '요청에 실패했어요.', 'error');

--- a/src/types/DTO/projectViewerDto.ts
+++ b/src/types/DTO/projectViewerDto.ts
@@ -65,16 +65,9 @@ export interface CommentEditResponseDto {
   description: string;
 }
 
-export interface LikeUpdateRequestDto {
-  teamId: number;
-  isLiked: boolean;
-}
-export interface LikeUpdateResponseDto {
-  teamId: number;
-  isLiked: boolean;
-  message: string;
-  remainingLikeCount: number;
-  maxLikeCount: number;
+export interface TeamVoteResponseDto {
+  remainingVotesCount: number;
+  maxVotesLimit: number;
 }
 
 export interface PreviewImage {


### PR DESCRIPTION
## 📝 개요

백엔드 좋아요/투표 토글 API가 단일 `PUT`(body로 상태 전달) → `PUT`(등록) / `DELETE`(취소) 분리 명세로 변경됨에 따라, 프론트엔드 API 클라이언트·DTO·호출부·MSW mock을 새 명세에 맞게 리팩토링하였습니다.

연관 백엔드 PR: PNUops/opus-backend#136

## 🎯 목적

* 변경된 백엔드 토글 API 명세(PUT/DELETE 분리, body 제거)에 프론트엔드 호출 방식 동기화
* 백엔드의 멱등 NO-OP 동작에 맞춰 "이미 좋아요/투표한 상태"에 대한 클라이언트 측 추가 분기 제거
* 사용처가 사라진 토글 요청/응답 DTO 정리 및 신규 응답 DTO 도입

## ✨ 변경 사항

**API 클라이언트 (`src/apis/projectViewer.ts`)**

* 단일 토글 함수 `putLikeToggle`, `putVoteToggle` 제거
* `addLike(teamId)`, `removeLike(teamId)`, `addVote(teamId)`, `removeVote(teamId)` 4개 함수로 분리 (모두 request body 없음)
* 좋아요 함수는 `Promise<void>`, 투표 함수는 `Promise<TeamVoteResponseDto>` 반환

**DTO (`src/types/DTO/projectViewerDto.ts`)**

* 사용처가 사라진 `LikeUpdateRequestDto`, `LikeUpdateResponseDto` 제거 (기존에 백엔드 응답과 mismatch였던 `remainingLikeCount`, `maxLikeCount` 필드도 함께 정리)
* 신규 응답 타입 `TeamVoteResponseDto { remainingVotesCount, maxVotesLimit }` 추가

**컴포넌트 (`src/pages/project-viewer/LikeSection.tsx`)**

* `likeMutation` / `voteMutation`의 `mutationFn`을 의도(등록/취소)에 따라 새 함수로 분기 호출하도록 수정
* 투표 후 남은 투표권을 클라이언트에서 추정 계산하던 로직 제거 → 서버 응답값(`remainingVotesCount`, `maxVotesLimit`)을 그대로 툴팁에 표시

**Mock handler (`src/mocks/handlers/teams.ts`)**

* `PUT /teams/:teamId/likes` (200, no body), `DELETE /teams/:teamId/likes` (204) 추가
* `PUT /teams/:teamId/votes` (200 + body), `DELETE /teams/:teamId/votes` (200 + body) 추가
