### PR TITLE
fix: 7차 QA 메인 페이지 수정 사항 반영

### DIFF
--- a/src/pages/main/CurrentContestSection.tsx
+++ b/src/pages/main/CurrentContestSection.tsx
@@ -24,17 +24,17 @@ const CurrentContestSection = () => {
             onError={(e) => (e.currentTarget.src = defaultBanner)}
           />
           <div className="absolute inset-0 z-10 bg-gradient-to-t from-black/90 via-black/50 to-transparent" />
-          <div className="relative z-20 flex w-full justify-between px-8 py-8 text-white sm:px-12 sm:py-10">
+          <div className="relative z-20 flex h-full w-full items-center justify-between px-8 py-8 text-white sm:px-12 sm:py-10">
             <div className="flex flex-col gap-2.5">
               <div className="flex items-center gap-2">
                 <span className="rounded-full bg-white/90 px-4 py-1.5 text-sm font-semibold text-gray-900">
                   {contest.categoryName}
                 </span>
               </div>
-              <h2 className="text-2xl leading-tight font-bold sm:text-4xl">{contest.contestName}</h2>
-              <div className="flex items-center gap-2 text-base sm:text-lg">
+              <h2 className="text-xl leading-tight font-bold sm:text-4xl">{contest.contestName}</h2>
+              <div className="flex items-center gap-2 text-sm sm:text-lg">
                 <FaCalendarAlt className="text-lg" />
-                <span>{`${dayjs(contest.voteStartAt).format('MM월 DD일')} ~ ${dayjs(contest.voteEndAt).format('MM월 DD일')}`}</span>
+                <span>{`${dayjs(contest.voteStartAt).format('YYYY년 MM월 DD일')} ~ ${dayjs(contest.voteEndAt).format('YYYY년 MM월 DD일')}`}</span>
               </div>
             </div>
             <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/20 backdrop-blur-sm transition-all duration-300 group-hover:bg-white group-hover:text-black sm:h-16 sm:w-16">

--- a/src/pages/main/StatisticsSection.tsx
+++ b/src/pages/main/StatisticsSection.tsx
@@ -8,7 +8,7 @@ const StatisticsSection = () => {
   });
 
   return (
-    <section className="flex flex-col gap-10 rounded-2xl p-12.5 shadow-lg">
+    <section className="flex flex-col gap-10 rounded-2xl p-8 shadow-lg md:p-12.5">
       <div className="text-center text-xl font-semibold">
         부산대학교 SW 프로젝트 관리 시스템은 이렇게 성장하고 있어요 🚀
       </div>
@@ -18,6 +18,8 @@ const StatisticsSection = () => {
         <StatItem label="프로젝트 등록 수" value={data.totalProjects} />
         <Divider />
         <StatItem label="총 좋아요 수" value={data.totalLikes} />
+        <Divider />
+        <StatItem label="총 가입자 수" value={0} />
       </div>
     </section>
   );

--- a/src/pages/main/StatisticsSection.tsx
+++ b/src/pages/main/StatisticsSection.tsx
@@ -13,7 +13,7 @@ const StatisticsSection = () => {
         부산대학교 SW 프로젝트 관리 시스템은 이렇게 성장하고 있어요 🚀
       </div>
       <div className="flex w-full flex-col justify-around gap-8 sm:flex-row sm:gap-0">
-        <StatItem label="진행된 대회 수" value={data.totalContests} />
+        <StatItem label="전체 대회 수" value={data.totalContests} />
         <Divider />
         <StatItem label="프로젝트 등록 수" value={data.totalProjects} />
         <Divider />

--- a/src/pages/main/StatisticsSection.tsx
+++ b/src/pages/main/StatisticsSection.tsx
@@ -19,7 +19,7 @@ const StatisticsSection = () => {
         <Divider />
         <StatItem label="총 좋아요 수" value={data.totalLikes} />
         <Divider />
-        <StatItem label="총 가입자 수" value={0} />
+        <StatItem label="총 가입자 수" value={data.totalMembers} />
       </div>
     </section>
   );

--- a/src/pages/main/StatisticsSection.tsx
+++ b/src/pages/main/StatisticsSection.tsx
@@ -13,13 +13,13 @@ const StatisticsSection = () => {
         부산대학교 SW 프로젝트 관리 시스템은 이렇게 성장하고 있어요 🚀
       </div>
       <div className="flex w-full flex-col justify-around gap-8 sm:flex-row sm:gap-0">
-        <StatItem label="전체 대회 수" value={data.totalContests} />
+        <StatItem label="전체 대회 수" value={`${data.totalContests}개`} />
         <Divider />
-        <StatItem label="프로젝트 등록 수" value={data.totalProjects} />
+        <StatItem label="프로젝트 등록 수" value={`${data.totalProjects}개`} />
         <Divider />
-        <StatItem label="총 좋아요 수" value={data.totalLikes} />
+        <StatItem label="총 좋아요 수" value={`${data.totalLikes}개`} />
         <Divider />
-        <StatItem label="총 가입자 수" value={data.totalMembers} />
+        <StatItem label="총 가입자 수" value={`${data.totalMembers}명`} />
       </div>
     </section>
   );
@@ -27,9 +27,9 @@ const StatisticsSection = () => {
 
 export default StatisticsSection;
 
-const StatItem = ({ label, value }: { label: string; value: number }) => (
+const StatItem = ({ label, value }: { label: string; value: string }) => (
   <div className="bg--color-subGreen flex flex-1 flex-col items-center justify-center gap-2 text-center">
-    <span className="text-2xl font-bold sm:text-3xl">{`${value.toLocaleString()}개`}</span>
+    <span className="text-2xl font-bold sm:text-3xl">{`${value.toLocaleString()}`}</span>
     <span className="text-midGray text-sm font-medium">{label}</span>
   </div>
 );

--- a/src/types/DTO/statisticsDto.ts
+++ b/src/types/DTO/statisticsDto.ts
@@ -1,4 +1,5 @@
 export interface MainStatsDto {
+  totalMembers: number;
   totalProjects: number;
   totalLikes: number;
   totalContests: number;


### PR DESCRIPTION
### 📝 개요
7차 QA 사항 중 메인 페이지 관련 수정 사항을 반영하는 작업

### ✨ 변경 사항
- 진행중인 대회 날짜 표기에 연도 추가
- 통계 영역에 총 가입자 수 항목 추가

### 📸 참고 이미지/영상 (선택)
<img width="954" height="894" alt="image" src="https://github.com/user-attachments/assets/ee8a042c-436d-406a-9148-d3d5c3495c5c" />
