### PR TITLE
feat: 지도교수·멘토 활동 페이지 구현

### DIFF
--- a/src/apis/advisor.ts
+++ b/src/apis/advisor.ts
@@ -1,0 +1,94 @@
+import axios, { type AxiosResponse } from 'axios';
+
+import type {
+  AdvisorFeedbackDto,
+  GetAdvisorProjectsResponseDto,
+  GetAdvisorTeamSubmissionsResponseDto,
+  PutAdvisorFeedbackRequestDto,
+} from '@dto/advisorDto';
+
+import apiClient from './apiClient';
+
+const createAdvisorFeedbackFormData = ({
+  description,
+  files = [],
+  removeFileIds = [],
+}: PutAdvisorFeedbackRequestDto) => {
+  const formData = new FormData();
+  formData.append('description', description);
+  files.forEach((file) => formData.append('files', file));
+  removeFileIds.forEach((fileId) => formData.append('removeFileIds', String(fileId)));
+  return formData;
+};
+
+export const getAdvisorProjects = async (contestId: number): Promise<GetAdvisorProjectsResponseDto> => {
+  const res = await apiClient.get<GetAdvisorProjectsResponseDto>(`/contests/${contestId}/mentor/projects`);
+  return res.data;
+};
+
+export const getAdvisorTeamSubmissions = async (
+  contestId: number,
+  teamId: number,
+): Promise<GetAdvisorTeamSubmissionsResponseDto> => {
+  const res = await apiClient.get<GetAdvisorTeamSubmissionsResponseDto>(
+    `/contests/${contestId}/teams/${teamId}/submissions`,
+  );
+  return res.data;
+};
+
+export const getMyAdvisorFeedback = async (
+  contestId: number,
+  submissionId: number,
+): Promise<AdvisorFeedbackDto | null> => {
+  try {
+    const res = await apiClient.get<AdvisorFeedbackDto>(
+      `/contests/${contestId}/submissions/${submissionId}/feedbacks/me`,
+    );
+    return res.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+
+    throw error;
+  }
+};
+
+export const putAdvisorFeedback = async (
+  contestId: number,
+  submissionId: number,
+  payload: PutAdvisorFeedbackRequestDto,
+) => {
+  const res = await apiClient.put(
+    `/contests/${contestId}/submissions/${submissionId}/feedbacks`,
+    createAdvisorFeedbackFormData(payload),
+    {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    },
+  );
+  return res.data;
+};
+
+export const getAdvisorSubmissionFile = async (
+  contestId: number,
+  submissionId: number,
+  fileId: number,
+): Promise<AxiosResponse<Blob>> => {
+  return apiClient.get<Blob>(`/contests/${contestId}/submissions/${submissionId}/files/${fileId}`, {
+    responseType: 'blob',
+  });
+};
+
+export const getAdvisorFeedbackFile = async (
+  contestId: number,
+  submissionId: number,
+  feedbackId: number,
+  fileId: number,
+): Promise<AxiosResponse<Blob>> => {
+  return apiClient.get<Blob>(
+    `/contests/${contestId}/submissions/${submissionId}/feedbacks/${feedbackId}/files/${fileId}`,
+    {
+      responseType: 'blob',
+    },
+  );
+};

--- a/src/constants/myPageSidebarData.ts
+++ b/src/constants/myPageSidebarData.ts
@@ -1,6 +1,10 @@
 import type { MyProjectDto } from '@dto/meDto';
 import type { LayoutSidebarSection } from '@layout/common/LayoutSideBar';
 
