### PR TITLE
feat: 제출 현황 파일 다운로드 기능 추가

### DIFF
--- a/src/apis/submission.ts
+++ b/src/apis/submission.ts
@@ -173,13 +173,17 @@ export const getSubmissionDownloads = async (contestId: number) => {
   return res.data;
 };
 
-/** 제출 파일 여러개 다운로드 (zip blob) — Content-Disposition 파일명을 위해 응답 전체 반환 */
+/** 분과별 제출 파일 일괄 다운로드 (zip blob) — Content-Disposition 파일명을 위해 응답 전체 반환 */
 export const postSubmissionDownloads = (contestId: number, targets: SubmissionDownloadTargetDto[]) =>
   apiClient.post<Blob>(`/contests/${contestId}/submissions/downloads`, { targets }, { responseType: 'blob' });
 
 /** 제출 파일 단건 다운로드 (blob) — Content-Disposition 파일명을 위해 응답 전체 반환 */
 export const getSubmissionFileDownload = (contestId: number, submissionId: number, fileId: number) =>
   apiClient.get<Blob>(`/contests/${contestId}/submissions/${submissionId}/files/${fileId}`, { responseType: 'blob' });
+
+/** 제출 파일 일괄 다운로드 (zip blob) — Content-Disposition 파일명을 위해 응답 전체 반환 */
+export const getSubmissionFilesDownload = (contestId: number, submissionId: number) =>
+  apiClient.get<Blob>(`/contests/${contestId}/submissions/${submissionId}/files`, { responseType: 'blob' });
 
 /** 피드백 첨부파일 단건 다운로드 (blob) — Content-Disposition 파일명을 위해 응답 전체 반환 */
 export const getFeedbackFileDownload = (contestId: number, submissionId: number, feedbackId: number, fileId: number) =>

--- a/src/constants/submission.ts
+++ b/src/constants/submission.ts
@@ -45,18 +45,18 @@ export const VISIBILITY_LABEL: Record<SubmissionVisibility, string> = {
   PUBLIC: '전체 공개',
   MEMBER: '회원 전체',
   STAFF: '대회 관계자',
-  PRIVATE: '제출 팀만',
+  TEAM: '제출 팀만',
 };
 
 /** 공개 범위 선택 옵션 순서 */
-export const VISIBILITY_OPTIONS: SubmissionVisibility[] = ['PUBLIC', 'MEMBER', 'STAFF', 'PRIVATE'];
+export const VISIBILITY_OPTIONS: SubmissionVisibility[] = ['PUBLIC', 'MEMBER', 'STAFF', 'TEAM'];
 
 /** 공개 범위 설명 (툴팁용) */
 export const VISIBILITY_DESCRIPTION: Record<SubmissionVisibility, string> = {
   PUBLIC: '비회원도 열람할 수 있습니다.',
   MEMBER: '로그인한 모든 회원이 열람할 수 있습니다.',
   STAFF: '팀원, 지도교수, 심사위원, 멘토, 관리자가 열람할 수 있습니다.',
-  PRIVATE: '제출 팀의 팀원과 관리자만 열람할 수 있습니다.',
+  TEAM: '제출 팀의 팀원과 관리자만 열람할 수 있습니다.',
 };
 
 /** 허용 파일 형식(enum) → 확장자 */

--- a/src/pages/admin/submission-manage/components/SubmissionFormModal.tsx
+++ b/src/pages/admin/submission-manage/components/SubmissionFormModal.tsx
@@ -42,7 +42,7 @@ const createDefaultValues = (): SubmissionFormValues => ({
   startAt: dayjs().hour(0).minute(0).second(0).format(LOCAL_DATETIME_FORMAT),
   endAt: dayjs().hour(23).minute(59).second(0).format(LOCAL_DATETIME_FORMAT),
   allowLateSubmission: true,
-  visibility: 'PRIVATE',
+  visibility: 'TEAM',
 });
 
 /** 폼 값을 요청 DTO로 변환 */

--- a/src/pages/admin/submission-manage/components/SubmissionStatusTab.tsx
+++ b/src/pages/admin/submission-manage/components/SubmissionStatusTab.tsx
@@ -10,7 +10,7 @@ import { Sheet, SheetContent, SheetTitle } from '@components/ui/sheet';
 import { useToast } from '@hooks/useToast';
 import { useContestIdOrRedirect } from '@hooks/useId';
 import { cn } from '@components/lib/utils';
-import { getFeedbackFileDownload, getSubmissionFileDownload } from '@apis/submission';
+import { getFeedbackFileDownload, getSubmissionFileDownload, getSubmissionFilesDownload } from '@apis/submission';
 import { submissionDetailOption, submissionFeedbacksOption, submissionStatusesOption } from '@queries/submission';
 import { downloadFromResponse } from '@utils/download';
 import { getApiErrorMessage } from '@utils/error';
@@ -66,6 +66,17 @@ export const SubmissionStatusTab = ({ initialTypeFilter = '' }: SubmissionStatus
       downloadFromResponse(response, file.fileName);
     } catch (error) {
       toast(getApiErrorMessage(error, '파일 다운로드에 실패했어요.'), 'error');
+    }
+  };
+
+  // 제출물 파일 전체 다운로드 (zip)
+  const handleDownloadSubmission = async (submission: SubmissionStatusResponseDto) => {
+    if (submission.submissionId === null) return;
+    try {
+      const response = await getSubmissionFilesDownload(contestId, submission.submissionId);
+      downloadFromResponse(response, `${submission.teamName}_${submission.submissionItemName}.zip`);
+    } catch (error) {
+      toast(getApiErrorMessage(error, '제출물 다운로드에 실패했어요.'), 'error');
     }
   };
 
@@ -283,7 +294,7 @@ export const SubmissionStatusTab = ({ initialTypeFilter = '' }: SubmissionStatus
                         variant="solid"
                         disabled={submission.submissionId === null}
                         icon={<Download size={16} />}
-                        onClick={() => toast('제출물을 다운로드했습니다.', 'success')}
+                        onClick={() => handleDownloadSubmission(submission)}
                       />
                     </div>
                   </td>

--- a/src/types/DTO/submissionDto.ts
+++ b/src/types/DTO/submissionDto.ts
@@ -2,7 +2,7 @@
 export type SubmissionOperationStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'CLOSED';
 
 /** 제출물 공개 범위 (SubmissionVisibility Enum) */
-export type SubmissionVisibility = 'PUBLIC' | 'MEMBER' | 'STAFF' | 'PRIVATE';
+export type SubmissionVisibility = 'PUBLIC' | 'MEMBER' | 'STAFF' | 'TEAM';
 
 /** 허용 파일 형식 (SubmissionFileFormat Enum) */
 export type SubmissionFileFormat =


### PR DESCRIPTION
### ✨ 변경 사항
- **제출 파일 일괄 다운로드 연동**: 제출 현황 탭의 다운로드 버튼을 실제 API(`GET /contests/{contestId}/submissions/{submissionId}/files`)에 연결. zip으로 받아 `팀이름_제출항목명.zip`으로 저장하고, 실패 시 에러 toast 노출
- **공개 범위 ENUM 수정**: "제출 팀만"에 잘못 매핑돼 있던 ENUM 값 수정