### PR TITLE
feat: 지도자 활동 페이지 API 수정 처리

### DIFF
--- a/src/apis/advisor.ts
+++ b/src/apis/advisor.ts
@@ -37,7 +37,7 @@ export const getAdvisorTeamSubmissions = async (
   teamId: number,
 ): Promise<GetAdvisorTeamSubmissionsResponseDto> => {
   const res = await apiClient.get<GetAdvisorTeamSubmissionsResponseDto>(
-    `/mentors/me/contests/${contestId}/teams/${teamId}/submissions `,
+    `/mentors/me/contests/${contestId}/teams/${teamId}/submissions`,
   );
   return res.data;
 };

--- a/src/apis/advisor.ts
+++ b/src/apis/advisor.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosResponse } from 'axios';
 
 import type {
   AdvisorFeedbackDto,
+  GetAdvisorContestsResponseDto,
   GetAdvisorProjectsResponseDto,
   GetAdvisorTeamSubmissionsResponseDto,
   PutAdvisorFeedbackRequestDto,
@@ -21,8 +22,13 @@ const createAdvisorFeedbackFormData = ({
   return formData;
 };
 
+export const getAdvisorContests = async (): Promise<GetAdvisorContestsResponseDto> => {
+  const res = await apiClient.get<GetAdvisorContestsResponseDto>('/mentors/me/contests');
+  return res.data;
+};
+
 export const getAdvisorProjects = async (contestId: number): Promise<GetAdvisorProjectsResponseDto> => {
-  const res = await apiClient.get<GetAdvisorProjectsResponseDto>(`/contests/${contestId}/mentor/projects`);
+  const res = await apiClient.get<GetAdvisorProjectsResponseDto>(`/mentors/me/contests/${contestId}/teams`);
   return res.data;
 };
 
@@ -31,7 +37,7 @@ export const getAdvisorTeamSubmissions = async (
   teamId: number,
 ): Promise<GetAdvisorTeamSubmissionsResponseDto> => {
   const res = await apiClient.get<GetAdvisorTeamSubmissionsResponseDto>(
-    `/contests/${contestId}/teams/${teamId}/submissions`,
+    `/mentors/me/contests/${contestId}/teams/${teamId}/submissions `,
   );
   return res.data;
 };

--- a/src/constants/myPageSidebarData.ts
+++ b/src/constants/myPageSidebarData.ts
@@ -1,9 +1,9 @@
-import type { CurrentContestResponseDto } from '@dto/contestsDto';
+import type { AdvisorContestDto } from '@dto/advisorDto';
 import type { MyProjectDto } from '@dto/meDto';
 import type { LayoutSidebarSection } from '@layout/common/LayoutSideBar';
 
 interface CreateMyPageSidebarDataOptions {
-  currentContests?: CurrentContestResponseDto[];
+  advisorContests?: AdvisorContestDto[];
   showAdvisorActivity?: boolean;
 }
 
@@ -60,7 +60,7 @@ export const createMyPageSidebarData = (
       label: '지도 활동',
       icon: 'advisorActivity',
       activePaths: ['/me/advisor-activity'],
-      links: options.currentContests?.map(({ contestId, contestName }) => ({
+      links: options.advisorContests?.map(({ contestId, contestName }) => ({
         key: `advisor-contest-${contestId}`,
         to: `advisor-activity/contests/${contestId}`,
         label: contestName,

--- a/src/layout/me/MyPageLayout.tsx
+++ b/src/layout/me/MyPageLayout.tsx
@@ -6,7 +6,7 @@ import LayoutSideBar from '@layout/common/LayoutSideBar';
 import { createMyPageSidebarData } from '@constants/myPageSidebarData';
 import useAuth from '@hooks/useAuth';
 import { getMyProjects } from '@apis/me';
-import { currentContestOption } from '@queries/contest';
+import { advisorContestsOption } from '@queries/advisor';
 import { MY_PROJECTS_QUERY_KEY } from '@queries/me';
 
 const MyPageLayout = () => {
@@ -17,15 +17,14 @@ const MyPageLayout = () => {
     enabled: isSignedIn,
     staleTime: 5 * 60 * 1000,
   });
-  const { data: currentContests = [] } = useQuery({
-    ...currentContestOption(),
+  const { data: advisorContests = [] } = useQuery({
+    ...advisorContestsOption(),
     enabled: isSignedIn && isAdvisor,
-    staleTime: 5 * 60 * 1000,
   });
   const myProjects = useMemo(() => fetchedMyProjects ?? [], [fetchedMyProjects]);
   const sidebarSections = useMemo(
-    () => createMyPageSidebarData(myProjects, { currentContests, showAdvisorActivity: isAdvisor }),
-    [currentContests, isAdvisor, myProjects],
+    () => createMyPageSidebarData(myProjects, { advisorContests, showAdvisorActivity: isAdvisor }),
+    [advisorContests, isAdvisor, myProjects],
   );
 
   if (!isSignedIn) {

--- a/src/pages/me/advisor-activity/AdvisorActivityPage.tsx
+++ b/src/pages/me/advisor-activity/AdvisorActivityPage.tsx
@@ -7,12 +7,12 @@ import { getAdvisorFeedbackFile, getAdvisorSubmissionFile, putAdvisorFeedback } 
 import useAuth from '@hooks/useAuth';
 import { useToast } from '@hooks/useToast';
 import {
+  advisorContestsOption,
   advisorFeedbackOption,
   advisorProjectsOption,
   advisorTeamSubmissionsOption,
   invalidateAdvisorActivityQueries,
 } from '@queries/advisor';
-import { currentContestOption } from '@queries/contest';
 import { downloadBlob } from '@utils/download';
 
 import { AdvisorContestSummary } from './components/AdvisorContestSummary';
@@ -52,21 +52,28 @@ const AdvisorActivityPage = () => {
   const [pendingFeedbackFiles, setPendingFeedbackFiles] = useState<Record<number, AdvisorSubmissionFile[]>>({});
   const [removedFeedbackFileIds, setRemovedFeedbackFileIds] = useState<Record<number, number[]>>({});
 
-  const currentContestQuery = useQuery({
-    ...currentContestOption(),
-    enabled: isAdvisor && requestedContestId === null,
+  const advisorContestsQuery = useQuery({
+    ...advisorContestsOption(),
+    enabled: isAdvisor,
   });
-  const defaultContest = currentContestQuery.data?.[0];
-  const contestId = requestedContestId ?? defaultContest?.contestId ?? null;
+  const advisorContests = useMemo(() => advisorContestsQuery.data ?? [], [advisorContestsQuery.data]);
+  const selectedContest = useMemo(() => {
+    if (requestedContestId === null) {
+      return advisorContests[0] ?? null;
+    }
+
+    return advisorContests.find((contest) => contest.contestId === requestedContestId) ?? null;
+  }, [advisorContests, requestedContestId]);
+  const contestId = selectedContest?.contestId ?? null;
 
   const advisorProjectsQuery = useQuery({
     ...advisorProjectsOption(contestId ?? 0),
     enabled: isAdvisor && contestId !== null,
   });
-  const projectsResponse = advisorProjectsQuery.data;
+  const advisorProjects = useMemo(() => advisorProjectsQuery.data ?? [], [advisorProjectsQuery.data]);
 
   useEffect(() => {
-    const firstProject = projectsResponse?.projects[0];
+    const firstProject = advisorProjects[0];
 
     if (!firstProject) {
       setExpandedTeamId(null);
@@ -74,10 +81,10 @@ const AdvisorActivityPage = () => {
     }
 
     setExpandedTeamId((currentTeamId) => {
-      const currentProjectExists = projectsResponse.projects.some((project) => project.teamId === currentTeamId);
+      const currentProjectExists = advisorProjects.some((project) => project.teamId === currentTeamId);
       return currentProjectExists ? currentTeamId : firstProject.teamId;
     });
-  }, [projectsResponse?.projects]);
+  }, [advisorProjects]);
 
   const teamSubmissionsQuery = useQuery({
     ...advisorTeamSubmissionsOption(contestId ?? 0, expandedTeamId ?? 0),
@@ -165,58 +172,57 @@ const AdvisorActivityPage = () => {
         submissionId: selectedSubmissionId,
       }));
   }, [removedFeedbackFileIds, selectedFeedback, selectedSubmissionId]);
-  const contestTitle =
-    defaultContest && defaultContest.contestId === contestId ? defaultContest.contestName : '지도 활동';
+  const contestTitle = selectedContest?.contestName ?? '지도 활동';
 
   const advisorActivity: AdvisorActivityContest = useMemo(() => {
-    const projects: AdvisorProject[] =
-      projectsResponse?.projects.map((project) => {
-        const isExpanded = project.teamId === expandedTeamId;
-        const submissions =
-          isExpanded && teamSubmissions
-            ? teamSubmissions.submissions.map((submission) => {
-                const isSelected = submission.submissionId === selectedSubmissionId;
-                const pendingFiles = pendingFeedbackFiles[submission.submissionId] ?? [];
+    const projects: AdvisorProject[] = advisorProjects.map((project) => {
+      const isExpanded = project.teamId === expandedTeamId;
+      const submissions =
+        isExpanded && teamSubmissions
+          ? teamSubmissions.submissions.map((submission) => {
+              const isSelected = submission.submissionId === selectedSubmissionId;
+              const pendingFiles = pendingFeedbackFiles[submission.submissionId] ?? [];
 
-                return {
-                  ...submission,
-                  feedbackFiles: isSelected ? [...serverFeedbackFiles, ...pendingFiles] : pendingFiles,
-                  files: submission.files.map((file) => ({
-                    ...file,
-                    source: 'submission' as const,
-                    submissionId: submission.submissionId,
-                  })),
-                  isFeedbackLoading: isSelected && advisorFeedbackQuery.isLoading,
-                };
-              })
-            : [];
+              return {
+                ...submission,
+                feedbackFiles: isSelected ? [...serverFeedbackFiles, ...pendingFiles] : pendingFiles,
+                files: submission.files.map((file) => ({
+                  ...file,
+                  source: 'submission' as const,
+                  submissionId: submission.submissionId,
+                })),
+                isFeedbackLoading: isSelected && advisorFeedbackQuery.isLoading,
+              };
+            })
+          : [];
 
-        return { ...project, submissions };
-      }) ?? [];
+      return { ...project, submissions };
+    });
 
     const contestTags =
-      contestId === null
+      selectedContest === null
         ? ['대회 미선택']
-        : [`대회 #${contestId}`, ...Array.from(new Set(projects.map((project) => project.trackName)))];
+        : Array.from(new Set([selectedContest.categoryName, ...selectedContest.assignedTrackNames])).filter(Boolean);
 
     return {
-      assignedTeamCount: projectsResponse?.assignedTeamCount ?? 0,
+      assignedTeamCount: selectedContest?.totalAssignedTeamCount ?? projects.length,
       contestId: contestId ?? 0,
       contestName: contestTitle,
-      pendingFeedbackCount: projectsResponse?.pendingFeedbackCount ?? 0,
+      pendingFeedbackCount:
+        selectedContest?.totalPendingFeedbackCount ??
+        projects.reduce((total, project) => total + project.pendingFeedbackCount, 0),
       projects,
       tags: contestTags,
     };
   }, [
+    advisorProjects,
     advisorFeedbackQuery.isLoading,
     contestId,
     contestTitle,
     expandedTeamId,
     pendingFeedbackFiles,
-    projectsResponse?.assignedTeamCount,
-    projectsResponse?.pendingFeedbackCount,
-    projectsResponse?.projects,
     selectedSubmissionId,
+    selectedContest,
     serverFeedbackFiles,
     teamSubmissions,
   ]);
@@ -230,16 +236,16 @@ const AdvisorActivityPage = () => {
     );
   }
 
-  if (currentContestQuery.isLoading && requestedContestId === null) {
+  if (advisorContestsQuery.isLoading) {
     return <AdvisorActivitySkeleton />;
   }
 
-  if (currentContestQuery.isError && requestedContestId === null) {
+  if (advisorContestsQuery.isError) {
     return (
       <AdvisorActivityMessage
-        title="대회 정보를 불러오지 못했습니다."
+        title="담당 대회 정보를 불러오지 못했습니다."
         description="잠시 후 다시 시도해주세요."
-        onRetry={() => void currentContestQuery.refetch()}
+        onRetry={() => void advisorContestsQuery.refetch()}
       />
     );
   }
@@ -247,8 +253,12 @@ const AdvisorActivityPage = () => {
   if (contestId === null) {
     return (
       <AdvisorActivityMessage
-        title="담당 대회가 없습니다."
-        description="현재 진행 중인 대회가 없거나 지도 활동을 확인할 대회를 찾지 못했습니다."
+        title={requestedContestId === null ? '담당 대회가 없습니다.' : '담당 대회를 찾지 못했습니다.'}
+        description={
+          requestedContestId === null
+            ? '지도 활동을 확인할 담당 대회가 없습니다.'
+            : '선택한 대회의 지도 활동 권한을 확인할 수 없습니다.'
+        }
       />
     );
   }

--- a/src/queries/advisor.ts
+++ b/src/queries/advisor.ts
@@ -1,8 +1,15 @@
 import { queryOptions, type QueryClient } from '@tanstack/react-query';
 
-import { getAdvisorProjects, getAdvisorTeamSubmissions, getMyAdvisorFeedback } from '@apis/advisor';
+import { getAdvisorContests, getAdvisorProjects, getAdvisorTeamSubmissions, getMyAdvisorFeedback } from '@apis/advisor';
 
 export const ADVISOR_ACTIVITY_QUERY_KEY = ['advisorActivity'] as const;
+
+export const advisorContestsOption = () =>
+  queryOptions({
+    queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'contests'],
+    queryFn: getAdvisorContests,
+    staleTime: 3 * 60 * 1000,
+  });
 
 export const advisorProjectsOption = (contestId: number) =>
   queryOptions({
@@ -32,6 +39,7 @@ export const invalidateAdvisorActivityQueries = (
   submissionId?: number,
 ) =>
   Promise.all([
+    queryClient.invalidateQueries({ queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'contests'] }),
     queryClient.invalidateQueries({ queryKey: [...ADVISOR_ACTIVITY_QUERY_KEY, 'projects', contestId] }),
     teamId
       ? queryClient.invalidateQueries({

--- a/src/types/DTO/advisorDto.ts
+++ b/src/types/DTO/advisorDto.ts
@@ -14,11 +14,18 @@ export interface AdvisorProjectDto {
   pendingFeedbackCount: number;
 }
 
-export interface GetAdvisorProjectsResponseDto {
-  assignedTeamCount: number;
-  pendingFeedbackCount: number;
-  projects: AdvisorProjectDto[];
+export interface AdvisorContestDto {
+  contestId: number;
+  contestName: string;
+  categoryName: string;
+  assignedTrackNames: string[];
+  totalPendingFeedbackCount: number;
+  totalAssignedTeamCount: number;
 }
+
+export type GetAdvisorContestsResponseDto = AdvisorContestDto[];
+
+export type GetAdvisorProjectsResponseDto = AdvisorProjectDto[];
 
 export interface AdvisorSubmissionDto {
   submissionId: number;


### PR DESCRIPTION
### 📝 개요
백엔드 지도자 활동 API 변경에 맞춰 지도자가 담당하는 대회 전체를 기준으로 지도 활동 페이지의 API 호출, DTO, 쿼리, 사이드바 데이터를 수정하였습니다.

### 🎯 목적
기존 현재 대회 기준 조회 방식에서 벗어나, 지도교수/외부멘토가 본인에게 배정된 모든 담당 대회의 팀과 제출물을 대회별로 확인하고 피드백을 관리할 수 있도록 합니다.

### ✨ 변경 사항
- 지도자 담당 대회 전체 조회 API 추가
- 지도자 활동 관련 API 경로를 `/mentors/me/contests` 기준으로 변경
- 담당 대회, 담당 팀, 제출물 응답 DTO 구조 수정
- 마이페이지 사이드바의 지도 활동 하위 메뉴를 담당 대회 전체 목록 기반으로 표시
- 선택한 담당 대회별 팀 목록, 제출물, 피드백 조회가 가능하도록 지도자 활동 페이지 로직 수정
- 지도자 활동 요약 정보에 담당 대회별 팀 수, 피드백 대기 수, 카테고리/트랙 정보 반영
- 피드백 저장 후 담당 대회/팀/제출물/피드백 쿼리가 함께 갱신되도록 처리

### 📸 참고 이미지/영상
- 이전과 동일