+interface CreateMyPageSidebarDataOptions {
+  showAdvisorActivity?: boolean;
+}
+
 const myPageSidebarData: LayoutSidebarSection[] = [
   {
     title: '',
@@ -16,38 +20,53 @@ const myPageSidebarData: LayoutSidebarSection[] = [
   },
 ];
 
-export const createMyPageSidebarData = (projects: MyProjectDto[]): LayoutSidebarSection[] => [
-  {
-    title: '',
-    links: [
-      {
-        to: 'activity',
-        label: '나의 활동',
-        icon: 'activity',
-        activePaths: ['/me/activity', '/me/contests'],
-        links: projects.map(({ contestId, projectName, teamId, teamName }) => ({
-          key: `team-${contestId}-${teamId}`,
-          label: projectName || teamName,
-          links: [
-            {
-              to: `contests/${contestId}/teams/${teamId}/dashboard`,
-              label: '대시보드',
-            },
-            {
-              to: `contests/${contestId}/teams/${teamId}/submissions`,
-              label: '제출물',
-            },
-            {
-              to: `/contest/${contestId}/teams/view/${teamId}`,
-              label: '프로젝트 상세',
-            },
-          ],
-        })),
-      },
-      { to: 'account', label: '계정 정보', icon: 'account' },
-    ],
-  },
-];
+export const createMyPageSidebarData = (
+  projects: MyProjectDto[],
+  options: CreateMyPageSidebarDataOptions = {},
+): LayoutSidebarSection[] => {
+  const activityLinks: LayoutSidebarSection['links'] = [
+    {
+      to: 'activity',
+      label: '나의 활동',
+      icon: 'activity',
+      activePaths: ['/me/activity', '/me/contests'],
+      links: projects.map(({ contestId, projectName, teamId, teamName }) => ({
+        key: `team-${contestId}-${teamId}`,
+        label: projectName || teamName,
+        links: [
+          {
+            to: `contests/${contestId}/teams/${teamId}/dashboard`,
+            label: '대시보드',
+          },
+          {
+            to: `contests/${contestId}/teams/${teamId}/submissions`,
+            label: '제출물',
+          },
+          {
+            to: `/contest/${contestId}/teams/view/${teamId}`,
+            label: '프로젝트 상세',
+          },
+        ],
+      })),
+    },
+  ];
+
+  if (options.showAdvisorActivity) {
+    activityLinks.push({
+      to: 'advisor-activity',
+      label: '지도 활동',
+      icon: 'advisorActivity',
+      activePaths: ['/me/advisor-activity'],
+    });
+  }
+
+  return [
+    {
+      title: '',
+      links: [...activityLinks, { to: 'account', label: '계정 정보', icon: 'account' }],
+    },
+  ];
+};
 
 export const createMyTeamSidebarData = (projects: MyProjectDto[]): LayoutSidebarSection[] =>
   projects.length === 0 ? [] : createMyPageSidebarData(projects);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -11,6 +11,9 @@ const useAuth = () => {
   const isLeader = isSignedIn && user?.roles?.includes('ROLE_팀장');
   const isMember = isSignedIn && user?.roles?.includes('ROLE_팀원');
   const isAdmin = isSignedIn && user?.roles?.includes('ROLE_관리자');
+  const isProfessor = isSignedIn && user?.roles?.includes('ROLE_교수');
+  const isExternalMentor = isSignedIn && user?.roles?.includes('ROLE_외부멘토');
+  const isAdvisor = isProfessor || isExternalMentor;
 
   const signOut = useCallback(() => {
     clearToken();
@@ -35,6 +38,9 @@ const useAuth = () => {
     isLeader,
     isMember,
     isAdmin,
+    isProfessor,
+    isExternalMentor,
+    isAdvisor,
     user,
     signIn,
     signOut,

--- a/src/layout/common/LayoutSideBar.tsx
+++ b/src/layout/common/LayoutSideBar.tsx
@@ -1,8 +1,9 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import { Activity, CircleUserRound } from 'lucide-react';
+import { PiChalkboardTeacher } from 'react-icons/pi';
 import { cn } from '@utils/classname';
 
-type LayoutSidebarIcon = 'activity' | 'account';
+type LayoutSidebarIcon = 'activity' | 'advisorActivity' | 'account';
 
 export interface LayoutSidebarLink {
   key?: string;
@@ -58,6 +59,10 @@ const LayoutSideBar = ({ sections }: LayoutSideBarProps) => {
 
     if (icon === 'account') {
       return <CircleUserRound size={20} className="shrink-0" />;
+    }
+
+    if (icon === 'advisorActivity') {
+      return <PiChalkboardTeacher size={20} className="shrink-0" />;
     }
 
     return null;

--- a/src/layout/me/MyPageLayout.tsx
+++ b/src/layout/me/MyPageLayout.tsx
@@ -9,7 +9,7 @@ import { getMyProjects } from '@apis/me';
 import { MY_PROJECTS_QUERY_KEY } from '@queries/me';
 
 const MyPageLayout = () => {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, isAdvisor } = useAuth();
   const { data: fetchedMyProjects } = useQuery({
     queryKey: MY_PROJECTS_QUERY_KEY,
     queryFn: getMyProjects,
@@ -17,7 +17,10 @@ const MyPageLayout = () => {
     staleTime: 5 * 60 * 1000,
   });
   const myProjects = useMemo(() => fetchedMyProjects ?? [], [fetchedMyProjects]);
-  const sidebarSections = useMemo(() => createMyPageSidebarData(myProjects), [myProjects]);
+  const sidebarSections = useMemo(
+    () => createMyPageSidebarData(myProjects, { showAdvisorActivity: isAdvisor }),
+    [isAdvisor, myProjects],
+  );
 
   if (!isSignedIn) {
     return (

--- a/src/pages/me/advisor-activity/AdvisorActivityPage.tsx
+++ b/src/pages/me/advisor-activity/AdvisorActivityPage.tsx
@@ -1,0 +1,438 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { RefreshCw } from 'lucide-react';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+import { getAdvisorFeedbackFile, getAdvisorSubmissionFile, putAdvisorFeedback } from '@apis/advisor';
+import useAuth from '@hooks/useAuth';
+import { useToast } from '@hooks/useToast';
+import {
+  advisorFeedbackOption,
+  advisorProjectsOption,
+  advisorTeamSubmissionsOption,
+  invalidateAdvisorActivityQueries,
+} from '@queries/advisor';
+import { currentContestOption } from '@queries/contest';
+import { downloadBlob } from '@utils/download';
+
+import { AdvisorContestSummary } from './components/AdvisorContestSummary';
+import { AdvisorProjectList } from './components/AdvisorProjectList';
+import type { AdvisorActivityContest, AdvisorProject, AdvisorSubmissionFile } from './types';
+
+const MAX_FEEDBACK_FILE_COUNT = 5;
+let nextLocalFeedbackFileId = -1;
+
+const parseId = (value: string | null | undefined) => {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+const createLocalFeedbackFiles = (submissionId: number, files: File[]): AdvisorSubmissionFile[] =>
+  files.map((file) => ({
+    fileId: nextLocalFeedbackFileId--,
+    fileName: file.name,
+    fileSize: file.size,
+    source: 'local',
+    sourceFile: file,
+    submissionId,
+  }));
+
+const AdvisorActivityPage = () => {
+  const { contestId: contestIdParam } = useParams<{ contestId?: string }>();
+  const [searchParams] = useSearchParams();
+  const requestedContestId = parseId(contestIdParam) ?? parseId(searchParams.get('contestId'));
+
+  const { isAdvisor } = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const [expandedTeamId, setExpandedTeamId] = useState<number | null>(null);
+  const [selectedSubmissionId, setSelectedSubmissionId] = useState<number | null>(null);
+  const [feedbackDrafts, setFeedbackDrafts] = useState<Record<number, string>>({});
+  const [pendingFeedbackFiles, setPendingFeedbackFiles] = useState<Record<number, AdvisorSubmissionFile[]>>({});
+  const [removedFeedbackFileIds, setRemovedFeedbackFileIds] = useState<Record<number, number[]>>({});
+
+  const currentContestQuery = useQuery({
+    ...currentContestOption(),
+    enabled: isAdvisor && requestedContestId === null,
+  });
+  const defaultContest = currentContestQuery.data?.[0];
+  const contestId = requestedContestId ?? defaultContest?.contestId ?? null;
+
+  const advisorProjectsQuery = useQuery({
+    ...advisorProjectsOption(contestId ?? 0),
+    enabled: isAdvisor && contestId !== null,
+  });
+  const projectsResponse = advisorProjectsQuery.data;
+
+  useEffect(() => {
+    const firstProject = projectsResponse?.projects[0];
+
+    if (!firstProject) {
+      setExpandedTeamId(null);
+      return;
+    }
+
+    setExpandedTeamId((currentTeamId) => {
+      const currentProjectExists = projectsResponse.projects.some((project) => project.teamId === currentTeamId);
+      return currentProjectExists ? currentTeamId : firstProject.teamId;
+    });
+  }, [projectsResponse?.projects]);
+
+  const teamSubmissionsQuery = useQuery({
+    ...advisorTeamSubmissionsOption(contestId ?? 0, expandedTeamId ?? 0),
+    enabled: isAdvisor && contestId !== null && expandedTeamId !== null,
+  });
+  const teamSubmissions = teamSubmissionsQuery.data;
+
+  useEffect(() => {
+    setSelectedSubmissionId((currentSubmissionId) => {
+      if (!teamSubmissions?.submissions.length) {
+        return null;
+      }
+
+      const currentSubmissionExists = teamSubmissions.submissions.some(
+        (submission) => submission.submissionId === currentSubmissionId,
+      );
+
+      return currentSubmissionExists ? currentSubmissionId : teamSubmissions.submissions[0].submissionId;
+    });
+  }, [teamSubmissions?.submissions]);
+
+  const advisorFeedbackQuery = useQuery({
+    ...advisorFeedbackOption(contestId ?? 0, selectedSubmissionId ?? 0),
+    enabled: isAdvisor && contestId !== null && selectedSubmissionId !== null,
+  });
+
+  useEffect(() => {
+    if (!advisorFeedbackQuery.isSuccess || selectedSubmissionId === null) {
+      return;
+    }
+
+    setFeedbackDrafts((prev) => ({
+      ...prev,
+      [selectedSubmissionId]: prev[selectedSubmissionId] ?? advisorFeedbackQuery.data?.description ?? '',
+    }));
+  }, [advisorFeedbackQuery.data?.description, advisorFeedbackQuery.isSuccess, selectedSubmissionId]);
+
+  const saveFeedbackMutation = useMutation({
+    mutationFn: ({
+      description,
+      files,
+      removeFileIds,
+      submissionId,
+    }: {
+      description: string;
+      files: File[];
+      removeFileIds: number[];
+      submissionId: number;
+      teamId: number | null;
+    }) => {
+      if (contestId === null) {
+        throw new Error('대회 ID가 필요합니다.');
+      }
+
+      return putAdvisorFeedback(contestId, submissionId, { description, files, removeFileIds });
+    },
+    onSuccess: async (_, { submissionId, teamId }) => {
+      if (contestId === null) {
+        return;
+      }
+
+      setPendingFeedbackFiles((prev) => ({ ...prev, [submissionId]: [] }));
+      setRemovedFeedbackFileIds((prev) => ({ ...prev, [submissionId]: [] }));
+      await invalidateAdvisorActivityQueries(queryClient, contestId, teamId ?? undefined, submissionId);
+      toast('피드백을 저장했어요.', 'success');
+    },
+    onError: () => {
+      toast('피드백 저장에 실패했어요.', 'error');
+    },
+  });
+
+  const selectedFeedback = advisorFeedbackQuery.data;
+  const serverFeedbackFiles = useMemo<AdvisorSubmissionFile[]>(() => {
+    if (!selectedFeedback || selectedSubmissionId === null) {
+      return [];
+    }
+
+    const removedFileIds = new Set(removedFeedbackFileIds[selectedSubmissionId] ?? []);
+    return selectedFeedback.files
+      .filter((file) => !removedFileIds.has(file.fileId))
+      .map((file) => ({
+        ...file,
+        feedbackId: selectedFeedback.feedbackId,
+        source: 'feedback',
+        submissionId: selectedSubmissionId,
+      }));
+  }, [removedFeedbackFileIds, selectedFeedback, selectedSubmissionId]);
+  const contestTitle =
+    defaultContest && defaultContest.contestId === contestId ? defaultContest.contestName : '지도 활동';
+
+  const advisorActivity: AdvisorActivityContest = useMemo(() => {
+    const projects: AdvisorProject[] =
+      projectsResponse?.projects.map((project) => {
+        const isExpanded = project.teamId === expandedTeamId;
+        const submissions =
+          isExpanded && teamSubmissions
+            ? teamSubmissions.submissions.map((submission) => {
+                const isSelected = submission.submissionId === selectedSubmissionId;
+                const pendingFiles = pendingFeedbackFiles[submission.submissionId] ?? [];
+
+                return {
+                  ...submission,
+                  feedbackFiles: isSelected ? [...serverFeedbackFiles, ...pendingFiles] : pendingFiles,
+                  files: submission.files.map((file) => ({
+                    ...file,
+                    source: 'submission' as const,
+                    submissionId: submission.submissionId,
+                  })),
+                  isFeedbackLoading: isSelected && advisorFeedbackQuery.isLoading,
+                };
+              })
+            : [];
+
+        return { ...project, submissions };
+      }) ?? [];
+
+    const contestTags =
+      contestId === null
+        ? ['대회 미선택']
+        : [`대회 #${contestId}`, ...Array.from(new Set(projects.map((project) => project.trackName)))];
+
+    return {
+      assignedTeamCount: projectsResponse?.assignedTeamCount ?? 0,
+      contestId: contestId ?? 0,
+      contestName: contestTitle,
+      pendingFeedbackCount: projectsResponse?.pendingFeedbackCount ?? 0,
+      projects,
+      tags: contestTags,
+    };
+  }, [
+    advisorFeedbackQuery.isLoading,
+    contestId,
+    contestTitle,
+    expandedTeamId,
+    pendingFeedbackFiles,
+    projectsResponse?.assignedTeamCount,
+    projectsResponse?.pendingFeedbackCount,
+    projectsResponse?.projects,
+    selectedSubmissionId,
+    serverFeedbackFiles,
+    teamSubmissions,
+  ]);
+
+  if (!isAdvisor) {
+    return (
+      <div className="border-lightGray mx-auto flex min-h-60 w-full max-w-6xl flex-col items-center justify-center gap-2 rounded-lg border bg-white px-6 text-center">
+        <h2 className="text-base font-bold text-neutral-900">접근 권한이 없습니다.</h2>
+        <p className="text-midGray text-sm">지도교수 또는 외부 멘토만 지도 활동을 확인할 수 있습니다.</p>
+      </div>
+    );
+  }
+
+  if (currentContestQuery.isLoading && requestedContestId === null) {
+    return <AdvisorActivitySkeleton />;
+  }
+
+  if (currentContestQuery.isError && requestedContestId === null) {
+    return (
+      <AdvisorActivityMessage
+        title="대회 정보를 불러오지 못했습니다."
+        description="잠시 후 다시 시도해주세요."
+        onRetry={() => void currentContestQuery.refetch()}
+      />
+    );
+  }
+
+  if (contestId === null) {
+    return (
+      <AdvisorActivityMessage
+        title="담당 대회가 없습니다."
+        description="현재 진행 중인 대회가 없거나 지도 활동을 확인할 대회를 찾지 못했습니다."
+      />
+    );
+  }
+
+  const handleToggleProject = (project: AdvisorProject) => {
+    if (expandedTeamId === project.teamId) {
+      setExpandedTeamId(null);
+      setSelectedSubmissionId(null);
+      return;
+    }
+
+    setExpandedTeamId(project.teamId);
+    setSelectedSubmissionId(null);
+  };
+
+  const handleChangeFeedback = (submissionId: number, value: string) => {
+    setFeedbackDrafts((prev) => ({ ...prev, [submissionId]: value }));
+  };
+
+  const handleAttachFeedbackFiles = (submissionId: number, files: File[]) => {
+    const removedFileCount = removedFeedbackFileIds[submissionId]?.length ?? 0;
+    const serverFileCount =
+      submissionId === selectedSubmissionId ? Math.max(0, (selectedFeedback?.files.length ?? 0) - removedFileCount) : 0;
+
+    setPendingFeedbackFiles((prev) => {
+      const currentFiles = prev[submissionId] ?? [];
+      const availableSlots = Math.max(0, MAX_FEEDBACK_FILE_COUNT - serverFileCount - currentFiles.length);
+      const validFiles = files.filter((file) => file.size > 0).slice(0, availableSlots);
+
+      if (validFiles.length === 0) {
+        toast('피드백 첨부파일은 최대 5개까지 첨부할 수 있어요.', 'error');
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [submissionId]: [...currentFiles, ...createLocalFeedbackFiles(submissionId, validFiles)],
+      };
+    });
+  };
+
+  const handleRemoveFeedbackFile = (submissionId: number, file: AdvisorSubmissionFile) => {
+    if (file.source === 'local') {
+      setPendingFeedbackFiles((prev) => ({
+        ...prev,
+        [submissionId]: (prev[submissionId] ?? []).filter((pendingFile) => pendingFile.fileId !== file.fileId),
+      }));
+      return;
+    }
+
+    if (file.source === 'feedback') {
+      setRemovedFeedbackFileIds((prev) => ({
+        ...prev,
+        [submissionId]: Array.from(new Set([...(prev[submissionId] ?? []), file.fileId])),
+      }));
+    }
+  };
+
+  const handleSaveFeedback = (submissionId: number) => {
+    const description = feedbackDrafts[submissionId]?.trim();
+
+    if (!description) {
+      toast('피드백 본문을 입력해주세요.', 'error');
+      return;
+    }
+
+    saveFeedbackMutation.mutate({
+      description,
+      files: (pendingFeedbackFiles[submissionId] ?? [])
+        .map((file) => file.sourceFile)
+        .filter((file): file is File => file !== undefined),
+      removeFileIds: removedFeedbackFileIds[submissionId] ?? [],
+      submissionId,
+      teamId: expandedTeamId,
+    });
+  };
+
+  const handleDownloadFile = async (file: AdvisorSubmissionFile) => {
+    if (file.sourceFile) {
+      downloadBlob(file.sourceFile, file.fileName);
+      return;
+    }
+
+    if (!file.submissionId) {
+      toast('파일 정보를 확인할 수 없어요.', 'error');
+      return;
+    }
+
+    try {
+      const res =
+        file.source === 'feedback' && file.feedbackId
+          ? await getAdvisorFeedbackFile(contestId, file.submissionId, file.feedbackId, file.fileId)
+          : await getAdvisorSubmissionFile(contestId, file.submissionId, file.fileId);
+
+      downloadBlob(res.data, file.fileName, res.headers['content-disposition']);
+    } catch {
+      toast('파일 다운로드에 실패했어요.', 'error');
+    }
+  };
+
+  if (advisorProjectsQuery.isLoading) {
+    return <AdvisorActivitySkeleton />;
+  }
+
+  if (advisorProjectsQuery.isError) {
+    return (
+      <AdvisorActivityMessage
+        title="지도 활동을 불러오지 못했습니다."
+        description="잠시 후 다시 시도해주세요."
+        onRetry={() => void advisorProjectsQuery.refetch()}
+      />
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+      <AdvisorContestSummary contest={advisorActivity} />
+      <AdvisorProjectList
+        contestId={advisorActivity.contestId}
+        projects={advisorActivity.projects}
+        expandedTeamId={expandedTeamId}
+        loadingTeamId={teamSubmissionsQuery.isLoading ? expandedTeamId : null}
+        savingSubmissionId={saveFeedbackMutation.isPending ? saveFeedbackMutation.variables?.submissionId : null}
+        selectedSubmissionId={selectedSubmissionId}
+        feedbackDrafts={feedbackDrafts}
+        onAttachFeedbackFiles={handleAttachFeedbackFiles}
+        onChangeFeedback={handleChangeFeedback}
+        onDownloadFile={handleDownloadFile}
+        onRemoveFeedbackFile={handleRemoveFeedbackFile}
+        onSaveFeedback={handleSaveFeedback}
+        onSelectSubmission={setSelectedSubmissionId}
+        onToggleProject={handleToggleProject}
+      />
+    </div>
+  );
+};
+
+export default AdvisorActivityPage;
+
+const AdvisorActivityMessage = ({
+  description,
+  onRetry,
+  title,
+}: {
+  description: string;
+  onRetry?: () => void;
+  title: string;
+}) => (
+  <div className="border-lightGray mx-auto flex min-h-60 w-full max-w-6xl flex-col items-center justify-center gap-3 rounded-lg border bg-white px-6 text-center">
+    <h2 className="text-base font-bold text-neutral-900">{title}</h2>
+    <p className="text-midGray text-sm">{description}</p>
+    {onRetry && (
+      <button
+        type="button"
+        onClick={onRetry}
+        className="border-lightGray hover:bg-whiteGray inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-semibold text-neutral-800 transition-colors"
+      >
+        <RefreshCw size={16} />
+        다시 시도
+      </button>
+    )}
+  </div>
+);
+
+const AdvisorActivitySkeleton = () => (
+  <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+    <div className="flex flex-col gap-7 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex flex-col gap-3">
+        <div className="h-8 w-48 animate-pulse rounded-md bg-neutral-200" />
+        <div className="flex gap-2">
+          <div className="h-6 w-20 animate-pulse rounded-full bg-neutral-200" />
+          <div className="h-6 w-24 animate-pulse rounded-full bg-neutral-200" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-6 lg:min-w-[24rem] lg:gap-10">
+        <div className="h-24 animate-pulse rounded-md bg-neutral-200" />
+        <div className="h-24 animate-pulse rounded-md bg-neutral-200" />
+      </div>
+    </div>
+    <section className="flex flex-col gap-5">
+      <div className="h-8 w-36 animate-pulse rounded-md bg-neutral-200" />
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div key={index} className="h-20 animate-pulse rounded-lg bg-neutral-200" />
+      ))}
+    </section>
+  </div>
+);

--- a/src/pages/me/advisor-activity/components/AdvisorContestSummary.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorContestSummary.tsx
@@ -1,0 +1,36 @@
+import type { AdvisorActivityContest } from '../types';
+
+interface AdvisorContestSummaryProps {
+  contest: Pick<AdvisorActivityContest, 'assignedTeamCount' | 'contestName' | 'pendingFeedbackCount' | 'tags'>;
+}
+
+export const AdvisorContestSummary = ({ contest }: AdvisorContestSummaryProps) => {
+  return (
+    <section className="flex flex-col gap-7 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex flex-col gap-3">
+        <h1 className="text-2xl font-extrabold text-neutral-950">{contest.contestName}</h1>
+        <div className="flex flex-wrap gap-2">
+          {contest.tags.map((tag) => (
+            <span key={tag} className="bg-whiteGray rounded-full px-3 py-1 text-xs text-neutral-700">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-6 lg:min-w-[24rem] lg:gap-10">
+        <SummaryMetric label="검토 대기" value={`${contest.pendingFeedbackCount}건`} />
+        <SummaryMetric label="담당 팀" value={`${contest.assignedTeamCount}팀`} />
+      </div>
+    </section>
+  );
+};
+
+const SummaryMetric = ({ label, value }: { label: string; value: string }) => {
+  return (
+    <div className="border-mainBlue/40 flex min-h-24 flex-col justify-center border-l-4 pl-6">
+      <span className="text-sm font-semibold text-neutral-900">{label}</span>
+      <strong className="text-midGray mt-2 text-3xl font-extrabold">{value}</strong>
+    </div>
+  );
+};

--- a/src/pages/me/advisor-activity/components/AdvisorFeedbackEditor.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorFeedbackEditor.tsx
@@ -1,0 +1,94 @@
+import { useRef, type ChangeEvent } from 'react';
+import { Paperclip } from 'lucide-react';
+
+import type { AdvisorSubmissionFile } from '../types';
+import { AdvisorFileList } from './AdvisorFileList';
+
+interface AdvisorFeedbackEditorProps {
+  value: string;
+  files: AdvisorSubmissionFile[];
+  isLoading?: boolean;
+  isSaving?: boolean;
+  onAttachFiles: (files: File[]) => void;
+  onChange: (value: string) => void;
+  onDownloadFile: (file: AdvisorSubmissionFile) => void;
+  onRemoveFile: (file: AdvisorSubmissionFile) => void;
+  onSave: () => void;
+}
+
+export const AdvisorFeedbackEditor = ({
+  value,
+  files,
+  isLoading = false,
+  isSaving = false,
+  onAttachFiles,
+  onChange,
+  onDownloadFile,
+  onRemoveFile,
+  onSave,
+}: AdvisorFeedbackEditorProps) => {
+  const canAttach = !isLoading && !isSaving && files.length < 5;
+  const canSave = !isLoading && !isSaving && value.trim().length > 0;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files ?? []);
+
+    if (selectedFiles.length > 0) {
+      onAttachFiles(selectedFiles);
+    }
+
+    event.target.value = '';
+  };
+
+  return (
+    <div className="mt-4 flex flex-col gap-4 rounded-md bg-white p-4">
+      <div className="flex flex-col gap-1">
+        <h4 className="text-mainBlue text-sm font-medium">피드백 작성</h4>
+        <p className="text-midGray text-xs leading-5">
+          제출물을 확인하고 피드백을 작성해주세요. 작성한 피드백은 팀과 관리자에게 공유됩니다.
+        </p>
+      </div>
+
+      {files.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold text-neutral-800">첨부한 참고 자료</span>
+          <AdvisorFileList files={files} onDownload={onDownloadFile} onRemove={onRemoveFile} />
+        </div>
+      )}
+
+      <label className="sr-only" htmlFor="advisor-feedback-description">
+        피드백 내용
+      </label>
+      <textarea
+        id="advisor-feedback-description"
+        value={value}
+        disabled={isLoading || isSaving}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={isLoading ? '피드백을 불러오는 중입니다.' : '제출물에 대한 피드백을 작성해주세요.'}
+        className="border-lightGray focus:border-mainBlue disabled:bg-whiteGray h-36 resize-none overflow-y-auto rounded-md border bg-white p-3 text-sm leading-relaxed transition-colors outline-none placeholder:text-neutral-300 disabled:cursor-wait"
+      />
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <input ref={fileInputRef} type="file" multiple className="sr-only" onChange={handleFileChange} />
+        <button
+          type="button"
+          disabled={!canAttach}
+          onClick={() => fileInputRef.current?.click()}
+          className="text-midGray hover:text-mainBlue flex h-9 w-fit items-center gap-2 rounded-md px-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Paperclip size={16} />
+          참고 자료 첨부
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canSave}
+          className="bg-mainBlue disabled:bg-midGray inline-flex h-10 items-center justify-center rounded-md px-4 text-sm font-semibold text-white transition-colors hover:bg-sky-800 disabled:cursor-not-allowed"
+        >
+          {isSaving ? '저장 중...' : '저장하기'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/me/advisor-activity/components/AdvisorFileList.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorFileList.tsx
@@ -1,0 +1,48 @@
+import { Download, FileText, X } from 'lucide-react';
+
+import type { AdvisorSubmissionFile } from '../types';
+import { formatFileSize } from '../utils/format';
+
+interface AdvisorFileListProps {
+  files: AdvisorSubmissionFile[];
+  onDownload: (file: AdvisorSubmissionFile) => void;
+  onRemove?: (file: AdvisorSubmissionFile) => void;
+}
+
+export const AdvisorFileList = ({ files, onDownload, onRemove }: AdvisorFileListProps) => {
+  if (files.length === 0) {
+    return <span className="text-midGray text-xs">제출 파일 없음</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {files.map((file) => (
+        <div
+          key={`${file.source ?? 'file'}-${file.submissionId ?? 'none'}-${file.fileId}-${file.fileName}`}
+          className="border-lightGray bg-whiteGray hover:border-mainBlue/60 flex max-w-full items-center rounded-md border transition-colors hover:bg-blue-50"
+        >
+          <button
+            type="button"
+            onClick={() => onDownload(file)}
+            className="flex min-w-0 items-center gap-2 px-2.5 py-1.5 text-left"
+          >
+            <FileText size={16} className="text-midGray shrink-0" />
+            <span className="max-w-64 truncate text-xs font-medium text-neutral-800">{file.fileName}</span>
+            <span className="text-midGray shrink-0 text-xs">{formatFileSize(file.fileSize)}</span>
+            <Download size={14} className="text-midGray shrink-0" />
+          </button>
+          {onRemove && (
+            <button
+              type="button"
+              onClick={() => onRemove(file)}
+              aria-label={`${file.fileName} 첨부 제거`}
+              className="text-midGray hover:text-mainRed flex h-8 w-8 shrink-0 items-center justify-center rounded-r-md transition-colors"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/me/advisor-activity/components/AdvisorProjectCard.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorProjectCard.tsx
@@ -1,0 +1,103 @@
+import { Link } from 'react-router-dom';
+
+import { cn } from '@utils/classname';
+
+import type { AdvisorProject, AdvisorSubmissionFile } from '../types';
+import { getAdvisorRoleLabel } from '../utils/format';
+import { AdvisorSubmissionPanel } from './AdvisorSubmissionPanel';
+
+interface AdvisorProjectCardProps {
+  contestId: number;
+  expanded: boolean;
+  feedbackDrafts: Record<number, string>;
+  isLoadingSubmissions?: boolean;
+  project: AdvisorProject;
+  savingSubmissionId?: number | null;
+  selectedSubmissionId: number | null;
+  onAttachFeedbackFiles: (submissionId: number, files: File[]) => void;
+  onChangeFeedback: (submissionId: number, value: string) => void;
+  onDownloadFile: (file: AdvisorSubmissionFile) => void;
+  onRemoveFeedbackFile: (submissionId: number, file: AdvisorSubmissionFile) => void;
+  onSaveFeedback: (submissionId: number) => void;
+  onSelectSubmission: (submissionId: number) => void;
+  onToggle: () => void;
+}
+
+export const AdvisorProjectCard = ({
+  contestId,
+  expanded,
+  feedbackDrafts,
+  isLoadingSubmissions = false,
+  project,
+  savingSubmissionId = null,
+  selectedSubmissionId,
+  onAttachFeedbackFiles,
+  onChangeFeedback,
+  onDownloadFile,
+  onRemoveFeedbackFile,
+  onSaveFeedback,
+  onSelectSubmission,
+  onToggle,
+}: AdvisorProjectCardProps) => {
+  const hasPendingFeedback = project.pendingFeedbackCount > 0;
+
+  return (
+    <article
+      className={cn(
+        'rounded-lg border border-blue-200 bg-white px-5 py-4 text-sm transition-colors',
+        expanded && 'bg-blue-50/20',
+      )}
+    >
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_auto_auto] xl:items-center xl:gap-8">
+        <div className="flex min-w-0 flex-wrap items-center gap-2.5 sm:gap-4">
+          <span className="text-mainBlue rounded-md bg-blue-50 px-3 py-1.5 text-xs font-bold">
+            {getAdvisorRoleLabel(project.roleType)}
+          </span>
+          <h3 className="text-base font-bold text-neutral-950">{project.projectName}</h3>
+          <span className="bg-whiteGray rounded-full px-3 py-1 text-xs text-neutral-700">{project.trackName}</span>
+          <span className="bg-whiteGray rounded-full px-3 py-1 text-xs text-neutral-700">{project.teamName}</span>
+        </div>
+
+        <div className="text-midGray flex items-center gap-2.5 text-xs xl:justify-self-center">
+          <span
+            className={cn('h-2 w-2 rounded-full', hasPendingFeedback ? 'bg-amber-500' : 'bg-blue-400')}
+            aria-hidden
+          />
+          <span>피드백 작성 대기 {project.pendingFeedbackCount}건</span>
+        </div>
+
+        <div className="flex gap-3 xl:justify-self-end">
+          <Link
+            to={`/contest/${contestId}/teams/view/${project.teamId}`}
+            className="border-mainBlue text-mainBlue inline-flex h-10 items-center justify-center rounded-md border px-4 text-center text-sm font-semibold transition-colors hover:bg-blue-50"
+          >
+            프로젝트 보기
+          </Link>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="bg-mainBlue inline-flex h-10 items-center justify-center rounded-md px-4 text-sm font-semibold text-white transition-colors hover:bg-sky-800"
+          >
+            피드백 작성
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <AdvisorSubmissionPanel
+          isLoading={isLoadingSubmissions}
+          savingSubmissionId={savingSubmissionId}
+          submissions={project.submissions}
+          selectedSubmissionId={selectedSubmissionId}
+          feedbackDrafts={feedbackDrafts}
+          onAttachFeedbackFiles={onAttachFeedbackFiles}
+          onChangeFeedback={onChangeFeedback}
+          onDownloadFile={onDownloadFile}
+          onRemoveFeedbackFile={onRemoveFeedbackFile}
+          onSaveFeedback={onSaveFeedback}
+          onSelectSubmission={onSelectSubmission}
+        />
+      )}
+    </article>
+  );
+};

--- a/src/pages/me/advisor-activity/components/AdvisorProjectList.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorProjectList.tsx
@@ -1,0 +1,71 @@
+import type { AdvisorProject, AdvisorSubmissionFile } from '../types';
+import { AdvisorProjectCard } from './AdvisorProjectCard';
+
+interface AdvisorProjectListProps {
+  contestId: number;
+  expandedTeamId: number | null;
+  feedbackDrafts: Record<number, string>;
+  loadingTeamId?: number | null;
+  projects: AdvisorProject[];
+  savingSubmissionId?: number | null;
+  selectedSubmissionId: number | null;
+  onAttachFeedbackFiles: (submissionId: number, files: File[]) => void;
+  onChangeFeedback: (submissionId: number, value: string) => void;
+  onDownloadFile: (file: AdvisorSubmissionFile) => void;
+  onRemoveFeedbackFile: (submissionId: number, file: AdvisorSubmissionFile) => void;
+  onSaveFeedback: (submissionId: number) => void;
+  onSelectSubmission: (submissionId: number) => void;
+  onToggleProject: (project: AdvisorProject) => void;
+}
+
+export const AdvisorProjectList = ({
+  contestId,
+  expandedTeamId,
+  feedbackDrafts,
+  loadingTeamId = null,
+  projects,
+  savingSubmissionId = null,
+  selectedSubmissionId,
+  onAttachFeedbackFiles,
+  onChangeFeedback,
+  onDownloadFile,
+  onRemoveFeedbackFile,
+  onSaveFeedback,
+  onSelectSubmission,
+  onToggleProject,
+}: AdvisorProjectListProps) => {
+  if (projects.length === 0) {
+    return (
+      <section className="border-lightGray text-midGray flex min-h-45 items-center justify-center rounded-lg border bg-white text-sm font-medium">
+        담당 프로젝트가 없습니다.
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-5" aria-label="담당 프로젝트">
+      <h2 className="text-2xl font-extrabold text-neutral-950">담당 프로젝트</h2>
+      <div className="flex flex-col gap-4">
+        {projects.map((project) => (
+          <AdvisorProjectCard
+            key={project.teamId}
+            contestId={contestId}
+            project={project}
+            expanded={project.teamId === expandedTeamId}
+            isLoadingSubmissions={loadingTeamId === project.teamId}
+            savingSubmissionId={savingSubmissionId}
+            selectedSubmissionId={selectedSubmissionId}
+            feedbackDrafts={feedbackDrafts}
+            onAttachFeedbackFiles={onAttachFeedbackFiles}
+            onChangeFeedback={onChangeFeedback}
+            onDownloadFile={onDownloadFile}
+            onRemoveFeedbackFile={onRemoveFeedbackFile}
+            onSaveFeedback={onSaveFeedback}
+            onSelectSubmission={onSelectSubmission}
+            onToggle={() => onToggleProject(project)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/pages/me/advisor-activity/components/AdvisorStatusBadge.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorStatusBadge.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@utils/classname';
+
+import type { AdvisorFeedbackStatus } from '../types';
+import { getFeedbackStatusLabel } from '../utils/format';
+
+interface AdvisorStatusBadgeProps {
+  status: AdvisorFeedbackStatus;
+}
+
+export const AdvisorStatusBadge = ({ status }: AdvisorStatusBadgeProps) => {
+  const completed = status === 'COMPLETED';
+
+  return (
+    <span
+      className={cn(
+        'inline-flex w-fit items-center rounded-md px-3 py-1 text-xs font-bold',
+        completed ? 'bg-subGreen text-mainGreen' : 'bg-amber-50 text-amber-600',
+      )}
+    >
+      {getFeedbackStatusLabel(status)}
+    </span>
+  );
+};

--- a/src/pages/me/advisor-activity/components/AdvisorSubmissionPanel.tsx
+++ b/src/pages/me/advisor-activity/components/AdvisorSubmissionPanel.tsx
@@ -1,0 +1,118 @@
+import { cn } from '@utils/classname';
+
+import type { AdvisorSubmission, AdvisorSubmissionFile } from '../types';
+import { AdvisorFeedbackEditor } from './AdvisorFeedbackEditor';
+import { AdvisorFileList } from './AdvisorFileList';
+import { AdvisorStatusBadge } from './AdvisorStatusBadge';
+
+interface AdvisorSubmissionPanelProps {
+  isLoading?: boolean;
+  savingSubmissionId?: number | null;
+  submissions: AdvisorSubmission[];
+  selectedSubmissionId: number | null;
+  feedbackDrafts: Record<number, string>;
+  onAttachFeedbackFiles: (submissionId: number, files: File[]) => void;
+  onChangeFeedback: (submissionId: number, value: string) => void;
+  onDownloadFile: (file: AdvisorSubmissionFile) => void;
+  onRemoveFeedbackFile: (submissionId: number, file: AdvisorSubmissionFile) => void;
+  onSaveFeedback: (submissionId: number) => void;
+  onSelectSubmission: (submissionId: number) => void;
+}
+
+export const AdvisorSubmissionPanel = ({
+  isLoading = false,
+  savingSubmissionId = null,
+  submissions,
+  selectedSubmissionId,
+  feedbackDrafts,
+  onAttachFeedbackFiles,
+  onChangeFeedback,
+  onDownloadFile,
+  onRemoveFeedbackFile,
+  onSaveFeedback,
+  onSelectSubmission,
+}: AdvisorSubmissionPanelProps) => {
+  if (isLoading) {
+    return (
+      <div className="border-lightGray text-midGray mt-4 flex min-h-28 items-center justify-center rounded-md border bg-white text-sm font-medium">
+        제출물을 불러오는 중입니다.
+      </div>
+    );
+  }
+
+  if (submissions.length === 0) {
+    return (
+      <div className="border-lightGray text-midGray mt-4 flex min-h-28 items-center justify-center rounded-md border bg-white text-sm font-medium">
+        제출물이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-lightGray mt-4 overflow-hidden rounded-md border bg-white">
+      <div className="bg-whiteGray hidden grid-cols-[1.4fr_1fr_2fr_6.5rem] gap-4 px-5 py-3 text-xs font-bold text-neutral-800 md:grid">
+        <span>제출물 항목</span>
+        <span>피드백 상태</span>
+        <span>제출 파일</span>
+        <span className="text-center">작업</span>
+      </div>
+
+      <div className="flex flex-col">
+        {submissions.map((submission) => {
+          const selected = submission.submissionId === selectedSubmissionId;
+
+          return (
+            <div
+              key={submission.submissionId}
+              className={cn(
+                'rounded-lg bg-white',
+                selected ? 'border-mainBlue border' : 'border-lightGray border-t first:border-t-0',
+              )}
+            >
+              <div className="grid gap-4 px-5 py-4 md:grid-cols-[1.4fr_1fr_2fr_6.5rem] md:items-center">
+                <div className="flex flex-col gap-1">
+                  <span className="text-sm font-semibold text-neutral-950">{submission.submissionItemName}</span>
+                  <span className="text-midGray text-xs md:hidden">제출물 항목</span>
+                </div>
+                <AdvisorStatusBadge status={submission.feedbackStatus} />
+                <AdvisorFileList files={submission.files} onDownload={onDownloadFile} />
+                <button
+                  type="button"
+                  onClick={() => onSelectSubmission(submission.submissionId)}
+                  className="border-mainBlue text-mainBlue inline-flex h-9 items-center justify-center justify-self-start rounded-md border px-3 text-xs font-semibold transition-colors hover:bg-blue-50 md:justify-self-center"
+                >
+                  자세히 보기
+                </button>
+              </div>
+
+              <div
+                className={cn(
+                  'grid transition-[grid-template-rows,opacity] duration-300 ease-out',
+                  selected ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
+                )}
+              >
+                <div className="overflow-hidden">
+                  {selected && (
+                    <div className="px-5 pb-5">
+                      <AdvisorFeedbackEditor
+                        value={feedbackDrafts[submission.submissionId] ?? ''}
+                        files={submission.feedbackFiles ?? []}
+                        isLoading={submission.isFeedbackLoading}
+                        isSaving={savingSubmissionId === submission.submissionId}
+                        onAttachFiles={(files) => onAttachFeedbackFiles(submission.submissionId, files)}
+                        onChange={(value) => onChangeFeedback(submission.submissionId, value)}
+                        onDownloadFile={onDownloadFile}
+                        onRemoveFile={(file) => onRemoveFeedbackFile(submission.submissionId, file)}
+                        onSave={() => onSaveFeedback(submission.submissionId)}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/me/advisor-activity/types.ts
+++ b/src/pages/me/advisor-activity/types.ts
@@ -1,0 +1,30 @@
+import type { AdvisorFeedbackStatus, AdvisorProjectDto, AdvisorRoleType, AdvisorSubmissionDto } from '@dto/advisorDto';
+import type { SubmissionFileResponseDto } from '@dto/submissionDto';
+
+export type AdvisorSubmissionFile = SubmissionFileResponseDto & {
+  feedbackId?: number;
+  source?: 'feedback' | 'local' | 'submission';
+  sourceFile?: File;
+  submissionId?: number;
+};
+
+export type { AdvisorFeedbackStatus, AdvisorRoleType };
+
+export interface AdvisorSubmission extends Omit<AdvisorSubmissionDto, 'files'> {
+  feedbackFiles?: AdvisorSubmissionFile[];
+  files: AdvisorSubmissionFile[];
+  isFeedbackLoading?: boolean;
+}
+
+export interface AdvisorProject extends AdvisorProjectDto {
+  submissions: AdvisorSubmission[];
+}
+
+export interface AdvisorActivityContest {
+  contestId: number;
+  contestName: string;
+  tags: string[];
+  assignedTeamCount: number;
+  pendingFeedbackCount: number;
+  projects: AdvisorProject[];
+}

--- a/src/pages/me/advisor-activity/utils/format.ts
+++ b/src/pages/me/advisor-activity/utils/format.ts
@@ -1,0 +1,22 @@
+import type { AdvisorFeedbackStatus, AdvisorRoleType } from '../types';
+
+export const formatFileSize = (bytes: number) => {
+  const mb = bytes / 1024 / 1024;
+  return mb >= 1024 ? `${(mb / 1024).toFixed(1)}GB` : `${mb.toFixed(1)}MB`;
+};
+
+export const getAdvisorRoleLabel = (roleType: AdvisorRoleType) => {
+  if (roleType === 'ROLE_교수') {
+    return '지도 교수';
+  }
+
+  return '외부 멘토';
+};
+
+export const getFeedbackStatusLabel = (status: AdvisorFeedbackStatus) => {
+  if (status === 'COMPLETED') {
+    return '작성 완료';
+  }
+
+  return '작성 대기';
+};

--- a/src/queries/advisor.ts
+++ b/src/queries/advisor.ts
@@ -1,0 +1,46 @@
+import { queryOptions, type QueryClient } from '@tanstack/react-query';
+
+import { getAdvisorProjects, getAdvisorTeamSubmissions, getMyAdvisorFeedback } from '@apis/advisor';
+
+export const ADVISOR_ACTIVITY_QUERY_KEY = ['advisorActivity'] as const;
+
+export const advisorProjectsOption = (contestId: number) =>
+  queryOptions({
+    queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'projects', contestId],
+    queryFn: () => getAdvisorProjects(contestId),
+    staleTime: 60 * 1000,
+  });
+
+export const advisorTeamSubmissionsOption = (contestId: number, teamId: number) =>
+  queryOptions({
+    queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'teamSubmissions', contestId, teamId],
+    queryFn: () => getAdvisorTeamSubmissions(contestId, teamId),
+    staleTime: 60 * 1000,
+  });
+
+export const advisorFeedbackOption = (contestId: number, submissionId: number) =>
+  queryOptions({
+    queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'feedback', contestId, submissionId],
+    queryFn: () => getMyAdvisorFeedback(contestId, submissionId),
+    staleTime: 60 * 1000,
+  });
+
+export const invalidateAdvisorActivityQueries = (
+  queryClient: QueryClient,
+  contestId: number,
+  teamId?: number,
+  submissionId?: number,
+) =>
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'projects', contestId] }),
+    teamId
+      ? queryClient.invalidateQueries({
+          queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'teamSubmissions', contestId, teamId],
+        })
+      : Promise.resolve(),
+    submissionId
+      ? queryClient.invalidateQueries({
+          queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'feedback', contestId, submissionId],
+        })
+      : Promise.resolve(),
+  ]);

--- a/src/route/AppRoutes.tsx
+++ b/src/route/AppRoutes.tsx
@@ -39,6 +39,7 @@ import MySubmissionPage from '@pages/me/activity/submission/MySubmissionPage';
 import SubmissionManagePage from '@pages/admin/submission-manage/SubmissionManagePage';
 import TeamDashboardPage from '@pages/me/team/TeamDashboardPage';
 import RoleAssignmentPage from '@pages/admin/role-assignment/RoleAssignmentPage';
+import AdvisorActivityPage from '@pages/me/advisor-activity/AdvisorActivityPage';
 
 const AppRoutes = () =>
   createBrowserRouter([
@@ -75,6 +76,8 @@ const AppRoutes = () =>
             { path: 'activity/likes', element: <MyLikePage /> },
             { path: 'activity/comments', element: <MyCommentPage /> },
             { path: 'activity/:teamId/submission', element: <MySubmissionPage /> },
+            { path: 'advisor-activity', element: <AdvisorActivityPage /> },
+            { path: 'advisor-activity/contests/:contestId', element: <AdvisorActivityPage /> },
             {
               path: 'contests/:contestId/teams/:teamId',
               element: <Navigate to="dashboard" replace />,

--- a/src/types/DTO/advisorDto.ts
+++ b/src/types/DTO/advisorDto.ts
@@ -1,0 +1,52 @@
+import type { MemberType } from 'types/MemberType';
+
+import type { SubmissionFileResponseDto } from './submissionDto';
+
+export type AdvisorRoleType = Extract<MemberType, 'ROLE_교수' | 'ROLE_외부멘토'>;
+export type AdvisorFeedbackStatus = 'PENDING' | 'COMPLETED';
+
+export interface AdvisorProjectDto {
+  teamId: number;
+  teamName: string;
+  projectName: string;
+  trackName: string;
+  roleType: AdvisorRoleType;
+  pendingFeedbackCount: number;
+}
+
+export interface GetAdvisorProjectsResponseDto {
+  assignedTeamCount: number;
+  pendingFeedbackCount: number;
+  projects: AdvisorProjectDto[];
+}
+
+export interface AdvisorSubmissionDto {
+  submissionId: number;
+  submissionItemId: number;
+  submissionItemName: string;
+  feedbackStatus: AdvisorFeedbackStatus;
+  files: SubmissionFileResponseDto[];
+}
+
+export interface GetAdvisorTeamSubmissionsResponseDto {
+  teamId: number;
+  teamName: string;
+  projectName: string;
+  trackName: string;
+  pendingFeedbackCount: number;
+  submissions: AdvisorSubmissionDto[];
+}
+
+export interface AdvisorFeedbackDto {
+  feedbackId: number;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+  files: SubmissionFileResponseDto[];
+}
+
+export interface PutAdvisorFeedbackRequestDto {
+  description: string;
+  files?: File[];
+  removeFileIds?: number[];
+}

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,23 @@
+const getFileNameFromContentDisposition = (contentDisposition?: string) => {
+  if (!contentDisposition) {
+    return null;
+  }
+
+  const utf8FileName = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
+  if (utf8FileName) {
+    return decodeURIComponent(utf8FileName);
+  }
+
+  const fileName = contentDisposition.match(/filename="?([^"]+)"?/i)?.[1];
+  return fileName ? decodeURIComponent(fileName) : null;
+};
+
+export const downloadBlob = (blob: Blob, fallbackFileName: string, contentDisposition?: string) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = getFileNameFromContentDisposition(contentDisposition) ?? fallbackFileName;
+  link.click();
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
### 📝 개요

지도교수/외부 멘토가 마이페이지에서 본인 담당 팀의 제출물을 확인하고 피드백을 작성할 수 있는 `지도 활동` 페이지를 구현하였습니다. (멘토 활동 -> 지도 활동으로 UI 표현 변경)

### 🎯 목적

* 지도교수/외부 멘토가 본인에게 배정된 팀의 제출물을 확인할 수 있도록 합니다.
* 제출물별 피드백 작성/수정 및 첨부파일 관리를 지원합니다.
* 학생 마이페이지의 `나의 활동`과 유사하게, 지도교수/외부 멘토에게도 전용 활동 진입점을 제공합니다.
* 담당 팀 수와 피드백 대기 건수를 한눈에 확인할 수 있도록 합니다.

### ✨ 변경 사항

* 지도교수/외부 멘토 전용 활동 페이지 추가

  * `/me/advisor-activity`
  * `/me/advisor-activity/contests/:contestId`
* `ROLE_교수`, `ROLE_외부멘토` 사용자를 advisor 권한으로 판별하는 `isAdvisor` 플래그 추가
* 마이페이지 사이드바에 advisor 사용자 대상 `지도 활동` 메뉴 노출
* 담당 프로젝트 목록 및 대회 요약 UI 구현

  * 담당 팀 수
  * 피드백 대기 건수
  * 트랙/대회 태그
* 담당 프로젝트 카드 UI 구현

  * 프로젝트명, 팀명, 트랙, 담당 역할, 피드백 대기 건수 표시
  * 프로젝트 상세 페이지 이동 지원
* 프로젝트별 제출물 목록 조회 및 패널 UI 구현

  * 제출물 항목명
  * 피드백 상태
  * 제출 파일 목록
* 피드백 작성/수정 UI 구현

  * 피드백 본문 입력
  * 피드백 첨부파일 추가/삭제
  * 최대 5개 첨부 제한
* advisor 관련 API 및 React Query 옵션 추가

  * 담당 프로젝트 목록 조회
  * 팀 제출물 목록 조회
  * 내 피드백 단건 조회
  * 피드백 저장
  * 제출물/피드백 첨부파일 다운로드
* Blob 다운로드 공통 유틸 추가
* 권한 없음, 담당 대회 없음, 로딩, 에러 상태 UI 처리

### 💬 논의 사항
cc. @pykido 

1. 담당 대회 fallback 조회 방식

   현재 `/me/advisor-activity` 진입 시 `contestId`가 없으면 `currentContestOption()`으로 현재 대회를 fallback 조회하고 있는 상황. 멘토 명세에는 `contestId`가 포함된 API만 있는 상태라, 이 fallback은 명세 밖의 편의 로직임.

   추후 담당 대회 목록 API가 제공된다면 다음 흐름으로 변경하는 것이 더 정확해 보임.

   * 로그인한 advisor의 담당 대회 목록 조회
   * 담당 대회가 1개면 해당 대회 자동 선택
   * 담당 대회가 여러 개면 사이드바/탭/셀렉트로 명시 선택
   * 담당 대회가 없으면 empty state 표시

2. 피드백 단건 조회 404 처리 범위

   현재 내 피드백 단건 조회 API에서 404를 모두 `작성된 피드백 없음`으로 처리하고 있는 중. 만약 백엔드 명세상 404가 다음 경우까지 포함한다면 실제 오류를 숨길 수 있음.

   * 제출물 자체가 없음
   * 권한 대상이 아닌 제출물임
   * 대회/팀/제출물 관계가 올바르지 않음

   따라서 `작성된 피드백 없음`과 `접근 불가/리소스 없음`을 구분할 수 있도록 백엔드 응답 코드 또는 에러 코드를 확인하면 각 상황별 표시 개선할 수 있을 듯 함.
