### PR TITLE
fix: 관리자 사이드바 대회 선택 상태 초기화

### DIFF
--- a/src/layout/admin/AdminSidebar.tsx
+++ b/src/layout/admin/AdminSidebar.tsx
@@ -104,13 +104,13 @@ const AdminSidebar = () => {
       className="border-lightGray fixed top-0 bottom-0 left-0 z-30 flex w-[272px] flex-col border-r bg-white"
     >
       <div className="h-header flex items-center justify-center px-6">
-        <Link to="/admin" aria-label="관리자 대시보드로 이동" className="flex items-center justify-center">
+        <Link to="/admin" aria-label="관리자 대시보드로 이동" className="flex items-center justify-center" replace>
           <img src={logoOpusAdmin} alt="OPUS Admin" className="h-14 w-auto max-w-[196px]" />
         </Link>
       </div>
 
       <nav className="min-h-0 flex-1 overflow-y-auto py-5">
-        <NavLink to="/admin" end className={dashboardLinkClass}>
+        <NavLink to="/admin" end className={dashboardLinkClass} replace>
           <LayoutGrid className="h-5 w-5 text-gray-500" strokeWidth={1.8} />
           <span>대시보드</span>
         </NavLink>
@@ -147,7 +147,7 @@ const AdminContestSidebarContent = () => {
   }, [activeSectionTitle]);
 
   const handleContestChange = (nextContestId: string) => {
-    navigate(`/admin/contest/${nextContestId}`);
+    navigate(`/admin/contest/${nextContestId}`, { replace: true });
   };
 
   const handleSectionOpen = (sectionTitle: string) => {

--- a/src/layout/admin/AdminSidebar.tsx
+++ b/src/layout/admin/AdminSidebar.tsx
@@ -138,7 +138,7 @@ const AdminContestSidebarContent = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { data: contests } = useSuspenseQuery(contestsOption());
-  const selectedContestId = contestId?.toString();
+  const selectedContestId = contestId?.toString() ?? '';
   const activeSectionTitle = getActiveSectionTitle(location.pathname, selectedContestId);
   const [openSectionTitle, setOpenSectionTitle] = useState<string | null>(activeSectionTitle);
 
@@ -183,7 +183,7 @@ const AdminContestSidebarContent = () => {
         {adminSidebarSections.map((section) => (
           <AdminSidebarSection
             key={section.title}
-            contestId={selectedContestId}
+            contestId={selectedContestId || undefined}
             isActive={activeSectionTitle === section.title}
             isOpen={openSectionTitle === section.title}
             section={section}


### PR DESCRIPTION
### 📝 개요

관리자 사이드바에서 `contestId`가 없는 경로(`/admin`)로 이동했을 때, 대회 선택 UI가 이전 선택값처럼 남아 보일 수 있는 문제를 수정했습니다.

### 🎯 목적

`useContestId()`에서 가져온 `contestId`는 URL에 따라 존재하지 않을 수 있습니다.
이때 Select 컴포넌트에는 `undefined`가 아닌 빈 문자열(`''`)을 전달해 선택되지 않은 상태를 명확히 표현하고, 하위 메뉴 컴포넌트에는 빈 문자열 대신 `undefined`를 전달해 “대회가 선택되지 않음” 상태를 의미적으로 유지하고자 했습니다.

### ✨ 변경 사항

* `selectedContestId`가 `undefined`가 되지 않도록 `contestId?.toString() ?? ''`로 정규화
* Select의 controlled value가 항상 문자열을 받도록 수정
* AdminSidebarSection에는 `selectedContestId || undefined`를 전달하여 빈 문자열을 대회 ID로 넘기지 않도록 수정
* 대회가 선택되지 않은 상태에서 기존 하위 메뉴 비활성/토스트 동작이 유지되도록 정리
* 메뉴 탐색 시 이동 경로가 브라우저 히스토리에 계속 누적되어, 관리자 사이드바 메뉴 이동에 `replace` 속성을 추가하였습니다.

### 💬 논의 사항

현재 구조에서는 URL을 source of truth로 두고 사이드바 상태를 파생시키는 방식으로 정리했습니다.