### PR TITLE
feat : develop 브랜치 대상 PR 빌드 체크

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Develop PR Build
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  develop-pr-build:
+    name: develop-pr-build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/src/mocks/data/statistics.ts
+++ b/src/mocks/data/statistics.ts
@@ -2,6 +2,7 @@ import { MainStatsDto, VoteLogItemDto, VoteRankingDto, VoteStatsDto } from '@dto
 import { PaginationResponseDto } from '@dto/commonDto';
 
 export const mockMainStats: MainStatsDto = {
+  totalMembers: 3200,
   totalProjects: 1250,
   totalLikes: 45800,
   totalContests: 42,


### PR DESCRIPTION
### 📝 개요
develop 브랜치 대상 PR에서 `npm run build`를 자동 실행하는 GitHub Actions workflow를 추가하였습니다.

### 🎯 목적
develop 브랜치 머지 전 빌드 검증을 자동화하여, 빌드 오류가 있는 코드의 머지를 방지하기 위함

### ✨ 변경 사항
- develop PR용 build workflow 추가
- `npm ci` 후 `npm run build` 실행
- `MainStatsDto` 타입에 맞게 mock 데이터 필드 보완