### PR TITLE
feat: 대회 페이지 상단 배너 이미지 추가

### DIFF
--- a/src/pages/contest/ContestPage.tsx
+++ b/src/pages/contest/ContestPage.tsx
@@ -6,15 +6,29 @@ import QueryWrapper from '@providers/QueryWrapper';
 import ContestNoticeList from './ContestNoticeList';
 import TeamCardGrid from '@pages/contest/TeamCardGrid';
 import { contestTeamOption } from '@queries/contest';
+import { API_BASE_URL } from '@constants/env';
+import { useState } from 'react';
 
 const ContestPage = () => {
   const contestId = useContestIdOrRedirect();
   const contestName = useContestName();
+  const [bannerVisible, setBannerVisible] = useState<boolean>(true);
+
   const { data: teams, isLoading, isError } = useQuery(contestTeamOption(contestId));
 
   return (
     <div className="flex flex-col gap-8">
-      <h3 className="lg:text-title text-2xl font-bold">{contestName ?? ''}</h3>
+      <div className="flex flex-col gap-3">
+        <h3 className="lg:text-title text-2xl font-bold">{contestName ?? ''}</h3>
+        {bannerVisible && (
+          <img
+            src={`${API_BASE_URL}/api/contests/${contestId}/image/banner`}
+            alt={contestName}
+            className="border-lightGray max-h-50 rounded-sm shadow-sm"
+            onError={() => setBannerVisible(false)}
+          />
+        )}
+      </div>
       <QueryWrapper loadingFallback={<NoticeListSkeleton />} errorStyle="h-36 rounded-xl shadow-md">
         <ContestNoticeList />
       </QueryWrapper>


### PR DESCRIPTION
### 📝 개요
7차 QA 사항 중 대회 페이지에 대회의 배너가 누락되어 있어 추가 필요

### ✨ 변경 사항
- 대회 페이지 최상단에 배너 이미지 출력을 추가
- 배너 이미지 없는 경우 영역 노출 X

### 📸 참고 이미지/영상
<img width="1264" height="735" alt="image" src="https://github.com/user-attachments/assets/68519cd2-656a-4a08-9ab2-3d133d20f924" />

