### PR TITLE
feat: OPUS 메인 공지사항 및 프로젝트 아카이브 UI 개선

### DIFF
--- a/src/pages/main/ArchiveProjectSection.tsx
+++ b/src/pages/main/ArchiveProjectSection.tsx
@@ -1,0 +1,107 @@
+import { Link } from 'react-router-dom';
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { type FallbackProps } from 'react-error-boundary';
+import { archiveProjectsOption } from '@queries/contest';
+
+const ArchiveGeometry = () => (
+  <span className="opus-archive-feature__geometry" aria-hidden="true">
+    {Array.from({ length: 24 }).map((_, index) => (
+      <span key={index} />
+    ))}
+  </span>
+);
+
+const ArchiveProjectSection = () => {
+  const queryClient = useQueryClient();
+  const { data: projects } = useSuspenseQuery(archiveProjectsOption(queryClient));
+
+  if (projects.length === 0) return null;
+
+  const [featuredProject, ...compactProjects] = projects;
+  const moreProjectsPath = `/contest/${featuredProject.contestId}`;
+
+  return (
+    <section className="opus-archive-section" aria-labelledby="opus-archive-title">
+      <header className="opus-archive-section__header">
+        <p>ARCHIVE</p>
+        <h2 id="opus-archive-title">다시 보는 프로젝트</h2>
+      </header>
+
+      <div className="opus-archive-layout" data-layout={compactProjects.length > 0 ? 'split' : 'single'}>
+        <article className="opus-archive-feature">
+          <Link
+            to={`/contest/${featuredProject.contestId}/teams/view/${featuredProject.teamId}`}
+            className="opus-archive-feature__link"
+            aria-label={`${featuredProject.projectName} 프로젝트 보기`}
+          >
+            <span className="opus-archive-project__number" aria-hidden="true">
+              01
+            </span>
+            <ArchiveGeometry />
+            <h3>{featuredProject.projectName}</h3>
+            <p>{featuredProject.overview || '프로젝트 소개가 등록되지 않았습니다.'}</p>
+            <span className="opus-archive-project__meta">{featuredProject.contestName}</span>
+            <span className="opus-archive-project__cta" aria-hidden="true">
+              프로젝트 보기 <span>↗</span>
+            </span>
+          </Link>
+        </article>
+
+        {compactProjects.length > 0 && (
+          <ol className="opus-archive-compact" start={2}>
+            {compactProjects.map((project, index) => (
+              <li key={project.teamId}>
+                <Link
+                  to={`/contest/${project.contestId}/teams/view/${project.teamId}`}
+                  className="opus-archive-compact__link"
+                  aria-label={`${project.projectName} 프로젝트 보기`}
+                >
+                  <span className="opus-archive-project__number" aria-hidden="true">
+                    {String(index + 2).padStart(2, '0')}
+                  </span>
+                  <span className="opus-archive-compact__copy">
+                    <strong>{project.projectName}</strong>
+                    <span>{project.overview || '프로젝트 소개가 등록되지 않았습니다.'}</span>
+                    <small>{project.contestName}</small>
+                  </span>
+                  <span className="opus-archive-compact__arrow" aria-hidden="true">
+                    ↗
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+
+      <Link to={moreProjectsPath} className="opus-editorial-link opus-archive-section__more">
+        프로젝트 더 보기 <span aria-hidden="true">↗</span>
+      </Link>
+    </section>
+  );
+};
+
+export const ArchiveProjectSkeleton = () => (
+  <section className="opus-archive-section" aria-label="과거 프로젝트를 불러오는 중" aria-busy="true">
+    <header className="opus-archive-section__header">
+      <p>ARCHIVE</p>
+      <h2>다시 보는 프로젝트</h2>
+    </header>
+    <div className="opus-archive-skeleton" aria-hidden="true">
+      <span />
+      <span />
+      <span />
+    </div>
+  </section>
+);
+
+export const ArchiveProjectError = ({ resetErrorBoundary }: FallbackProps) => (
+  <section className="opus-archive-section opus-archive-section--error" role="alert">
+    <p>과거 프로젝트를 불러오지 못했습니다.</p>
+    <button type="button" onClick={resetErrorBoundary}>
+      다시 시도 ↗
+    </button>
+  </section>
+);
+
+export default ArchiveProjectSection;

--- a/src/pages/main/CampusNoticeHologram.tsx
+++ b/src/pages/main/CampusNoticeHologram.tsx
@@ -8,7 +8,7 @@ const CampusNoticeHologram = ({ onExploreContests }: CampusNoticeHologramProps) 
       <header className="opus-campus-news__header">
         <div>
           <span className="opus-campus-news__signal" aria-hidden="true" />
-          <strong>PNU SIGNAL</strong>
+          <strong>OPUS SIGNAL</strong>
         </div>
 
         <span className="opus-campus-news__live">LIVE</span>

--- a/src/pages/main/CurrentContestSection.tsx
+++ b/src/pages/main/CurrentContestSection.tsx
@@ -1,10 +1,35 @@
 import { Link } from 'react-router-dom';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { type FallbackProps } from 'react-error-boundary';
 import dayjs from 'dayjs';
 import { contestsOption, currentContestOption } from '@queries/contest';
 import { type CurrentContestResponseDto } from '@dto/contestsDto';
 
 const geometryPatterns = ['dots', 'lines', 'arc', 'quarter'] as const;
+
+export const ContestGridSkeleton = () => (
+  <div className="opus-contest-skeleton" aria-label="대회 목록을 불러오는 중" aria-busy="true">
+    {Array.from({ length: 4 }).map((_, index) => (
+      <div key={index} className="opus-contest-skeleton__item" aria-hidden="true">
+        <div className="opus-contest-skeleton__line" />
+        <div className="opus-contest-skeleton__line" />
+        <div className="opus-contest-skeleton__line" />
+      </div>
+    ))}
+  </div>
+);
+
+export const ContestGridError = ({ resetErrorBoundary }: FallbackProps) => (
+  <section className="opus-contest-error" role="alert" aria-labelledby="contest-error-title">
+    <p className="opus-contest-error__number" aria-hidden="true">
+      !
+    </p>
+    <h2 id="contest-error-title">대회 정보를 불러오지 못했습니다.</h2>
+    <button type="button" onClick={resetErrorBoundary}>
+      다시 시도 ↗
+    </button>
+  </section>
+);
 
 const getGeometryPieceCount = (pattern: (typeof geometryPatterns)[number]) => {
   if (pattern === 'dots') return 40;

--- a/src/pages/main/EditorialHome.css
+++ b/src/pages/main/EditorialHome.css
@@ -413,6 +413,175 @@ html {
   font-weight: 700;
 }
 
+.opus-signal-section {
+  padding: 30px clamp(28px, 4.2vw, 64px) 34px;
+  border-bottom: 1px solid var(--opus-home-line);
+}
+
+.opus-signal-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(229, 240, 252, 0.28);
+}
+
+.opus-signal-section__header > div {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.opus-signal-section__header h2,
+.opus-signal-section__skeleton-heading {
+  margin: 0;
+  color: var(--opus-home-ink);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.18em;
+}
+
+.opus-signal-section__header > span {
+  color: var(--opus-home-cyan);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.opus-signal-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.opus-signal-list li {
+  border-bottom: 1px solid rgba(229, 240, 252, 0.18);
+}
+
+.opus-signal-list__link {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: clamp(18px, 3vw, 42px);
+  min-height: 72px;
+  padding: 12px 2px;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    color 160ms ease,
+    padding 180ms ease;
+}
+
+.opus-signal-list__link:hover,
+.opus-signal-list__link:focus-visible {
+  padding-right: 8px;
+  padding-left: 8px;
+  color: var(--opus-home-cyan);
+}
+
+.opus-signal-list__link:focus-visible,
+.opus-editorial-link:focus-visible {
+  outline: 2px solid var(--opus-home-cyan);
+  outline-offset: 4px;
+}
+
+.opus-signal-list__link time {
+  color: var(--opus-home-blue);
+  font-size: clamp(1rem, 1.55vw, 1.28rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 850;
+  letter-spacing: -0.02em;
+}
+
+.opus-signal-list__title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--opus-home-ink);
+  font-size: clamp(0.96rem, 1.55vw, 1.18rem);
+  font-weight: 680;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.opus-signal-list__arrow {
+  color: currentColor;
+  font-size: 1.12rem;
+  transition: transform 180ms ease;
+}
+
+.opus-signal-list__link:hover .opus-signal-list__arrow,
+.opus-signal-list__link:focus-visible .opus-signal-list__arrow,
+.opus-editorial-link:hover span,
+.opus-editorial-link:focus-visible span {
+  transform: translate(3px, -3px);
+}
+
+.opus-signal-section__empty {
+  margin: 0;
+  padding: 22px 2px 6px;
+  color: rgba(248, 246, 240, 0.54);
+  font-size: 0.86rem;
+}
+
+.opus-editorial-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+  padding: 8px 0;
+  border-bottom: 2px solid var(--opus-home-cyan);
+  color: var(--opus-home-ink);
+  font-size: 0.88rem;
+  font-weight: 780;
+  text-decoration: none;
+}
+
+.opus-editorial-link span {
+  display: inline-block;
+  transition: transform 180ms ease;
+}
+
+.opus-signal-skeleton {
+  display: flex;
+  flex-direction: column;
+}
+
+.opus-signal-skeleton span {
+  display: block;
+  width: 100%;
+  height: 72px;
+  border-bottom: 1px solid rgba(229, 240, 252, 0.18);
+  background: rgba(229, 240, 252, 0.08);
+  animation: opus-skeleton-pulse 1.15s ease-in-out infinite alternate;
+}
+
+.opus-signal-section--error {
+  display: flex;
+  min-height: 126px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.opus-signal-section--error p,
+.opus-archive-section--error p {
+  margin: 0;
+  color: var(--opus-home-muted);
+  font-size: 0.9rem;
+}
+
+.opus-signal-section--error button,
+.opus-archive-section--error button {
+  padding: 8px 0;
+  border: 0;
+  border-bottom: 2px solid var(--opus-home-cyan);
+  background: transparent;
+  color: var(--opus-home-ink);
+  font-weight: 750;
+}
+
 @keyframes opus-campus-news-loading {
   from {
     opacity: 0.45;
@@ -911,6 +1080,281 @@ html {
   margin-top: 0;
 }
 
+.opus-archive-section {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(48px, 7vw, 92px) clamp(28px, 4.2vw, 64px) clamp(52px, 7vw, 94px);
+  border-bottom: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-section__header {
+  display: grid;
+  grid-template-columns: minmax(100px, 0.3fr) minmax(0, 1fr);
+  align-items: end;
+  gap: clamp(22px, 4vw, 64px);
+  margin-bottom: clamp(34px, 5vw, 62px);
+}
+
+.opus-archive-section__header p {
+  margin: 0;
+  color: var(--opus-home-cyan);
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.22em;
+}
+
+.opus-archive-section__header h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4.4vw, 4.25rem);
+  line-height: 0.95;
+  font-weight: 850;
+  letter-spacing: -0.065em;
+  word-break: keep-all;
+}
+
+.opus-archive-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+  border-top: 1px solid var(--opus-home-line);
+  border-bottom: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-layout[data-layout='single'] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.opus-archive-feature {
+  min-width: 0;
+}
+
+.opus-archive-layout[data-layout='split'] .opus-archive-feature {
+  border-right: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-feature__link {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 360px;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow: hidden;
+  padding: clamp(28px, 4vw, 54px);
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 200ms ease;
+}
+
+.opus-archive-feature__link:hover,
+.opus-archive-feature__link:focus-visible,
+.opus-archive-compact__link:hover,
+.opus-archive-compact__link:focus-visible {
+  background: var(--opus-home-navy-raised);
+}
+
+.opus-archive-feature__link:focus-visible,
+.opus-archive-compact__link:focus-visible {
+  z-index: 2;
+  outline: 2px solid var(--opus-home-cyan);
+  outline-offset: -4px;
+}
+
+.opus-archive-project__number {
+  color: var(--opus-home-blue);
+  font-size: clamp(2rem, 3.4vw, 3.5rem);
+  line-height: 0.8;
+  font-weight: 850;
+  letter-spacing: -0.07em;
+}
+
+.opus-archive-feature h3 {
+  position: relative;
+  z-index: 1;
+  max-width: 17ch;
+  margin: clamp(48px, 7vw, 82px) 0 14px;
+  font-size: clamp(1.65rem, 3.1vw, 3rem);
+  line-height: 1.1;
+  font-weight: 820;
+  letter-spacing: -0.05em;
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}
+
+.opus-archive-feature p {
+  position: relative;
+  z-index: 1;
+  display: -webkit-box;
+  max-width: 56ch;
+  margin: 0 0 12px;
+  overflow: hidden;
+  color: var(--opus-home-muted);
+  font-size: 0.94rem;
+  line-height: 1.6;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.opus-archive-project__meta {
+  position: relative;
+  z-index: 1;
+  color: var(--opus-home-cyan);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+}
+
+.opus-archive-project__cta {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: auto;
+  padding-top: 28px;
+  font-size: 0.88rem;
+  font-weight: 760;
+}
+
+.opus-archive-project__cta span,
+.opus-archive-compact__arrow {
+  display: inline-block;
+  transition: transform 180ms ease;
+}
+
+.opus-archive-feature__link:hover .opus-archive-project__cta span,
+.opus-archive-feature__link:focus-visible .opus-archive-project__cta span,
+.opus-archive-compact__link:hover .opus-archive-compact__arrow,
+.opus-archive-compact__link:focus-visible .opus-archive-compact__arrow {
+  transform: translate(3px, -3px);
+}
+
+.opus-archive-feature__geometry {
+  position: absolute;
+  z-index: 0;
+  top: 42px;
+  right: clamp(30px, 4vw, 62px);
+  display: grid;
+  grid-template-columns: repeat(6, 4px);
+  gap: 10px 13px;
+  color: var(--opus-home-blue);
+  opacity: 0.62;
+  transition: transform 240ms ease;
+}
+
+.opus-archive-feature__geometry span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.opus-archive-feature__link:hover .opus-archive-feature__geometry,
+.opus-archive-feature__link:focus-visible .opus-archive-feature__geometry {
+  transform: translate(-5px, 5px);
+}
+
+.opus-archive-compact {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.opus-archive-compact li + li {
+  border-top: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-compact__link {
+  display: grid;
+  min-height: 180px;
+  grid-template-columns: 54px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 18px;
+  padding: clamp(26px, 3vw, 38px);
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 200ms ease;
+}
+
+.opus-archive-compact .opus-archive-project__number {
+  padding-top: 4px;
+  color: var(--opus-home-cyan);
+  font-size: 1.15rem;
+}
+
+.opus-archive-compact__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.opus-archive-compact__copy strong {
+  overflow: hidden;
+  font-size: clamp(1.05rem, 1.7vw, 1.35rem);
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.opus-archive-compact__copy > span {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--opus-home-muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.opus-archive-compact__copy small {
+  overflow: hidden;
+  color: var(--opus-home-cyan);
+  font-size: 0.66rem;
+  font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.opus-archive-compact__arrow {
+  color: var(--opus-home-cyan);
+  font-size: 1rem;
+}
+
+.opus-archive-section__more {
+  margin-top: 30px;
+}
+
+.opus-archive-skeleton {
+  display: grid;
+  min-height: 360px;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+  border-top: 1px solid var(--opus-home-line);
+  border-bottom: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-skeleton span {
+  background: rgba(229, 240, 252, 0.08);
+  animation: opus-skeleton-pulse 1.15s ease-in-out infinite alternate;
+}
+
+.opus-archive-skeleton span:first-child {
+  grid-row: span 2;
+  border-right: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-skeleton span + span {
+  border-bottom: 1px solid var(--opus-home-line);
+}
+
+.opus-archive-section--error {
+  display: flex;
+  min-height: 180px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
 @keyframes opus-title-enter {
   from {
     opacity: 0;
@@ -1055,6 +1499,31 @@ html {
   .opus-contest-skeleton__item:first-child {
     min-height: 330px;
   }
+
+  .opus-archive-layout,
+  .opus-archive-skeleton {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .opus-archive-layout[data-layout='split'] .opus-archive-feature,
+  .opus-archive-skeleton span:first-child {
+    border-right: 0;
+    border-bottom: 1px solid var(--opus-home-line);
+  }
+
+  .opus-archive-compact {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .opus-archive-compact li + li {
+    border-top: 0;
+    border-left: 1px solid var(--opus-home-line);
+  }
+
+  .opus-archive-skeleton span:first-child {
+    grid-row: auto;
+  }
 }
 
 @media (max-width: 720px) {
@@ -1094,6 +1563,30 @@ html {
     margin-bottom: -4px;
   }
 
+  .opus-signal-section {
+    padding: 24px 22px 28px;
+  }
+
+  .opus-signal-list__link {
+    grid-template-columns: 58px minmax(0, 1fr) auto;
+    gap: 14px;
+    min-height: 74px;
+  }
+
+  .opus-signal-list__title {
+    display: -webkit-box;
+    overflow: hidden;
+    line-height: 1.4;
+    text-overflow: unset;
+    white-space: normal;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .opus-signal-skeleton span {
+    height: 74px;
+  }
+
   .opus-contest-card__link {
     padding: 32px 24px;
   }
@@ -1107,6 +1600,60 @@ html {
   .opus-contest-card__geometry {
     right: 22px;
     opacity: 0.55;
+  }
+
+  .opus-archive-section {
+    padding: 48px 22px 56px;
+  }
+
+  .opus-archive-section__header {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 14px;
+    margin-bottom: 32px;
+  }
+
+  .opus-archive-section__header h2 {
+    font-size: clamp(2.2rem, 10vw, 3.4rem);
+  }
+
+  .opus-archive-feature__link {
+    min-height: 320px;
+    padding: 30px 24px;
+  }
+
+  .opus-archive-feature h3 {
+    margin-top: 58px;
+  }
+
+  .opus-archive-feature__geometry {
+    top: 34px;
+    right: 24px;
+    opacity: 0.48;
+  }
+
+  .opus-archive-compact {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .opus-archive-compact li + li {
+    border-top: 1px solid var(--opus-home-line);
+    border-left: 0;
+  }
+
+  .opus-archive-compact__link {
+    min-height: 148px;
+    grid-template-columns: 42px minmax(0, 1fr) auto;
+    gap: 14px;
+    padding: 26px 20px;
+  }
+
+  .opus-archive-skeleton {
+    min-height: 300px;
+  }
+
+  .opus-signal-section--error,
+  .opus-archive-section--error {
+    align-items: flex-start;
   }
 }
 

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,42 +1,12 @@
 import { useRef } from 'react';
-import { type FallbackProps } from 'react-error-boundary';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import QueryWrapper from '@providers/QueryWrapper';
-import { currentContestOption } from '@queries/contest';
-import CurrentContestSection from './CurrentContestSection';
-import OpusMascot from './OpusMascot';
-import CampusNoticeHologram from './CampusNoticeHologram';
-import OpusClock from './OpusClock';
+import CurrentContestSection, { ContestGridError, ContestGridSkeleton } from './CurrentContestSection';
+import Masthead, { MastheadFallback } from './Masthead';
+import NoticeSignalSection, { NoticeSignalError, NoticeSignalSkeleton } from './NoticeSignalSection';
+import ArchiveProjectSection, { ArchiveProjectError, ArchiveProjectSkeleton } from './ArchiveProjectSection';
 import './EditorialHome.css';
 
-const ContestGridSkeleton = () => (
-  <div className="opus-contest-skeleton" aria-label="대회 목록을 불러오는 중" aria-busy="true">
-    {Array.from({ length: 4 }).map((_, index) => (
-      <div key={index} className="opus-contest-skeleton__item" aria-hidden="true">
-        <div className="opus-contest-skeleton__line" />
-        <div className="opus-contest-skeleton__line" />
-        <div className="opus-contest-skeleton__line" />
-      </div>
-    ))}
-  </div>
-);
-
-const ContestGridError = ({ resetErrorBoundary }: FallbackProps) => (
-  <section className="opus-contest-error" role="alert" aria-labelledby="contest-error-title">
-    <p className="opus-contest-error__number" aria-hidden="true">
-      !
-    </p>
-    <h2 id="contest-error-title">대회 정보를 불러오지 못했습니다.</h2>
-    <button type="button" onClick={resetErrorBoundary}>
-      다시 시도 ↗
-    </button>
-  </section>
-);
-
 const MainPage = () => {
-  const { data: currentContests } = useSuspenseQuery(currentContestOption());
-  const heroTitle = currentContests.length > 0 ? ' 진행 중인 대회' : ' 대회';
-
   const contestSectionRef = useRef<HTMLDivElement>(null);
 
   const handleExploreContests = () => {
@@ -48,28 +18,19 @@ const MainPage = () => {
 
   return (
     <main className="opus-home">
-      <section className="opus-masthead" aria-labelledby="opus-home-title">
-        <div className="opus-masthead__content">
-          <div className="opus-masthead__intro">
-            <OpusClock />
+      <QueryWrapper
+        loadingFallback={<MastheadFallback onExploreContests={handleExploreContests} />}
+        errorFallback={() => <MastheadFallback onExploreContests={handleExploreContests} />}
+      >
+        <Masthead onExploreContests={handleExploreContests} />
+      </QueryWrapper>
 
-            <p className="opus-masthead__eyebrow">OPUS</p>
-
-            <h1 id="opus-home-title" className="opus-masthead__title">
-              {currentContests.length > 0 ? <span>현재</span> : <span>최근</span>}
-
-              {heroTitle}
-            </h1>
-          </div>
-
-          <div className="opus-mascot-zone">
-            <CampusNoticeHologram onExploreContests={handleExploreContests} />
-            <OpusMascot />
-          </div>
-        </div>
-
-        <div className="opus-masthead__rule" aria-hidden="true" />
-      </section>
+      <QueryWrapper
+        loadingFallback={<NoticeSignalSkeleton />}
+        errorFallback={(props) => <NoticeSignalError {...props} />}
+      >
+        <NoticeSignalSection />
+      </QueryWrapper>
 
       <div ref={contestSectionRef}>
         <QueryWrapper
@@ -79,6 +40,13 @@ const MainPage = () => {
           <CurrentContestSection />
         </QueryWrapper>
       </div>
+
+      <QueryWrapper
+        loadingFallback={<ArchiveProjectSkeleton />}
+        errorFallback={(props) => <ArchiveProjectError {...props} />}
+      >
+        <ArchiveProjectSection />
+      </QueryWrapper>
     </main>
   );
 };

--- a/src/pages/main/Masthead.tsx
+++ b/src/pages/main/Masthead.tsx
@@ -1,0 +1,49 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { currentContestOption } from '@queries/contest';
+import OpusMascot from './OpusMascot';
+import CampusNoticeHologram from './CampusNoticeHologram';
+import OpusClock from './OpusClock';
+
+interface MastheadProps {
+  onExploreContests: () => void;
+}
+
+interface MastheadContentProps extends MastheadProps {
+  hasCurrentContests: boolean;
+}
+
+const MastheadContent = ({ hasCurrentContests, onExploreContests }: MastheadContentProps) => (
+  <section className="opus-masthead" aria-labelledby="opus-home-title">
+    <div className="opus-masthead__content">
+      <div className="opus-masthead__intro">
+        <OpusClock />
+
+        <p className="opus-masthead__eyebrow">OPUS</p>
+
+        <h1 id="opus-home-title" className="opus-masthead__title">
+          <span>{hasCurrentContests ? '현재' : '최근'}</span>
+          {hasCurrentContests ? ' 진행 중인 대회' : ' 대회'}
+        </h1>
+      </div>
+
+      <div className="opus-mascot-zone">
+        <CampusNoticeHologram onExploreContests={onExploreContests} />
+        <OpusMascot />
+      </div>
+    </div>
+
+    <div className="opus-masthead__rule" aria-hidden="true" />
+  </section>
+);
+
+const Masthead = ({ onExploreContests }: MastheadProps) => {
+  const { data: currentContests } = useSuspenseQuery(currentContestOption());
+
+  return <MastheadContent hasCurrentContests={currentContests.length > 0} onExploreContests={onExploreContests} />;
+};
+
+export const MastheadFallback = ({ onExploreContests }: MastheadProps) => (
+  <MastheadContent hasCurrentContests={false} onExploreContests={onExploreContests} />
+);
+
+export default Masthead;

--- a/src/pages/main/NoticeSignalSection.tsx
+++ b/src/pages/main/NoticeSignalSection.tsx
@@ -1,0 +1,75 @@
+import dayjs from 'dayjs';
+import { Link } from 'react-router-dom';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { noticeOption } from '@queries/notices';
+import { type FallbackProps } from 'react-error-boundary';
+
+const NoticeSignalSection = () => {
+  const { data: notices } = useSuspenseQuery(noticeOption());
+  const recentNotices = [...notices]
+    .sort((a, b) => dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf())
+    .slice(0, 2);
+
+  return (
+    <section className="opus-signal-section" aria-labelledby="opus-signal-title">
+      <header className="opus-signal-section__header">
+        <div>
+          <span className="opus-campus-news__signal" aria-hidden="true" />
+          <h2 id="opus-signal-title">OPUS SIGNAL</h2>
+        </div>
+        <span>NOTICE</span>
+      </header>
+
+      {recentNotices.length > 0 ? (
+        <ol className="opus-signal-list">
+          {recentNotices.map((notice) => (
+            <li key={notice.noticeId}>
+              <Link to={`/notices/${notice.noticeId}`} className="opus-signal-list__link">
+                <time dateTime={dayjs(notice.createdAt).format('YYYY-MM-DD')}>
+                  {dayjs(notice.createdAt).format('MM.DD')}
+                </time>
+                <span className="opus-signal-list__title">{notice.title}</span>
+                <span className="opus-signal-list__arrow" aria-hidden="true">
+                  ↗
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="opus-signal-section__empty">새로운 공지가 없습니다.</p>
+      )}
+
+      <Link to="/notices" className="opus-editorial-link">
+        전체 공지 보기 <span aria-hidden="true">↗</span>
+      </Link>
+    </section>
+  );
+};
+
+export const NoticeSignalSkeleton = () => (
+  <section className="opus-signal-section" aria-label="최근 공지를 불러오는 중" aria-busy="true">
+    <header className="opus-signal-section__header">
+      <div>
+        <span className="opus-campus-news__signal" aria-hidden="true" />
+        <span className="opus-signal-section__skeleton-heading">OPUS SIGNAL</span>
+      </div>
+      <span>NOTICE</span>
+    </header>
+    <div className="opus-signal-skeleton" aria-hidden="true">
+      <span />
+      <span />
+    </div>
+  </section>
+);
+
+export const NoticeSignalError = ({ resetErrorBoundary }: FallbackProps) => (
+  <section className="opus-signal-section opus-signal-section--error" role="alert">
+    <p>공지사항을 불러오지 못했습니다.</p>
+    <button type="button" onClick={resetErrorBoundary}>
+      다시 시도 ↗
+    </button>
+  </section>
+);
+
+export default NoticeSignalSection;

--- a/src/pages/notice/NoticeDetailPage.tsx
+++ b/src/pages/notice/NoticeDetailPage.tsx
@@ -25,7 +25,10 @@ const NoticeDetail = () => {
   return (
     <div className="max-w mx-auto">
       <h1 className="mb-6 flex items-center gap-2 text-2xl font-bold">
-        <Link to={!contestId ? '/' : `/contest/${contestId}`} title={`${contestName ?? '메인으'}로 돌아가기`}>
+        <Link
+          to={!contestId ? '/notices' : `/contest/${contestId}`}
+          title={`${contestName ?? '전체 공지사항'}으로 돌아가기`}
+        >
           <Undo2 className="shrink-0 cursor-pointer" />
         </Link>
         {`${contestName ?? ''} 공지사항`.trim()}

--- a/src/pages/notice/NoticeListPage.tsx
+++ b/src/pages/notice/NoticeListPage.tsx
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { NoticeList, NoticeListItem, NoticeListNoData, NoticeListSkeleton } from '@components/notice';
+import QueryWrapper from '@providers/QueryWrapper';
+import { noticeOption } from '@queries/notices';
+
+const NoticeItems = () => {
+  const { data: notices } = useSuspenseQuery(noticeOption());
+  const recentFirstNotices = [...notices].sort((a, b) => dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf());
+
+  return (
+    <NoticeList>
+      {recentFirstNotices.length === 0 && <NoticeListNoData />}
+      {recentFirstNotices.map((notice) => (
+        <NoticeListItem key={notice.noticeId} {...notice} />
+      ))}
+    </NoticeList>
+  );
+};
+
+const NoticeListPage = () => (
+  <section aria-labelledby="notice-list-title">
+    <h1 id="notice-list-title" className="mb-6 text-2xl font-bold">
+      전체 공지사항
+    </h1>
+    <QueryWrapper loadingFallback={<NoticeListSkeleton />} errorStyle="min-h-36 rounded-xl shadow-md">
+      <NoticeItems />
+    </QueryWrapper>
+  </section>
+);
+
+export default NoticeListPage;

--- a/src/queries/contest.ts
+++ b/src/queries/contest.ts
@@ -1,5 +1,9 @@
-import { queryOptions } from '@tanstack/react-query';
+import { queryOptions, type QueryClient } from '@tanstack/react-query';
 import { getAllContests, getContestTeams, getCurrentContest, getSortStatus } from '@apis/contest';
+import { teamDetailOption } from './team';
+
+const ARCHIVE_PROJECT_LIMIT = 3;
+const ARCHIVE_CONTEST_LIMIT = 3;
 
 export const contestsOption = () => {
   return queryOptions({ queryKey: ['contests'], queryFn: getAllContests });
@@ -16,3 +20,45 @@ export const contestTeamOption = (contestId: number) => {
 export const sortStatusOption = (contestId: number) => {
   return queryOptions({ queryKey: ['sortStatus'], queryFn: () => getSortStatus(contestId) });
 };
+
+export const archiveProjectsOption = (queryClient: QueryClient) =>
+  queryOptions({
+    queryKey: ['archiveProjects'],
+    queryFn: async () => {
+      const contests = await queryClient.fetchQuery(contestsOption());
+      // TODO: 공개 프로젝트 목록 API가 project.updatedAt과 정렬/페이지네이션을 제공하면
+      // 대회 수정일 기반의 이 fallback 정책을 프로젝트 최신 업데이트순으로 교체한다.
+      const archiveContests = contests
+        .filter((contest) => !contest.isCurrent)
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+        .slice(0, ARCHIVE_CONTEST_LIMIT);
+
+      const teamGroups = await Promise.all(
+        archiveContests.map(async (contest) => ({
+          contest,
+          teams: await queryClient.fetchQuery(contestTeamOption(contest.contestId)),
+        })),
+      );
+      const candidates = teamGroups
+        .flatMap(({ contest, teams }) =>
+          teams.filter((team) => team.projectName.trim().length > 0).map((team) => ({ contest, team })),
+        )
+        .slice(0, ARCHIVE_PROJECT_LIMIT);
+
+      const details = await Promise.allSettled(
+        candidates.map(({ team }) => queryClient.fetchQuery(teamDetailOption(team.teamId))),
+      );
+
+      return candidates.map(({ contest, team }, index) => {
+        const detail = details[index].status === 'fulfilled' ? details[index].value : undefined;
+
+        return {
+          contestId: contest.contestId,
+          contestName: contest.contestName,
+          teamId: team.teamId,
+          projectName: detail?.projectName?.trim() || team.projectName,
+          overview: detail?.overview?.trim() ?? '',
+        };
+      });
+    },
+  });

--- a/src/route/AppRoutes.tsx
+++ b/src/route/AppRoutes.tsx
@@ -10,6 +10,7 @@ import SignUpPage from '@pages/signup/SignUpPage';
 import FindPage from '@pages/find/FindPage';
 import OAuthCallback from '@pages/signin/SocialSignIn/OAuthCallback';
 import NoticeDetailPage from '@pages/notice/NoticeDetailPage';
+import NoticeListPage from '@pages/notice/NoticeListPage';
 import ContestPage from '@pages/contest/ContestPage';
 import FullContainerLayout from '@layout/FullContainerLayout';
 import AdminLayout from '@layout/admin/AdminLayout';
@@ -66,6 +67,7 @@ const AppRoutes = () =>
             { path: 'contest/:contestId/teams/edit/:teamId', element: <ProjectEditPage /> },
             { path: 'find', element: <FindPage /> },
             { path: 'oauth/callback', element: <OAuthCallback /> },
+            { path: 'notices', element: <NoticeListPage /> },
             { path: 'notices/:noticeId', element: <NoticeDetailPage /> },
             { path: 'notices/:contestId/:noticeId', element: <NoticeDetailPage /> },
           ],


### PR DESCRIPTION
### 📝 개요

OPUS 메인페이지에 최근 공지사항을 확인할 수 있는 `OPUS SIGNAL` 영역과 과거 프로젝트를 탐색할 수 있는 `ARCHIVE` 영역 UI를 개선하였습니다.

### 🎯 목적

- 메인페이지에서 주요 공지사항을 빠르게 확인할 수 있도록 합니다.
- 현재 진행 중인 대회뿐 아니라 과거 프로젝트도 탐색할 수 있도록 합니다.
- 개별 API 오류가 메인페이지 전체 렌더링에 영향을 주지 않도록 상태 처리를 분리합니다.

### 📸 참고 이미지
<p align="center">
<img width="700" src="https://github.com/user-attachments/assets/97c39eb2-08b4-49b0-83dc-08150a878b80" />
</p>